### PR TITLE
REPRAM 2.1: signed root discovery (omega trust anchor)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
 BINARY_NAME=repram
+OMEGA_BINARY_NAME=repram-omega
 
-.PHONY: build run test clean docker-build docker-run docker-compose-up docker-compose-down
+.PHONY: build build-omega run test clean docker-build docker-run docker-compose-up docker-compose-down
 
 build:
 	go build -o bin/$(BINARY_NAME) ./cmd/repram
+	go build -o bin/$(OMEGA_BINARY_NAME) ./cmd/repram-omega
+
+build-omega:
+	go build -o bin/$(OMEGA_BINARY_NAME) ./cmd/repram-omega
 
 run: build
 	./bin/$(BINARY_NAME)

--- a/cmd/repram-omega/main.go
+++ b/cmd/repram-omega/main.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -78,10 +79,10 @@ func runKeygen(args []string) error {
 	pubB64 := base64.StdEncoding.EncodeToString(pub)
 	privB64 := base64.StdEncoding.EncodeToString(priv)
 
-	if err := writeFileMode(*outPriv, []byte(privB64+"\n"), 0o600); err != nil {
+	if err := atomicWriteNoClobber(*outPriv, []byte(privB64+"\n"), 0o600); err != nil {
 		return fmt.Errorf("write private key: %w", err)
 	}
-	if err := writeFileMode(*outPub, []byte(pubB64+"\n"), 0o644); err != nil {
+	if err := atomicWriteNoClobber(*outPub, []byte(pubB64+"\n"), 0o644); err != nil {
 		return fmt.Errorf("write public key: %w", err)
 	}
 
@@ -167,17 +168,45 @@ func splitCSV(s string) []string {
 	return out
 }
 
-// writeFileMode writes data to path atomically(ish) with the given mode. The
-// file is truncated if it already exists; callers that want to avoid
-// clobbering an existing key should check first.
-func writeFileMode(path string, data []byte, mode os.FileMode) error {
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+// atomicWriteNoClobber writes data to path via tempfile+rename so a crash
+// mid-write cannot leave a truncated key file on disk. Refuses to overwrite
+// an existing file — rerunning keygen against the same path is almost
+// certainly an operator mistake, and the consequence (silently clobbering
+// a working key) is unrecoverable.
+func atomicWriteNoClobber(path string, data []byte, mode os.FileMode) error {
+	if _, err := os.Stat(path); err == nil {
+		return fmt.Errorf("refusing to overwrite existing file %s", path)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
 	if err != nil {
 		return err
 	}
-	if _, err := f.Write(data); err != nil {
-		f.Close()
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
 		return err
 	}
-	return f.Close()
+	if err := tmp.Chmod(mode); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
 }

--- a/cmd/repram-omega/main.go
+++ b/cmd/repram-omega/main.go
@@ -1,0 +1,183 @@
+// Command repram-omega is the operator tool for REPRAM's signed-root-list
+// trust anchor. It runs offline — never on a REPRAM node. See
+// docs/internal/REPRAM-2.1-Spec.md and docs/omega-operations.md.
+//
+// Subcommands:
+//
+//	keygen  generate a new Ed25519 omega keypair
+//	sign    sign a root list for publication as a DNS TXT record
+//
+// The omega private key must be stored on an air-gapped signing machine.
+// Never transmit it over any network.
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"repram/internal/trust"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage(os.Stderr)
+		os.Exit(2)
+	}
+
+	switch os.Args[1] {
+	case "keygen":
+		if err := runKeygen(os.Args[2:]); err != nil {
+			fmt.Fprintf(os.Stderr, "keygen: %v\n", err)
+			os.Exit(1)
+		}
+	case "sign":
+		if err := runSign(os.Args[2:]); err != nil {
+			fmt.Fprintf(os.Stderr, "sign: %v\n", err)
+			os.Exit(1)
+		}
+	case "-h", "--help", "help":
+		usage(os.Stdout)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown subcommand: %s\n\n", os.Args[1])
+		usage(os.Stderr)
+		os.Exit(2)
+	}
+}
+
+func usage(w *os.File) {
+	fmt.Fprintln(w, "repram-omega — operator tool for REPRAM signed root lists")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  repram-omega keygen --out-private <path> --out-public <path>")
+	fmt.Fprintln(w, "  repram-omega sign --key <path> --version <id> --expires-in <seconds> --nodes <csv>")
+}
+
+func runKeygen(args []string) error {
+	fs := flag.NewFlagSet("keygen", flag.ContinueOnError)
+	outPriv := fs.String("out-private", "", "path to write the Ed25519 private key (required)")
+	outPub := fs.String("out-public", "", "path to write the Ed25519 public key (required)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *outPriv == "" || *outPub == "" {
+		fs.Usage()
+		return fmt.Errorf("both --out-private and --out-public are required")
+	}
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return fmt.Errorf("generate keypair: %w", err)
+	}
+
+	pubB64 := base64.StdEncoding.EncodeToString(pub)
+	privB64 := base64.StdEncoding.EncodeToString(priv)
+
+	if err := writeFileMode(*outPriv, []byte(privB64+"\n"), 0o600); err != nil {
+		return fmt.Errorf("write private key: %w", err)
+	}
+	if err := writeFileMode(*outPub, []byte(pubB64+"\n"), 0o644); err != nil {
+		return fmt.Errorf("write public key: %w", err)
+	}
+
+	fmt.Println("Generated Ed25519 keypair.")
+	fmt.Printf("Public key: %s\n", pubB64)
+	fmt.Printf("Private key written to %s (mode 0600)\n", *outPriv)
+	fmt.Printf("Public key written to %s\n", *outPub)
+	fmt.Println()
+	fmt.Println("Next steps:")
+	fmt.Println("  1. Bake the public key into internal/trust/omega.go (OmegaPubkey)")
+	fmt.Println("     and repram-mcp/src/node/trust/omega.ts (OMEGA_PUBKEY).")
+	fmt.Printf("  2. Store %s on your offline signing machine.\n", *outPriv)
+	fmt.Println("  3. Never transmit the private key over any network.")
+	return nil
+}
+
+func runSign(args []string) error {
+	fs := flag.NewFlagSet("sign", flag.ContinueOnError)
+	keyPath := fs.String("key", "", "path to Ed25519 private key file (required)")
+	version := fs.String("version", trust.OmegaVersion, "omega version identifier")
+	expiresIn := fs.Duration("expires-in", 0, "lifetime of the signed list (e.g. 24h)")
+	nodes := fs.String("nodes", "", "comma-separated root node addresses host:gossip-port (required)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *keyPath == "" {
+		return fmt.Errorf("--key is required")
+	}
+	if *expiresIn <= 0 {
+		return fmt.Errorf("--expires-in must be positive (e.g. 24h)")
+	}
+	if strings.TrimSpace(*nodes) == "" {
+		return fmt.Errorf("--nodes is required")
+	}
+
+	privKeyB64, err := os.ReadFile(*keyPath)
+	if err != nil {
+		return fmt.Errorf("read key: %w", err)
+	}
+	priv, err := decodePrivateKey(string(privKeyB64))
+	if err != nil {
+		return err
+	}
+
+	list := &trust.SignedList{
+		Version: *version,
+		Expires: time.Now().Add(*expiresIn).Unix(),
+		Nodes:   splitCSV(*nodes),
+	}
+	list.Sign(priv)
+
+	fmt.Println(list.Encode())
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "To publish:")
+	fmt.Fprintln(os.Stderr, "  1. Paste the line above as the value of the _omega.repram.io TXT record.")
+	fmt.Fprintln(os.Stderr, "  2. Verify propagation with: dig TXT _omega.repram.io")
+	fmt.Fprintf(os.Stderr, "  3. This record expires at %s UTC.\n",
+		time.Unix(list.Expires, 0).UTC().Format(time.RFC3339))
+	return nil
+}
+
+func decodePrivateKey(raw string) (ed25519.PrivateKey, error) {
+	raw = strings.TrimSpace(raw)
+	decoded, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil {
+		return nil, fmt.Errorf("decode private key: %w", err)
+	}
+	if len(decoded) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("private key has wrong length: got %d want %d", len(decoded), ed25519.PrivateKeySize)
+	}
+	return ed25519.PrivateKey(decoded), nil
+}
+
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := parts[:0]
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// writeFileMode writes data to path atomically(ish) with the given mode. The
+// file is truncated if it already exists; callers that want to avoid
+// clobbering an existing key should check first.
+func writeFileMode(path string, data []byte, mode os.FileMode) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
+}

--- a/cmd/repram-omega/main_test.go
+++ b/cmd/repram-omega/main_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"repram/internal/trust"
+)
+
+// TestDecodePrivateKeyRoundtrip — keygen output decodes back to a working key.
+func TestDecodePrivateKeyRoundtrip(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	encoded := base64.StdEncoding.EncodeToString(priv) + "\n"
+
+	got, err := decodePrivateKey(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != ed25519.PrivateKeySize {
+		t.Errorf("size = %d, want %d", len(got), ed25519.PrivateKeySize)
+	}
+}
+
+// TestDecodePrivateKeyWrongLength — truncated keys are rejected rather than
+// silently producing garbage signatures.
+func TestDecodePrivateKeyWrongLength(t *testing.T) {
+	short := base64.StdEncoding.EncodeToString([]byte("too short"))
+	_, err := decodePrivateKey(short)
+	if err == nil {
+		t.Fatalf("expected error for short key, got nil")
+	}
+}
+
+// TestSignFlowRoundtrip — simulate `keygen` writing a private key and
+// `sign` reading it + emitting a TXT record line that parses and verifies.
+// This is the end-to-end operator workflow.
+func TestSignFlowRoundtrip(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	dir := t.TempDir()
+	privPath := filepath.Join(dir, "omega-v1.key")
+	if err := os.WriteFile(privPath, []byte(base64.StdEncoding.EncodeToString(priv)+"\n"), 0o600); err != nil {
+		t.Fatalf("write priv: %v", err)
+	}
+
+	// Build the same list the sign subcommand would build.
+	loadedBytes, err := os.ReadFile(privPath)
+	if err != nil {
+		t.Fatalf("read priv: %v", err)
+	}
+	loadedPriv, err := decodePrivateKey(string(loadedBytes))
+	if err != nil {
+		t.Fatalf("decode priv: %v", err)
+	}
+
+	list := &trust.SignedList{
+		Version: trust.OmegaVersion,
+		Expires: time.Now().Add(1 * time.Hour).Unix(),
+		Nodes:   splitCSV("root-a.example:9090,root-b.example:9090"),
+	}
+	list.Sign(loadedPriv)
+
+	// The TXT payload must parse and verify under the original pubkey.
+	parsed, err := trust.Parse(list.Encode())
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if err := parsed.Verify(pub, time.Now()); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+}
+
+// TestKeygenWritesProtectedPrivateKey — the private-key file is created
+// with mode 0600 so a shared signing machine doesn't leak it.
+func TestKeygenWritesProtectedPrivateKey(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses mode bits")
+	}
+
+	dir := t.TempDir()
+	privPath := filepath.Join(dir, "omega-v1.key")
+	pubPath := filepath.Join(dir, "omega-v1.pub")
+
+	if err := runKeygen([]string{"--out-private", privPath, "--out-public", pubPath}); err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+
+	info, err := os.Stat(privPath)
+	if err != nil {
+		t.Fatalf("stat priv: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("priv-key mode = %o, want 0600", perm)
+	}
+}
+
+// TestSplitCSVTrimsWhitespace — operator-friendly input handling.
+func TestSplitCSVTrimsWhitespace(t *testing.T) {
+	got := splitCSV("  a:9090 , b:9090 ,, c:9090  ")
+	want := []string{"a:9090", "b:9090", "c:9090"}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Errorf("got %v want %v", got, want)
+	}
+}

--- a/cmd/repram/bootstrap_gate_test.go
+++ b/cmd/repram/bootstrap_gate_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"repram/internal/cluster"
+	"repram/internal/node"
+)
+
+// newPublicTestServer builds an HTTPServer in public-network mode so the
+// bootstrap-gate logic engages. Root status is controllable via the
+// returned *cluster.ClusterNode.
+func newPublicTestServer(t *testing.T) (*HTTPServer, *cluster.ClusterNode, func()) {
+	t.Helper()
+
+	cn := cluster.NewClusterNode(
+		"public-test-node", "localhost", 0, 0,
+		1,
+		0,
+		5*time.Second,
+		"",
+		"default",
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := cn.Start(ctx, nil); err != nil {
+		t.Fatalf("start cluster: %v", err)
+	}
+
+	securityMW := node.NewSecurityMiddleware(1000, 2000, 10*1024*1024, false)
+
+	server := &HTTPServer{
+		clusterNode: cn,
+		nodeID:      "public-test-node",
+		network:     "public",
+		minTTL:      300,
+		maxTTL:      86400,
+		startTime:   time.Now(),
+		securityMW:  securityMW,
+	}
+
+	cleanup := func() {
+		securityMW.Close()
+		cn.Stop()
+		cancel()
+	}
+	return server, cn, cleanup
+}
+
+// TestBootstrapHandler_NonRootReturns403 — a public-network node that has
+// not been marked as root must refuse bootstrap requests. This is the
+// cornerstone of the 2.1 trust model: only signed-list members hand out
+// peer topology.
+func TestBootstrapHandler_NonRootReturns403(t *testing.T) {
+	server, cn, cleanup := newPublicTestServer(t)
+	defer cleanup()
+
+	// Default: not a root.
+	if cn.IsRoot() {
+		t.Fatalf("expected IsRoot()=false by default")
+	}
+
+	body := strings.NewReader(`{"node_id":"joiner","address":"x","gossip_port":9090,"http_port":8080}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/bootstrap", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	server.bootstrapHandler(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", w.Code)
+	}
+
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if resp["error"] != "not a bootstrap root" {
+		t.Errorf("unexpected error body: %+v", resp)
+	}
+}
+
+// TestBootstrapHandler_RootAnswers — once a node is marked root, it
+// processes bootstrap requests normally.
+func TestBootstrapHandler_RootAnswers(t *testing.T) {
+	server, cn, cleanup := newPublicTestServer(t)
+	defer cleanup()
+
+	cn.SetRoot(true)
+
+	body := strings.NewReader(`{"node_id":"joiner","address":"x","gossip_port":9090,"http_port":8080}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/bootstrap", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	server.bootstrapHandler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+// TestBootstrapHandler_PrivateNetworkBypass — private-network nodes skip
+// the root check entirely. They drive peer discovery via REPRAM_PEERS, not
+// the signed list, so the gate doesn't apply.
+func TestBootstrapHandler_PrivateNetworkBypass(t *testing.T) {
+	server, cleanup := newTestServer(t) // default: network="private"
+	defer cleanup()
+
+	body := strings.NewReader(`{"node_id":"joiner","address":"x","gossip_port":9090,"http_port":8080}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/bootstrap", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	server.bootstrapHandler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("private-network bootstrap status = %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+}

--- a/cmd/repram/main.go
+++ b/cmd/repram/main.go
@@ -91,19 +91,27 @@ func main() {
 	// Self-recognition: a node is a root iff its advertised address
 	// appears in the signed list. Roots answer /v1/bootstrap; non-roots
 	// return 403. Private-network deployments are never roots.
-	if rootList != nil {
+	applyRootStatus := func(list *trust.SignedList) {
 		selfAdvertised := fmt.Sprintf("%s:%d", address, gossipPort)
 		isRoot := false
-		for _, n := range rootList.Nodes {
+		for _, n := range list.Nodes {
 			if n == selfAdvertised {
 				isRoot = true
 				break
 			}
 		}
+		wasRoot := clusterNode.IsRoot()
 		clusterNode.SetRoot(isRoot)
-		if isRoot {
-			logging.Info("  Root status: this node is a bootstrap root")
+		if isRoot != wasRoot {
+			if isRoot {
+				logging.Info("Root status changed: this node is now a bootstrap root")
+			} else {
+				logging.Info("Root status changed: this node is no longer a bootstrap root")
+			}
 		}
+	}
+	if rootList != nil {
+		applyRootStatus(rootList)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -111,6 +119,24 @@ func main() {
 
 	if err := clusterNode.Start(ctx, bootstrapNodes); err != nil {
 		log.Fatalf("Failed to start cluster node: %v", err)
+	}
+
+	// Start the omega refresh loop for public-network nodes. Keeps the
+	// cached signed list fresh and recomputes root status on each refresh.
+	if rootList != nil {
+		pubkey, err := trust.DecodedOmegaPubkey()
+		if err != nil {
+			log.Fatalf("decode omega pubkey: %v", err)
+		}
+		refresher := trust.NewRefresher(trust.RefresherConfig{
+			Pubkey:   pubkey,
+			CacheDir: trust.DefaultCacheDir(),
+			OnUpdate: applyRootStatus,
+			OnError: func(err error) {
+				logging.Warn("Omega refresh: %v", err)
+			},
+		}, rootList)
+		go refresher.Run(ctx)
 	}
 
 	server := &HTTPServer{

--- a/cmd/repram/main.go
+++ b/cmd/repram/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -27,6 +26,7 @@ import (
 	"repram/internal/logging"
 	"repram/internal/node"
 	"repram/internal/storage"
+	"repram/internal/trust"
 )
 
 func main() {
@@ -71,13 +71,40 @@ func main() {
 		}
 	}
 
-	// DNS-based bootstrap for public network
+	// Signed-root-list bootstrap for the public network. See
+	// docs/internal/REPRAM-2.1-Spec.md. This replaces the pre-2.1
+	// unsigned DNS path; there is no fallback by design.
+	var rootList *trust.SignedList
 	if network == "public" && len(bootstrapNodes) == 0 {
-		resolved := resolveBootstrapDNS("bootstrap.repram.network", 9090)
-		bootstrapNodes = append(bootstrapNodes, resolved...)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		list, err := resolveOmegaBootstrap(ctx)
+		cancel()
+		if err != nil {
+			log.Fatalf("Omega bootstrap failed: %v", err)
+		}
+		rootList = list
+		bootstrapNodes = append(bootstrapNodes, list.Nodes...)
 	}
 
 	clusterNode := cluster.NewClusterNode(nodeID, address, gossipPort, httpPort, replicationFactor, int64(maxStorageMB)*1024*1024, time.Duration(writeTimeout)*time.Second, clusterSecret, enclave)
+
+	// Self-recognition: a node is a root iff its advertised address
+	// appears in the signed list. Roots answer /v1/bootstrap; non-roots
+	// return 403. Private-network deployments are never roots.
+	if rootList != nil {
+		selfAdvertised := fmt.Sprintf("%s:%d", address, gossipPort)
+		isRoot := false
+		for _, n := range rootList.Nodes {
+			if n == selfAdvertised {
+				isRoot = true
+				break
+			}
+		}
+		clusterNode.SetRoot(isRoot)
+		if isRoot {
+			logging.Info("  Root status: this node is a bootstrap root")
+		}
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -158,33 +185,43 @@ func envInt(key string, defaultVal int) int {
 	return defaultVal
 }
 
-// resolveBootstrapDNS resolves bootstrap peers via DNS.
-// Returns host:port strings for each resolved address.
-func resolveBootstrapDNS(hostname string, defaultPort int) []string {
-	// Try SRV records first for port flexibility
-	_, srvRecords, err := net.LookupSRV("gossip", "tcp", hostname)
-	if err == nil && len(srvRecords) > 0 {
-		var peers []string
-		for _, srv := range srvRecords {
-			peers = append(peers, fmt.Sprintf("%s:%d", strings.TrimSuffix(srv.Target, "."), srv.Port))
-		}
-		logging.Info("Resolved %d bootstrap peers via SRV", len(peers))
-		return peers
-	}
-
-	// Fall back to A/AAAA records
-	addrs, err := net.LookupHost(hostname)
+// resolveOmegaBootstrap fetches and verifies the signed root list from DNS,
+// falling back to a previously-cached verified list if DNS is unreachable.
+// Hard-fails only when neither source yields a currently-valid signed list —
+// a node without a verified trust anchor must not join the public network.
+func resolveOmegaBootstrap(ctx context.Context) (*trust.SignedList, error) {
+	pubkey, err := trust.DecodedOmegaPubkey()
 	if err != nil {
-		logging.Warn("DNS bootstrap resolution failed for %s: %v (starting as first node)", hostname, err)
-		return nil
+		return nil, fmt.Errorf("baked-in omega pubkey is invalid: %w", err)
 	}
 
-	var peers []string
-	for _, addr := range addrs {
-		peers = append(peers, fmt.Sprintf("%s:%d", addr, defaultPort))
+	cacheDir := trust.DefaultCacheDir()
+	now := time.Now()
+
+	list, fetchErr := trust.FetchSigned(ctx, trust.DNSConfig{}, pubkey, now)
+	if fetchErr == nil {
+		if err := trust.SaveCache(cacheDir, list); err != nil {
+			logging.Warn("Failed to update omega cache at %s: %v (continuing)", cacheDir, err)
+		}
+		logging.Info("Omega bootstrap: verified signed root list (%d nodes, expires %s)",
+			len(list.Nodes), time.Unix(list.Expires, 0).UTC().Format(time.RFC3339))
+		return list, nil
 	}
-	logging.Info("Resolved %d bootstrap peers via DNS", len(peers))
-	return peers
+
+	logging.Warn("Omega DNS fetch failed: %v — trying cached list at %s", fetchErr, cacheDir)
+	cached, cacheErr := trust.LoadCache(cacheDir)
+	if cacheErr != nil {
+		return nil, fmt.Errorf("dns: %v; cache: %w", fetchErr, cacheErr)
+	}
+	if cached == nil {
+		return nil, fmt.Errorf("no DNS record and no cache available: %w", fetchErr)
+	}
+	if err := cached.Verify(pubkey, now); err != nil {
+		return nil, fmt.Errorf("cached omega list invalid: %w (dns: %v)", err, fetchErr)
+	}
+	logging.Info("Omega bootstrap: using cached signed root list (%d nodes, expires %s)",
+		len(cached.Nodes), time.Unix(cached.Expires, 0).UTC().Format(time.RFC3339))
+	return cached, nil
 }
 
 // CORS middleware
@@ -500,6 +537,17 @@ func (s *HTTPServer) gossipHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *HTTPServer) bootstrapHandler(w http.ResponseWriter, r *http.Request) {
+	// Only roots answer bootstrap requests. On the public network a node is
+	// a root iff its advertised address is in the current signed omega list
+	// (see resolveOmegaBootstrap). On private networks no one is a root
+	// under this gate — peer discovery is driven by REPRAM_PEERS directly.
+	if s.network == "public" && !s.clusterNode.IsRoot() {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]string{"error": "not a bootstrap root"})
+		return
+	}
+
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "Failed to read request body", http.StatusBadRequest)

--- a/cmd/repram/main.go
+++ b/cmd/repram/main.go
@@ -84,6 +84,12 @@ func main() {
 		}
 		rootList = list
 		bootstrapNodes = append(bootstrapNodes, list.Nodes...)
+	} else if network == "public" && len(bootstrapNodes) > 0 {
+		// REPRAM_PEERS short-circuits omega resolution, which in turn
+		// leaves IsRoot() false and causes /v1/bootstrap to 403. Fine
+		// for local testing; wrong for a real public-network root node.
+		// See docs/omega-operations.md for the guidance.
+		logging.Warn("REPRAM_NETWORK=public with REPRAM_PEERS set: skipping omega verification. This node will not be recognized as a bootstrap root and will return 403 for /v1/bootstrap requests.")
 	}
 
 	clusterNode := cluster.NewClusterNode(nodeID, address, gossipPort, httpPort, replicationFactor, int64(maxStorageMB)*1024*1024, time.Duration(writeTimeout)*time.Second, clusterSecret, enclave)
@@ -112,6 +118,12 @@ func main() {
 	}
 	if rootList != nil {
 		applyRootStatus(rootList)
+		selfAdvertised := fmt.Sprintf("%s:%d", address, gossipPort)
+		if clusterNode.IsRoot() {
+			logging.Info("Initial root status: bootstrap root (advertised as %s)", selfAdvertised)
+		} else {
+			logging.Info("Initial root status: not a root (advertised as %s); /v1/bootstrap returns 403", selfAdvertised)
+		}
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -221,7 +233,10 @@ func resolveOmegaBootstrap(ctx context.Context) (*trust.SignedList, error) {
 		return nil, fmt.Errorf("baked-in omega pubkey is invalid: %w", err)
 	}
 
-	cacheDir := trust.DefaultCacheDir()
+	cacheDir, usedLastResort := trust.ResolveCacheDir()
+	if usedLastResort {
+		logging.Warn("Using %s as cache directory; this typically requires root write access. Set REPRAM_CACHE_DIR for a writable location if refresh writes start failing.", cacheDir)
+	}
 	now := time.Now()
 
 	list, fetchErr := trust.FetchSigned(ctx, trust.DNSConfig{}, pubkey, now)

--- a/docs/omega-operations.md
+++ b/docs/omega-operations.md
@@ -7,6 +7,17 @@ The omega *public* key is compiled into every node binary. The omega
 *private* key lives on an air-gapped signing machine and is used only to
 sign root lists. It never touches a node, a CI system, or any network.
 
+## Configuration interactions (read first)
+
+**Root nodes must not set `REPRAM_PEERS`.** The public-network omega
+verification is gated on "public network AND no manual peers." Setting
+`REPRAM_PEERS` on a public-network node short-circuits the entire omega
+path: the node skips the signed-list fetch, `IsRoot()` stays `false`, and
+`/v1/bootstrap` returns 403 for every request. Nodes log a warning at
+startup when they detect this combination, but the failure mode is quiet
+otherwise. Use `REPRAM_NETWORK=private` with `REPRAM_PEERS` for private
+clusters; leave `REPRAM_PEERS` unset on public-network root nodes.
+
 ## When to use which tool
 
 - `repram-omega keygen` — one time, at network birth, and again only if the
@@ -83,19 +94,37 @@ newly-added node starts answering on the same schedule.
 
 ## Rotating the omega key (version bump)
 
-Required if the private key is lost or compromised. This is a shipping-a-
-new-binary event, not a DNS update.
+Required if the private key is lost or compromised. **Rotation is
+binary-coordinated, not DNS-coordinated.** The omega pubkey is baked into
+the node binary — a DNS update alone rotates nothing; existing nodes keep
+verifying against the old pubkey and reject any list signed with the new
+one. Get the ordering wrong and you partition the network.
 
-1. `repram-omega keygen` on the air-gapped machine, written to
-   `omega-v2.key` / `omega-v2.pub`.
-2. Bump the constants:
-   - `OmegaVersion = "omega-v2"`, new `OmegaPubkey` in Go.
-   - `OMEGA_VERSION = "omega-v2"`, new `OMEGA_PUBKEY` in TS.
-3. Cut a new release.
-4. Publish `_omega-v2.repram.io` in parallel with `_omega-v1.repram.io`
-   during the migration window. Keep the old version live until confident
-   no `omega-v1` nodes remain.
-5. Retire `_omega-v1.repram.io` when ready.
+Correct sequence:
+
+1. **Generate new keypair** on the air-gapped machine: `repram-omega
+   keygen --out-private omega-v2.key --out-public omega-v2.pub`.
+2. **Ship a binary release** with the new pubkey baked in:
+   - `OmegaVersion = "omega-v2"`, new `OmegaPubkey` in `internal/trust/omega.go`.
+   - `OMEGA_VERSION = "omega-v2"`, new `OMEGA_PUBKEY` in
+     `repram-mcp/src/node/trust/omega.ts`.
+   Both constants must match exactly. Tag and release.
+3. **Wait for deployment to propagate** across operators and
+   self-hosters. The previous signed-list `exp` is your deadline — past
+   that, un-upgraded nodes can no longer refresh their root list.
+4. **Begin publishing new-key signed lists** via `_omega-v2.repram.io`
+   in parallel with the existing `_omega-v1.repram.io`. Nodes on the new
+   binary start accepting the new lists; nodes still on the old binary
+   continue using the old lists.
+5. **Retire `_omega-v1.repram.io`** once you're confident no `omega-v1`
+   binaries remain in the network.
+
+If the old key is compromised and you can't wait for propagation, shorten
+the transition window by pre-shipping the new binary before publishing any
+old-key list that would span the rotation — or accept a brief period in
+which un-upgraded nodes cannot bootstrap new peers. In either case, do
+not publish new-key signed lists before the binary containing the new
+pubkey has reached all nodes that need to verify them.
 
 ## Recovery if the signing machine is unavailable
 

--- a/docs/omega-operations.md
+++ b/docs/omega-operations.md
@@ -1,0 +1,113 @@
+# Omega Operations
+
+Operator guide for REPRAM's signed-root-discovery trust anchor. Context and
+rationale live in `docs/internal/REPRAM-2.1-Spec.md`.
+
+The omega *public* key is compiled into every node binary. The omega
+*private* key lives on an air-gapped signing machine and is used only to
+sign root lists. It never touches a node, a CI system, or any network.
+
+## When to use which tool
+
+- `repram-omega keygen` — one time, at network birth, and again only if the
+  key is lost or compromised. Generating a new omega key invalidates every
+  existing signed root list and requires shipping a new binary.
+- `repram-omega sign` — every time the root node set changes and before the
+  current signed list expires.
+
+Both run on the offline signing machine. Do not install `repram-omega` on a
+REPRAM node.
+
+## First-time setup
+
+1. On an air-gapped machine, generate the keypair:
+
+   ```
+   repram-omega keygen \
+     --out-private omega-v1.key \
+     --out-public  omega-v1.pub
+   ```
+
+   `omega-v1.key` is written with mode `0600`. Back it up to offline media
+   (two copies, two locations). Losing it means rotating the omega version.
+
+2. Copy the base64 public key from stdout (or from `omega-v1.pub`) into the
+   node source on the online build machine:
+
+   - `internal/trust/omega.go` — `OmegaPubkey` constant.
+   - `repram-mcp/src/node/trust/omega.ts` — `OMEGA_PUBKEY` constant.
+
+   Both must match. Build, tag, release.
+
+## Publishing a signed root list
+
+1. On the signing machine, decide the node set and lifetime. A 24-hour
+   lifetime is a reasonable default; the network operator can refresh more
+   often without cost.
+
+   ```
+   repram-omega sign \
+     --key omega-v1.key \
+     --version omega-v1 \
+     --expires-in 24h \
+     --nodes root-a.example:9090,root-b.example:9090,root-c.example:9090
+   ```
+
+2. The command prints the full TXT-record value on stdout and the
+   publication checklist on stderr. Transfer only the stdout line (it is
+   public data) to the DNS provider's control panel or API.
+
+3. Update two records:
+
+   - `_bootstrap.repram.io  TXT  "omega=_omega.repram.io"` — rarely
+     changes; points discovery at the omega record.
+   - `_omega.repram.io      TXT  "<output of repram-omega sign>"` —
+     republished on every refresh.
+
+4. Verify propagation:
+
+   ```
+   dig +short TXT _bootstrap.repram.io
+   dig +short TXT _omega.repram.io
+   ```
+
+5. Nodes pick up the new record on their next refresh cycle (before the
+   previous record's `exp`). There is no need to restart nodes.
+
+## Changing the root node set
+
+Run `sign` with the new `--nodes` list, publish the new TXT record. A node
+whose advertised `REPRAM_ADDRESS:REPRAM_GOSSIP_PORT` is removed from the
+list stops answering `/v1/bootstrap` requests within one refresh cycle; a
+newly-added node starts answering on the same schedule.
+
+## Rotating the omega key (version bump)
+
+Required if the private key is lost or compromised. This is a shipping-a-
+new-binary event, not a DNS update.
+
+1. `repram-omega keygen` on the air-gapped machine, written to
+   `omega-v2.key` / `omega-v2.pub`.
+2. Bump the constants:
+   - `OmegaVersion = "omega-v2"`, new `OmegaPubkey` in Go.
+   - `OMEGA_VERSION = "omega-v2"`, new `OMEGA_PUBKEY` in TS.
+3. Cut a new release.
+4. Publish `_omega-v2.repram.io` in parallel with `_omega-v1.repram.io`
+   during the migration window. Keep the old version live until confident
+   no `omega-v1` nodes remain.
+5. Retire `_omega-v1.repram.io` when ready.
+
+## Recovery if the signing machine is unavailable
+
+The network keeps operating until the current signed list's `exp`. Existing
+nodes continue to gossip with each other normally. New nodes cannot bootstrap
+onto the public network once the cached list expires everywhere.
+
+To recover:
+
+1. Restore the private key from offline backup onto a clean air-gapped
+   machine.
+2. `repram-omega sign` with a fresh `exp`.
+3. Publish.
+
+There is no online key-recovery path by design. This is the point.

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -32,7 +32,7 @@ Two implementations of the REPRAM node exist with identical wire format, so Go a
 
 * **Go Node** (`cmd/repram/`): Standalone Go binary. Stores key-value pairs in memory with TTL expiration, replicates via gossip protocol, and exposes a REST API (`PUT/GET/HEAD /v1/data/{key}`, `/v1/keys`, `/v1/health`, `/v1/topology`, `/v1/metrics`).
 * **TypeScript Node** (`repram-mcp/`): Unified MCP server + REPRAM node. In default mode, `npx repram-mcp` starts an embedded node with MCP stdio transport — agents get `repram_store`, `repram_retrieve`, `repram_exists`, `repram_list_keys` tools with no separate server. In standalone mode (`--standalone`), it runs as a pure HTTP server equivalent to the Go binary. Can also connect to an external node via `REPRAM_URL` for backwards compatibility.
-* **Bootstrap Layer**: DNS-based peer discovery for the public network (`bootstrap.repram.network`), or manual `REPRAM_PEERS` for private clusters.
+* **Bootstrap Layer**: Ed25519-signed root-list discovery for the public network (TXT records at `_bootstrap.repram.io` → `_omega.repram.io`, verified against a baked-in "omega" pubkey — see [`docs/omega-operations.md`](omega-operations.md)), or manual `REPRAM_PEERS` for private clusters.
 * **Gossip Network**: HTTP-based peer-to-peer message propagation with quorum acknowledgement. Small enclaves use full broadcast; larger enclaves (>10 peers) use probabilistic √N fanout with epidemic forwarding and message deduplication.
 * **Enclaves**: `REPRAM_ENCLAVE` scopes data replication — nodes in the same enclave replicate data, all nodes share topology. Dynamic quorum adapts to enclave size.
 

--- a/internal/cluster/node.go
+++ b/internal/cluster/node.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"repram/internal/gossip"
@@ -26,6 +27,12 @@ type ClusterNode struct {
 
 	pendingWrites map[string]*WriteOperation
 	writesMutex   sync.RWMutex
+
+	// isRoot tracks whether this node appears in the currently-trusted
+	// signed root list. Updated on each successful omega refresh
+	// (see cmd/repram/main.go and future phase 4 refresh loop). When
+	// false, the HTTP server refuses bootstrap requests with 403.
+	isRoot atomic.Bool
 }
 
 type WriteOperation struct {
@@ -96,6 +103,20 @@ func (cn *ClusterNode) Start(ctx context.Context, bootstrapAddresses []string) e
 
 func (cn *ClusterNode) Stop() error {
 	return cn.protocol.Stop()
+}
+
+// IsRoot reports whether this node's advertised address is present in the
+// currently-trusted signed root list. Used by the HTTP server to gate
+// bootstrap responses — non-roots return 403 rather than handing out peer
+// topology to arbitrary callers.
+func (cn *ClusterNode) IsRoot() bool {
+	return cn.isRoot.Load()
+}
+
+// SetRoot updates the root flag. Call after each verified refresh of the
+// omega signed root list.
+func (cn *ClusterNode) SetRoot(v bool) {
+	cn.isRoot.Store(v)
 }
 
 func (cn *ClusterNode) Put(ctx context.Context, key string, data []byte, ttl time.Duration) error {

--- a/internal/trust/cache.go
+++ b/internal/trust/cache.go
@@ -1,0 +1,118 @@
+package trust
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// CacheFileName is the on-disk name for the cached signed list. Callers
+// receive a directory, not a file path; cache.Load/Save handle the filename
+// so the name can evolve without touching call sites.
+const CacheFileName = "root-list.json"
+
+// cachedList is the on-disk representation. We persist the *parsed* list
+// (not the raw TXT string) so the reader doesn't have to re-parse on every
+// startup. The signature is preserved so a load can be re-verified.
+type cachedList struct {
+	Version   string   `json:"version"`
+	Expires   int64    `json:"expires"`
+	Nodes     []string `json:"nodes"`
+	Signature []byte   `json:"signature"`
+}
+
+// LoadCache reads and returns the signed list stored at
+// filepath.Join(dir, CacheFileName). Returns (nil, nil) when the cache file
+// is absent — that is the normal first-run case. Any other error is returned.
+//
+// Callers must still Verify the returned list: the on-disk copy is
+// public data, so an attacker with write access to the cache file could
+// replace it with another signed list from the same omega version. Verify
+// catches an expired or wrong-version swap, and the baked-in pubkey catches
+// a forged one.
+func LoadCache(dir string) (*SignedList, error) {
+	path := filepath.Join(dir, CacheFileName)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read cache %s: %w", path, err)
+	}
+
+	var c cachedList
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return nil, fmt.Errorf("parse cache %s: %w", path, err)
+	}
+	return &SignedList{
+		Version:   c.Version,
+		Expires:   c.Expires,
+		Nodes:     c.Nodes,
+		Signature: c.Signature,
+	}, nil
+}
+
+// SaveCache writes list to filepath.Join(dir, CacheFileName) atomically by
+// writing to a temp file in the same directory and renaming into place. The
+// directory is created (with 0700) if it doesn't exist.
+func SaveCache(dir string, list *SignedList) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("mkdir cache dir %s: %w", dir, err)
+	}
+
+	payload, err := json.Marshal(cachedList{
+		Version:   list.Version,
+		Expires:   list.Expires,
+		Nodes:     list.Nodes,
+		Signature: list.Signature,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal cache: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(dir, CacheFileName+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp cache file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := tmp.Write(payload); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temp cache file: %w", err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return fmt.Errorf("chmod temp cache file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp cache file: %w", err)
+	}
+
+	finalPath := filepath.Join(dir, CacheFileName)
+	if err := os.Rename(tmpPath, finalPath); err != nil {
+		return fmt.Errorf("rename cache file: %w", err)
+	}
+	cleanup = false
+	return nil
+}
+
+// DefaultCacheDir resolves the cache directory with the priority defined in
+// the 2.1 spec: REPRAM_CACHE_DIR > $HOME/.repram/cache > /var/cache/repram.
+func DefaultCacheDir() string {
+	if dir := os.Getenv("REPRAM_CACHE_DIR"); dir != "" {
+		return dir
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".repram", "cache")
+	}
+	return "/var/cache/repram"
+}

--- a/internal/trust/cache.go
+++ b/internal/trust/cache.go
@@ -107,12 +107,26 @@ func SaveCache(dir string, list *SignedList) error {
 
 // DefaultCacheDir resolves the cache directory with the priority defined in
 // the 2.1 spec: REPRAM_CACHE_DIR > $HOME/.repram/cache > /var/cache/repram.
+//
+// Callers should prefer ResolveCacheDir, which additionally returns whether
+// the fallback was used. The /var/cache/repram path typically requires
+// root write access; non-root container deployments will produce refresh
+// log spam if they land on it. Operators in that situation should set
+// REPRAM_CACHE_DIR explicitly.
 func DefaultCacheDir() string {
+	dir, _ := ResolveCacheDir()
+	return dir
+}
+
+// ResolveCacheDir returns the cache directory and whether the last-resort
+// /var/cache/repram fallback was selected. Callers can use the second
+// return value to log a one-time startup warning.
+func ResolveCacheDir() (dir string, usedLastResort bool) {
 	if dir := os.Getenv("REPRAM_CACHE_DIR"); dir != "" {
-		return dir
+		return dir, false
 	}
 	if home, err := os.UserHomeDir(); err == nil && home != "" {
-		return filepath.Join(home, ".repram", "cache")
+		return filepath.Join(home, ".repram", "cache"), false
 	}
-	return "/var/cache/repram"
+	return "/var/cache/repram", true
 }

--- a/internal/trust/cache_test.go
+++ b/internal/trust/cache_test.go
@@ -1,0 +1,109 @@
+package trust
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSaveAndLoadRoundtrip(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	list := &SignedList{
+		Version: OmegaVersion,
+		Expires: time.Now().Add(1 * time.Hour).Unix(),
+		Nodes:   []string{"a:9090", "b:9090"},
+	}
+	list.Sign(priv)
+
+	dir := t.TempDir()
+	if err := SaveCache(dir, list); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	loaded, err := LoadCache(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("loaded nil after save")
+	}
+
+	if loaded.Version != list.Version || loaded.Expires != list.Expires {
+		t.Errorf("fields differ: %+v vs %+v", loaded, list)
+	}
+	if len(loaded.Nodes) != len(list.Nodes) {
+		t.Errorf("nodes length differ: %d vs %d", len(loaded.Nodes), len(list.Nodes))
+	}
+	if len(loaded.Signature) != len(list.Signature) {
+		t.Errorf("signature length differ")
+	}
+}
+
+// TestLoadCacheMissing — absent cache file reports (nil, nil) so first-run
+// callers can treat it as a normal condition.
+func TestLoadCacheMissing(t *testing.T) {
+	dir := t.TempDir()
+	loaded, err := LoadCache(dir)
+	if err != nil {
+		t.Fatalf("load missing: %v", err)
+	}
+	if loaded != nil {
+		t.Errorf("expected nil, got %+v", loaded)
+	}
+}
+
+// TestSaveCacheAtomic — the on-disk file should never contain partial data.
+// We can't cleanly simulate a crash, but we can at least check that no temp
+// file is left behind after a normal save.
+func TestSaveCacheAtomic(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(rand.Reader)
+	list := &SignedList{
+		Version:   OmegaVersion,
+		Expires:   time.Now().Add(time.Hour).Unix(),
+		Nodes:     []string{"a:9090"},
+		Signature: ed25519.Sign(priv, []byte("unused")),
+	}
+
+	dir := t.TempDir()
+	if err := SaveCache(dir, list); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(entries) != 1 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("expected exactly 1 file in cache dir, got %v", names)
+	}
+	if got := entries[0].Name(); got != CacheFileName {
+		t.Errorf("cache file name = %q, want %q", got, CacheFileName)
+	}
+}
+
+func TestDefaultCacheDirEnvWins(t *testing.T) {
+	t.Setenv("REPRAM_CACHE_DIR", "/tmp/explicit")
+	if got := DefaultCacheDir(); got != "/tmp/explicit" {
+		t.Errorf("REPRAM_CACHE_DIR override ignored: got %q", got)
+	}
+}
+
+func TestDefaultCacheDirHomeFallback(t *testing.T) {
+	t.Setenv("REPRAM_CACHE_DIR", "")
+	// os.UserHomeDir checks HOME on linux; force a known value.
+	t.Setenv("HOME", "/home/fake")
+	got := DefaultCacheDir()
+	want := filepath.Join("/home/fake", ".repram", "cache")
+	if got != want {
+		t.Errorf("home fallback = %q, want %q", got, want)
+	}
+}

--- a/internal/trust/omega.go
+++ b/internal/trust/omega.go
@@ -1,0 +1,46 @@
+// Package trust holds the baked-in trust anchors for REPRAM's public network.
+//
+// OmegaPubkey is the root of trust for DNS-delivered bootstrap data. The
+// corresponding private key is held offline by the network operator and is
+// used only to sign root lists published via DNS TXT records (see
+// docs/internal/REPRAM-2.1-Spec.md). The private key is never deployed to any
+// node and never transmitted over any network.
+//
+// OmegaVersion identifies the signing scheme. Future spec revisions that
+// change the signed-record format bump this version. A running binary rejects
+// any signed list whose version does not match its compiled-in OmegaVersion.
+package trust
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+)
+
+const (
+	// OmegaVersion is the signing-scheme identifier. See spec section
+	// "Protocol Versioning".
+	OmegaVersion = "omega-v1"
+
+	// OmegaPubkey is a PLACEHOLDER base64-encoded Ed25519 public key.
+	// The real omega public key is generated offline and baked in as part
+	// of the 2.1 release cutover (see Phase 6 in the implementation plan).
+	// Tests must not rely on this value — they generate ephemeral keypairs
+	// and inject them directly.
+	OmegaPubkey = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+)
+
+// DecodedOmegaPubkey returns OmegaPubkey parsed as an ed25519.PublicKey, or
+// an error if the baked-in value is not a valid 32-byte Ed25519 key.
+//
+// Callers that need to verify signatures at runtime should call this once at
+// startup and cache the result.
+func DecodedOmegaPubkey() (ed25519.PublicKey, error) {
+	raw, err := base64.StdEncoding.DecodeString(OmegaPubkey)
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) != ed25519.PublicKeySize {
+		return nil, errInvalidPubkeyLength
+	}
+	return ed25519.PublicKey(raw), nil
+}

--- a/internal/trust/refresher.go
+++ b/internal/trust/refresher.go
@@ -1,0 +1,221 @@
+package trust
+
+import (
+	"context"
+	"crypto/ed25519"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+// RefreshRotationFraction is the fraction of the remaining lifetime at which
+// to wake and refresh. 0.9 means: sleep 90% of the way to expiration, so
+// there's a 10% buffer to retry on failure before the list goes stale.
+const RefreshRotationFraction = 0.9
+
+// RefreshJitter is the symmetric ±jitter applied to the rotation deadline.
+// Prevents synchronized thundering-herd refreshes across the network.
+const RefreshJitter = 0.1
+
+// RefreshBackoffMin is the initial retry delay after a failed refresh.
+const RefreshBackoffMin = 30 * time.Second
+
+// RefreshBackoffMax caps exponential backoff so a long outage doesn't leave
+// the network with refresh delays of hours.
+const RefreshBackoffMax = 10 * time.Minute
+
+// Clock is a minimal clock abstraction so tests can drive refresh timing
+// deterministically.
+type Clock interface {
+	Now() time.Time
+	// After returns a channel that emits once after d. Tests can replace
+	// this with a channel they control.
+	After(d time.Duration) <-chan time.Time
+}
+
+// RealClock is time.Now()/time.After. Callers that don't need deterministic
+// timing can pass this directly.
+type RealClock struct{}
+
+func (RealClock) Now() time.Time                         { return time.Now() }
+func (RealClock) After(d time.Duration) <-chan time.Time { return time.After(d) }
+
+// RefresherConfig bundles the knobs a Refresher needs. Fields left zero
+// select sensible defaults.
+type RefresherConfig struct {
+	// Pubkey is the omega public key used to verify every new list.
+	// Required.
+	Pubkey ed25519.PublicKey
+
+	// CacheDir is where the verified list is persisted. Defaults to
+	// DefaultCacheDir().
+	CacheDir string
+
+	// DNS configures the resolver used to fetch new signed lists.
+	DNS DNSConfig
+
+	// OnUpdate is called with each newly-verified list. Use this to wire
+	// root-status changes back into the cluster (node.SetRoot(...)).
+	// Required.
+	OnUpdate func(*SignedList)
+
+	// OnError is called on every refresh failure. Optional; default is a
+	// no-op. Use it to log or emit metrics.
+	OnError func(error)
+
+	// Clock overrides time.Now / time.After. Production callers leave
+	// this nil to use RealClock.
+	Clock Clock
+
+	// Rand is the randomness source for jitter. Production callers leave
+	// this nil — a package-default rand is used. Tests can inject a
+	// deterministic rand for reproducibility.
+	Rand *rand.Rand
+}
+
+// Refresher runs the background refresh loop defined in the 2.1 spec. One
+// per node. Start it after the initial bootstrap succeeds; stop it during
+// shutdown by cancelling the context passed to Run.
+type Refresher struct {
+	cfg RefresherConfig
+
+	// current holds the list most recently verified. Guarded by mu.
+	mu      sync.Mutex
+	current *SignedList
+
+	// triggerCh accepts manual refresh requests (peer-count drop,
+	// bootstrap failure, etc.). Buffered so sends never block the caller.
+	triggerCh chan struct{}
+}
+
+// NewRefresher constructs a Refresher with an initial list already
+// verified by the caller. The initial list establishes the first deadline.
+func NewRefresher(cfg RefresherConfig, initial *SignedList) *Refresher {
+	if cfg.Clock == nil {
+		cfg.Clock = RealClock{}
+	}
+	if cfg.CacheDir == "" {
+		cfg.CacheDir = DefaultCacheDir()
+	}
+	if cfg.OnError == nil {
+		cfg.OnError = func(error) {}
+	}
+	if cfg.Rand == nil {
+		cfg.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
+	}
+	return &Refresher{
+		cfg:       cfg,
+		current:   initial,
+		triggerCh: make(chan struct{}, 1),
+	}
+}
+
+// Trigger requests an immediate refresh. Safe to call concurrently; extra
+// triggers while a refresh is already pending are coalesced.
+func (r *Refresher) Trigger() {
+	select {
+	case r.triggerCh <- struct{}{}:
+	default:
+	}
+}
+
+// Current returns the list most recently verified. Never nil after
+// construction; the initial list is always available.
+func (r *Refresher) Current() *SignedList {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.current
+}
+
+// Run blocks until ctx is cancelled, driving the refresh loop. It schedules
+// the next refresh at (exp - now) * RotationFraction ± Jitter. On failure
+// it retries with exponential backoff (RefreshBackoffMin..Max), retaining
+// the previous list so the gate keeps working until the cached list itself
+// expires.
+func (r *Refresher) Run(ctx context.Context) {
+	backoff := RefreshBackoffMin
+	for {
+		wait := r.nextDelay()
+		select {
+		case <-ctx.Done():
+			return
+		case <-r.cfg.Clock.After(wait):
+		case <-r.triggerCh:
+		}
+
+		if err := r.refreshOnce(ctx); err != nil {
+			r.cfg.OnError(err)
+			// On failure, wait the backoff then retry. Do not
+			// update r.current — the old list keeps serving until
+			// its own exp passes.
+			select {
+			case <-ctx.Done():
+				return
+			case <-r.cfg.Clock.After(backoff):
+			case <-r.triggerCh:
+			}
+			backoff *= 2
+			if backoff > RefreshBackoffMax {
+				backoff = RefreshBackoffMax
+			}
+			continue
+		}
+		backoff = RefreshBackoffMin
+	}
+}
+
+// refreshOnce fetches, verifies, caches, and publishes a new list. On
+// error the refresher's current list is untouched.
+func (r *Refresher) refreshOnce(ctx context.Context) error {
+	now := r.cfg.Clock.Now()
+	list, err := FetchSigned(ctx, r.cfg.DNS, r.cfg.Pubkey, now)
+	if err != nil {
+		return err
+	}
+
+	if err := SaveCache(r.cfg.CacheDir, list); err != nil {
+		// Cache failures are non-fatal: the verified list is still
+		// good in memory, and we'll try again next cycle. Surface
+		// via OnError so the operator knows the disk is unhappy.
+		r.cfg.OnError(err)
+	}
+
+	r.mu.Lock()
+	r.current = list
+	r.mu.Unlock()
+
+	r.cfg.OnUpdate(list)
+	return nil
+}
+
+// nextDelay computes how long to sleep before the next scheduled refresh.
+// Returns a zero duration when the current list is already expired (force
+// immediate refresh) and RefreshBackoffMin if no current list exists
+// (shouldn't happen in practice, but defensive).
+func (r *Refresher) nextDelay() time.Duration {
+	r.mu.Lock()
+	current := r.current
+	r.mu.Unlock()
+
+	if current == nil {
+		return RefreshBackoffMin
+	}
+
+	// Use the injectable clock for remaining-lifetime math so tests with
+	// a fake clock behave deterministically.
+	now := r.cfg.Clock.Now()
+	remaining := time.Duration(current.Expires-now.Unix()) * time.Second
+	if remaining <= 0 {
+		return 0
+	}
+
+	target := time.Duration(float64(remaining) * RefreshRotationFraction)
+	jitterSpan := time.Duration(float64(target) * RefreshJitter * 2) // ±jitter = 2× range
+	if jitterSpan > 0 {
+		target += time.Duration(r.cfg.Rand.Int63n(int64(jitterSpan))) - jitterSpan/2
+	}
+	if target < 0 {
+		target = 0
+	}
+	return target
+}

--- a/internal/trust/refresher_test.go
+++ b/internal/trust/refresher_test.go
@@ -1,0 +1,302 @@
+package trust
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	mathrand "math/rand"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeClock drives the Refresher's time-dependent logic from tests.
+// Calls to After return channels that the test fires manually via Advance.
+type fakeClock struct {
+	mu         sync.Mutex
+	now        time.Time
+	pending    []pendingAfter
+	afterCalls chan struct{} // signalled on every After registration
+}
+
+type pendingAfter struct {
+	fireAt time.Time
+	ch     chan time.Time
+}
+
+func newFakeClock(now time.Time) *fakeClock {
+	return &fakeClock{
+		now:        now,
+		afterCalls: make(chan struct{}, 64),
+	}
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) After(d time.Duration) <-chan time.Time {
+	c.mu.Lock()
+	ch := make(chan time.Time, 1)
+	c.pending = append(c.pending, pendingAfter{fireAt: c.now.Add(d), ch: ch})
+	c.mu.Unlock()
+	select {
+	case c.afterCalls <- struct{}{}:
+	default:
+	}
+	return ch
+}
+
+// WaitForPending blocks until at least n After calls have been registered
+// since the last WaitForPending, or until timeout. Used to eliminate the
+// registration race between the test goroutine and the refresher goroutine.
+func (c *fakeClock) WaitForPending(n int, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	seen := 0
+	for seen < n {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return
+		}
+		select {
+		case <-c.afterCalls:
+			seen++
+		case <-time.After(remaining):
+			return
+		}
+	}
+}
+
+// Advance fires all pending After channels whose fireAt is now ≤ c.now+d.
+// Returns the number of channels that fired.
+func (c *fakeClock) Advance(d time.Duration) int {
+	c.mu.Lock()
+	c.now = c.now.Add(d)
+	var kept []pendingAfter
+	var fired int
+	for _, p := range c.pending {
+		if !p.fireAt.After(c.now) {
+			p.ch <- c.now
+			fired++
+		} else {
+			kept = append(kept, p)
+		}
+	}
+	c.pending = kept
+	c.mu.Unlock()
+	return fired
+}
+
+func buildSignedListT(t *testing.T, priv ed25519.PrivateKey, expires int64, nodes []string) *SignedList {
+	t.Helper()
+	list := &SignedList{
+		Version: OmegaVersion,
+		Expires: expires,
+		Nodes:   nodes,
+	}
+	list.Sign(priv)
+	return list
+}
+
+// TestRefresherUpdatesOnSchedule — when the scheduled delay fires and DNS
+// returns a fresh list, OnUpdate is called and Current() reflects the new
+// list.
+func TestRefresherUpdatesOnSchedule(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+
+	start := time.Unix(1_800_000_000, 0)
+	initial := buildSignedListT(t, priv, start.Add(1*time.Hour).Unix(), []string{"a:9090"})
+	refreshed := buildSignedListT(t, priv, start.Add(2*time.Hour).Unix(), []string{"a:9090", "b:9090"})
+
+	clock := newFakeClock(start)
+	resolver := &stubResolver{
+		records: map[string][]string{
+			"_bootstrap.repram.io": {"omega=_omega.repram.io"},
+			"_omega.repram.io":     {refreshed.Encode()},
+		},
+	}
+
+	var updateCount int
+	updated := make(chan *SignedList, 1)
+	cfg := RefresherConfig{
+		Pubkey:   pub,
+		CacheDir: t.TempDir(),
+		DNS:      DNSConfig{Resolver: resolver},
+		Clock:    clock,
+		Rand:     mathrand.New(mathrand.NewSource(1)),
+		OnUpdate: func(l *SignedList) {
+			updateCount++
+			updated <- l
+		},
+		OnError: func(err error) { t.Errorf("unexpected error: %v", err) },
+	}
+
+	r := NewRefresher(cfg, initial)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		r.Run(ctx)
+		close(done)
+	}()
+
+	// Fire the first scheduled refresh (at ~54 minutes; advance past it).
+	clock.WaitForPending(1, time.Second)
+	clock.Advance(1 * time.Hour)
+
+	select {
+	case got := <-updated:
+		if len(got.Nodes) != 2 {
+			t.Errorf("refreshed list node count = %d, want 2", len(got.Nodes))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for OnUpdate")
+	}
+
+	cancel()
+	<-done
+}
+
+// TestRefresherRetainsListOnFailure — a failed refresh must NOT clear
+// Current(). Callers depend on this: even if DNS is down, the root flag
+// stays accurate until the underlying list expires.
+func TestRefresherRetainsListOnFailure(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	start := time.Unix(1_800_000_000, 0)
+	initial := buildSignedListT(t, priv, start.Add(1*time.Hour).Unix(), []string{"a:9090"})
+
+	clock := newFakeClock(start)
+	sentinel := errors.New("simulated DNS failure")
+	resolver := &stubResolver{
+		err: map[string]error{"_bootstrap.repram.io": sentinel},
+	}
+
+	errCh := make(chan error, 4)
+	cfg := RefresherConfig{
+		Pubkey:   pub,
+		CacheDir: t.TempDir(),
+		DNS:      DNSConfig{Resolver: resolver},
+		Clock:    clock,
+		Rand:     mathrand.New(mathrand.NewSource(1)),
+		OnUpdate: func(*SignedList) { t.Error("OnUpdate called on a failing refresh") },
+		OnError:  func(err error) { errCh <- err },
+	}
+
+	r := NewRefresher(cfg, initial)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go r.Run(ctx)
+
+	clock.WaitForPending(1, time.Second)
+	clock.Advance(1 * time.Hour) // triggers the scheduled refresh
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, sentinel) {
+			t.Errorf("OnError got %v, want sentinel", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for OnError")
+	}
+
+	// Current list is unchanged.
+	if got := r.Current(); got == nil || got.Expires != initial.Expires {
+		t.Errorf("Current() changed after failure: got %+v", got)
+	}
+}
+
+// TestRefresherTriggerForcesImmediateRefresh — Trigger() wakes the loop
+// without waiting for the scheduled deadline.
+func TestRefresherTriggerForcesImmediateRefresh(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	start := time.Unix(1_800_000_000, 0)
+	initial := buildSignedListT(t, priv, start.Add(24*time.Hour).Unix(), []string{"a:9090"})
+	fresh := buildSignedListT(t, priv, start.Add(48*time.Hour).Unix(), []string{"a:9090", "b:9090"})
+
+	clock := newFakeClock(start)
+	resolver := &stubResolver{
+		records: map[string][]string{
+			"_bootstrap.repram.io": {"omega=_omega.repram.io"},
+			"_omega.repram.io":     {fresh.Encode()},
+		},
+	}
+
+	updates := make(chan *SignedList, 1)
+	cfg := RefresherConfig{
+		Pubkey:   pub,
+		CacheDir: t.TempDir(),
+		DNS:      DNSConfig{Resolver: resolver},
+		Clock:    clock,
+		Rand:     mathrand.New(mathrand.NewSource(1)),
+		OnUpdate: func(l *SignedList) { updates <- l },
+		OnError:  func(err error) { t.Errorf("unexpected error: %v", err) },
+	}
+
+	r := NewRefresher(cfg, initial)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	// Force an immediate refresh without advancing the clock.
+	r.Trigger()
+
+	select {
+	case l := <-updates:
+		if len(l.Nodes) != 2 {
+			t.Errorf("triggered list nodes = %d, want 2", len(l.Nodes))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Trigger did not cause a refresh")
+	}
+}
+
+// TestNextDelayScalesWithRemaining — the scheduled delay should be
+// approximately RefreshRotationFraction * remaining, within ±jitter.
+func TestNextDelayScalesWithRemaining(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	_ = pub
+	start := time.Unix(1_800_000_000, 0)
+	lifetime := 1 * time.Hour
+	initial := buildSignedListT(t, priv, start.Add(lifetime).Unix(), []string{"a:9090"})
+
+	clock := newFakeClock(start)
+	r := &Refresher{
+		cfg: RefresherConfig{
+			Clock: clock,
+			Rand:  mathrand.New(mathrand.NewSource(1)),
+		},
+		current: initial,
+	}
+
+	got := r.nextDelay()
+	expected := time.Duration(float64(lifetime) * RefreshRotationFraction)
+	jitterBand := time.Duration(float64(expected) * RefreshJitter)
+	if got < expected-jitterBand || got > expected+jitterBand {
+		t.Errorf("nextDelay = %s, want %s±%s", got, expected, jitterBand)
+	}
+}
+
+// TestNextDelayZeroWhenExpired — if somehow the list is already expired,
+// schedule immediate refresh rather than sleeping.
+func TestNextDelayZeroWhenExpired(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	_ = pub
+	start := time.Unix(1_800_000_000, 0)
+	expired := buildSignedListT(t, priv, start.Add(-1*time.Minute).Unix(), []string{"a:9090"})
+	clock := newFakeClock(start)
+	r := &Refresher{
+		cfg:     RefresherConfig{Clock: clock, Rand: mathrand.New(mathrand.NewSource(1))},
+		current: expired,
+	}
+	if got := r.nextDelay(); got != 0 {
+		t.Errorf("nextDelay on expired list = %s, want 0", got)
+	}
+}

--- a/internal/trust/resolver.go
+++ b/internal/trust/resolver.go
@@ -1,0 +1,128 @@
+package trust
+
+import (
+	"context"
+	"crypto/ed25519"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+// Default DNS names for the public network. Overridable for tests and for
+// future spec revisions that migrate the records.
+const (
+	DefaultBootstrapName = "_bootstrap.repram.io"
+)
+
+// TXTResolver is the minimal interface this package needs from a DNS
+// resolver. net.Resolver satisfies it. Tests use an in-memory
+// implementation to avoid network dependencies.
+type TXTResolver interface {
+	LookupTXT(ctx context.Context, name string) ([]string, error)
+}
+
+// DNSConfig is a bundle of knobs for the bootstrap DNS lookup. Zero values
+// select sensible defaults: the standard net.Resolver and the public-network
+// bootstrap name from the 2.1 spec.
+type DNSConfig struct {
+	Resolver      TXTResolver
+	BootstrapName string
+}
+
+func (c DNSConfig) resolver() TXTResolver {
+	if c.Resolver != nil {
+		return c.Resolver
+	}
+	return net.DefaultResolver
+}
+
+func (c DNSConfig) bootstrapName() string {
+	if c.BootstrapName != "" {
+		return c.BootstrapName
+	}
+	return DefaultBootstrapName
+}
+
+var (
+	errNoBootstrapRecord = errors.New("trust: bootstrap TXT record has no omega= entry")
+	errEmptyTXT          = errors.New("trust: TXT lookup returned no usable records")
+)
+
+// FetchSigned resolves the signed root list over DNS and verifies it against
+// pubkey. It performs two lookups: first _bootstrap.repram.io (or whatever
+// cfg.BootstrapName overrides it to) for an `omega=<target>` indirection,
+// then the target for the actual signed record.
+//
+// On success, returns a verified list — callers may trust list.Nodes
+// directly. On any failure (DNS, parse, version, expiration, signature),
+// returns a descriptive error and no list.
+//
+// The spec permits TXT records to be split across multiple strings by the
+// resolver; this function joins them before parsing.
+func FetchSigned(ctx context.Context, cfg DNSConfig, pubkey ed25519.PublicKey, now time.Time) (*SignedList, error) {
+	r := cfg.resolver()
+	bootstrapName := cfg.bootstrapName()
+
+	indirection, err := lookupSingleTXT(ctx, r, bootstrapName)
+	if err != nil {
+		return nil, fmt.Errorf("lookup %s: %w", bootstrapName, err)
+	}
+	target, err := parseBootstrapIndirection(indirection)
+	if err != nil {
+		return nil, err
+	}
+
+	signedRaw, err := lookupSingleTXT(ctx, r, target)
+	if err != nil {
+		return nil, fmt.Errorf("lookup %s: %w", target, err)
+	}
+
+	list, err := Parse(signedRaw)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", target, err)
+	}
+	if err := list.Verify(pubkey, now); err != nil {
+		return nil, fmt.Errorf("verify %s: %w", target, err)
+	}
+	return list, nil
+}
+
+// lookupSingleTXT returns the first non-empty TXT record for name, after
+// joining any multi-string splits. Multiple records under the same name are
+// unusual for our use case; we take the first to keep behavior deterministic.
+func lookupSingleTXT(ctx context.Context, r TXTResolver, name string) (string, error) {
+	records, err := r.LookupTXT(ctx, name)
+	if err != nil {
+		return "", err
+	}
+	for _, rec := range records {
+		rec = strings.TrimSpace(rec)
+		if rec != "" {
+			return rec, nil
+		}
+	}
+	return "", errEmptyTXT
+}
+
+// parseBootstrapIndirection parses a _bootstrap.repram.io TXT value of the
+// form `omega=<target-name>`. The indirection layer exists so future spec
+// revisions can migrate the signed-record hostname without changing the
+// baked-in name.
+func parseBootstrapIndirection(raw string) (string, error) {
+	for _, field := range strings.Split(raw, fieldSeparator) {
+		key, value, ok := strings.Cut(strings.TrimSpace(field), kvSeparator)
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(key) == "omega" {
+			target := strings.TrimSpace(value)
+			if target == "" {
+				return "", errNoBootstrapRecord
+			}
+			return target, nil
+		}
+	}
+	return "", errNoBootstrapRecord
+}

--- a/internal/trust/resolver.go
+++ b/internal/trust/resolver.go
@@ -59,8 +59,12 @@ var (
 // directly. On any failure (DNS, parse, version, expiration, signature),
 // returns a descriptive error and no list.
 //
-// The spec permits TXT records to be split across multiple strings by the
-// resolver; this function joins them before parsing.
+// Note on multi-string TXT records: DNS TXT records can be split across
+// multiple 255-byte "character-strings" on the wire. Go's net.Resolver
+// already concatenates those into one string per record before returning,
+// so each element of the []string LookupTXT returns is already a complete
+// record. The TS parallel in repram-mcp does need to join because Node's
+// dns.resolveTxt returns string[][] (records × segments).
 func FetchSigned(ctx context.Context, cfg DNSConfig, pubkey ed25519.PublicKey, now time.Time) (*SignedList, error) {
 	r := cfg.resolver()
 	bootstrapName := cfg.bootstrapName()
@@ -89,9 +93,11 @@ func FetchSigned(ctx context.Context, cfg DNSConfig, pubkey ed25519.PublicKey, n
 	return list, nil
 }
 
-// lookupSingleTXT returns the first non-empty TXT record for name, after
-// joining any multi-string splits. Multiple records under the same name are
-// unusual for our use case; we take the first to keep behavior deterministic.
+// lookupSingleTXT returns the first non-empty TXT record for name. Each
+// element of the []string returned by net.Resolver.LookupTXT is already a
+// complete record (the stdlib concatenates multi-string splits before
+// returning). Multiple records under the same name are unusual for our use
+// case; we take the first to keep behavior deterministic.
 func lookupSingleTXT(ctx context.Context, r TXTResolver, name string) (string, error) {
 	records, err := r.LookupTXT(ctx, name)
 	if err != nil {

--- a/internal/trust/resolver_test.go
+++ b/internal/trust/resolver_test.go
@@ -1,0 +1,121 @@
+package trust
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"testing"
+	"time"
+)
+
+// stubResolver is an in-memory TXTResolver for tests. Keyed by hostname.
+type stubResolver struct {
+	records map[string][]string
+	err     map[string]error
+}
+
+func (s *stubResolver) LookupTXT(_ context.Context, name string) ([]string, error) {
+	if err, ok := s.err[name]; ok {
+		return nil, err
+	}
+	return s.records[name], nil
+}
+
+func TestFetchSignedHappyPath(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	list := &SignedList{
+		Version: OmegaVersion,
+		Expires: time.Now().Add(1 * time.Hour).Unix(),
+		Nodes:   []string{"root-a.example:9090", "root-b.example:9090"},
+	}
+	list.Sign(priv)
+
+	resolver := &stubResolver{
+		records: map[string][]string{
+			"_bootstrap.repram.io": {"omega=_omega.repram.io"},
+			"_omega.repram.io":     {list.Encode()},
+		},
+	}
+
+	got, err := FetchSigned(context.Background(), DNSConfig{Resolver: resolver}, pub, time.Now())
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if len(got.Nodes) != 2 {
+		t.Errorf("nodes length = %d, want 2", len(got.Nodes))
+	}
+}
+
+func TestFetchSignedHandlesIndirectionMissing(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	resolver := &stubResolver{
+		records: map[string][]string{
+			"_bootstrap.repram.io": {"something-else=value"},
+		},
+	}
+	_, err := FetchSigned(context.Background(), DNSConfig{Resolver: resolver}, pub, time.Now())
+	if !errors.Is(err, errNoBootstrapRecord) {
+		t.Errorf("want errNoBootstrapRecord, got %v", err)
+	}
+}
+
+func TestFetchSignedPropagatesVerifyFailure(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	list := &SignedList{
+		Version: OmegaVersion,
+		Expires: time.Now().Add(-1 * time.Minute).Unix(), // expired
+		Nodes:   []string{"a:9090"},
+	}
+	list.Sign(priv)
+
+	resolver := &stubResolver{
+		records: map[string][]string{
+			"_bootstrap.repram.io": {"omega=_omega.repram.io"},
+			"_omega.repram.io":     {list.Encode()},
+		},
+	}
+	_, err := FetchSigned(context.Background(), DNSConfig{Resolver: resolver}, pub, time.Now())
+	if !errors.Is(err, errExpiredList) {
+		t.Errorf("want errExpiredList, got %v", err)
+	}
+}
+
+func TestFetchSignedPropagatesSignatureMismatch(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(rand.Reader)
+	attackerPub, _, _ := ed25519.GenerateKey(rand.Reader)
+
+	list := &SignedList{
+		Version: OmegaVersion,
+		Expires: time.Now().Add(1 * time.Hour).Unix(),
+		Nodes:   []string{"a:9090"},
+	}
+	list.Sign(priv) // signed by legitimate key
+
+	resolver := &stubResolver{
+		records: map[string][]string{
+			"_bootstrap.repram.io": {"omega=_omega.repram.io"},
+			"_omega.repram.io":     {list.Encode()},
+		},
+	}
+	// Attacker's pubkey does not match the signing key.
+	_, err := FetchSigned(context.Background(), DNSConfig{Resolver: resolver}, attackerPub, time.Now())
+	if !errors.Is(err, errBadSignature) {
+		t.Errorf("want errBadSignature, got %v", err)
+	}
+}
+
+func TestFetchSignedDNSError(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	sentinel := errors.New("dns down")
+	resolver := &stubResolver{
+		err: map[string]error{"_bootstrap.repram.io": sentinel},
+	}
+	_, err := FetchSigned(context.Background(), DNSConfig{Resolver: resolver}, pub, time.Now())
+	if !errors.Is(err, sentinel) {
+		t.Errorf("want sentinel, got %v", err)
+	}
+}

--- a/internal/trust/signedlist.go
+++ b/internal/trust/signedlist.go
@@ -1,0 +1,226 @@
+package trust
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Spec field names and separators. See docs/internal/REPRAM-2.1-Spec.md
+// "Signed Root List: DNS Format" and "Signature Format".
+const (
+	fieldVersion = "v"
+	fieldExpires = "exp"
+	fieldNodes   = "nodes"
+	fieldSig     = "sig"
+
+	fieldSeparator = ";"
+	kvSeparator    = "="
+	nodeSeparator  = ","
+)
+
+var (
+	errInvalidPubkeyLength = errors.New("trust: baked-in omega pubkey has wrong length")
+	errMissingField        = errors.New("trust: signed list missing required field")
+	errDuplicateField      = errors.New("trust: signed list has duplicate field")
+	errMalformedField      = errors.New("trust: signed list has malformed field")
+	errMalformedSignature  = errors.New("trust: signed list signature is not valid base64")
+	errExpiredList         = errors.New("trust: signed list has expired")
+	errVersionMismatch     = errors.New("trust: signed list version does not match binary")
+	errBadSignature        = errors.New("trust: signed list signature verification failed")
+	errEmptyNodes          = errors.New("trust: signed list contains no nodes")
+)
+
+// SignedList is a verified-or-unverified parsed root list. Construct one via
+// Parse (for records received over DNS) or by setting the fields directly
+// (for signing tools). Verify must be called before trusting Nodes.
+type SignedList struct {
+	// Version must equal OmegaVersion at verification time.
+	Version string
+
+	// Expires is a Unix timestamp (seconds). The list is invalid at or
+	// after this time.
+	Expires int64
+
+	// Nodes are advertised addresses ("host:gossip-port") of the root
+	// nodes. Stored in the order received; Canonical() sorts them.
+	Nodes []string
+
+	// Signature is the Ed25519 signature over Canonical(). Empty on a
+	// freshly constructed list that has not yet been signed.
+	Signature []byte
+}
+
+// Parse deserializes a TXT-record payload of the form
+//
+//	v=omega-v1;exp=1735689600;nodes=a:9090,b:9090;sig=<base64>
+//
+// Field order is tolerated on input but normalized on output via Canonical.
+// Duplicate fields are rejected.
+func Parse(raw string) (*SignedList, error) {
+	if raw == "" {
+		return nil, fmt.Errorf("%w: empty record", errMalformedField)
+	}
+
+	seen := make(map[string]struct{}, 4)
+	var list SignedList
+	var hasVersion, hasExpires, hasNodes, hasSig bool
+
+	for _, part := range strings.Split(raw, fieldSeparator) {
+		if part == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(part, kvSeparator)
+		if !ok {
+			return nil, fmt.Errorf("%w: %q", errMalformedField, part)
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+
+		if _, dup := seen[key]; dup {
+			return nil, fmt.Errorf("%w: %s", errDuplicateField, key)
+		}
+		seen[key] = struct{}{}
+
+		switch key {
+		case fieldVersion:
+			list.Version = value
+			hasVersion = true
+		case fieldExpires:
+			exp, err := strconv.ParseInt(value, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("%w: exp=%q", errMalformedField, value)
+			}
+			list.Expires = exp
+			hasExpires = true
+		case fieldNodes:
+			if value == "" {
+				return nil, errEmptyNodes
+			}
+			list.Nodes = splitAndTrim(value, nodeSeparator)
+			if len(list.Nodes) == 0 {
+				return nil, errEmptyNodes
+			}
+			hasNodes = true
+		case fieldSig:
+			sig, err := base64.StdEncoding.DecodeString(value)
+			if err != nil {
+				return nil, errMalformedSignature
+			}
+			list.Signature = sig
+			hasSig = true
+		default:
+			// Unknown fields are ignored to leave room for forward-
+			// compatible additions that don't bump the omega version.
+			// Breaking changes bump OmegaVersion and are rejected
+			// earlier by the version check.
+		}
+	}
+
+	switch {
+	case !hasVersion:
+		return nil, fmt.Errorf("%w: %s", errMissingField, fieldVersion)
+	case !hasExpires:
+		return nil, fmt.Errorf("%w: %s", errMissingField, fieldExpires)
+	case !hasNodes:
+		return nil, fmt.Errorf("%w: %s", errMissingField, fieldNodes)
+	case !hasSig:
+		return nil, fmt.Errorf("%w: %s", errMissingField, fieldSig)
+	}
+
+	return &list, nil
+}
+
+// Canonical returns the signed-payload bytes: fixed field order, nodes
+// lex-sorted, no whitespace, no signature. This is the exact byte sequence
+// that Sign signs and Verify verifies.
+func (s *SignedList) Canonical() []byte {
+	nodes := make([]string, len(s.Nodes))
+	copy(nodes, s.Nodes)
+	sort.Strings(nodes)
+
+	var b strings.Builder
+	b.WriteString(fieldVersion)
+	b.WriteString(kvSeparator)
+	b.WriteString(s.Version)
+	b.WriteString(fieldSeparator)
+	b.WriteString(fieldExpires)
+	b.WriteString(kvSeparator)
+	b.WriteString(strconv.FormatInt(s.Expires, 10))
+	b.WriteString(fieldSeparator)
+	b.WriteString(fieldNodes)
+	b.WriteString(kvSeparator)
+	b.WriteString(strings.Join(nodes, nodeSeparator))
+	return []byte(b.String())
+}
+
+// Encode produces the full TXT-record value including the base64-encoded
+// signature. Intended for use by the repram-omega signing tool.
+func (s *SignedList) Encode() string {
+	return string(s.Canonical()) + fieldSeparator + fieldSig + kvSeparator +
+		base64.StdEncoding.EncodeToString(s.Signature)
+}
+
+// Sign computes the signature over Canonical() using priv, stores it on s,
+// and returns it.
+func (s *SignedList) Sign(priv ed25519.PrivateKey) []byte {
+	sig := ed25519.Sign(priv, s.Canonical())
+	s.Signature = sig
+	return sig
+}
+
+// Verify validates version, expiration, and signature against pubkey. It
+// reports the first failure encountered. Callers MUST check the returned
+// error before trusting s.Nodes.
+//
+// now is the reference time for expiration checks (usually time.Now()).
+// Separate argument so tests can inject deterministic clocks.
+func (s *SignedList) Verify(pubkey ed25519.PublicKey, now time.Time) error {
+	if s.Version != OmegaVersion {
+		return fmt.Errorf("%w: got %q want %q", errVersionMismatch, s.Version, OmegaVersion)
+	}
+	if now.Unix() >= s.Expires {
+		return fmt.Errorf("%w: exp=%d now=%d", errExpiredList, s.Expires, now.Unix())
+	}
+	if len(s.Nodes) == 0 {
+		return errEmptyNodes
+	}
+	if len(pubkey) != ed25519.PublicKeySize {
+		return errInvalidPubkeyLength
+	}
+	if !ed25519.Verify(pubkey, s.Canonical(), s.Signature) {
+		return errBadSignature
+	}
+	return nil
+}
+
+// Sentinel-error accessors for callers that want to branch on failure mode
+// without importing package-private identifiers.
+
+// ErrVersionMismatch indicates a signed list whose v= field does not match
+// the binary's compiled-in OmegaVersion.
+func ErrVersionMismatch() error { return errVersionMismatch }
+
+// ErrExpired indicates a signed list whose exp= timestamp is in the past.
+func ErrExpired() error { return errExpiredList }
+
+// ErrBadSignature indicates a signed list whose signature does not verify
+// against the provided public key.
+func ErrBadSignature() error { return errBadSignature }
+
+func splitAndTrim(s, sep string) []string {
+	parts := strings.Split(s, sep)
+	out := parts[:0]
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/trust/signedlist.go
+++ b/internal/trust/signedlist.go
@@ -34,6 +34,7 @@ var (
 	errVersionMismatch     = errors.New("trust: signed list version does not match binary")
 	errBadSignature        = errors.New("trust: signed list signature verification failed")
 	errEmptyNodes          = errors.New("trust: signed list contains no nodes")
+	errUnknownField        = errors.New("trust: signed list has unknown field")
 )
 
 // SignedList is a verified-or-unverified parsed root list. Construct one via
@@ -115,10 +116,14 @@ func Parse(raw string) (*SignedList, error) {
 			list.Signature = sig
 			hasSig = true
 		default:
-			// Unknown fields are ignored to leave room for forward-
-			// compatible additions that don't bump the omega version.
-			// Breaking changes bump OmegaVersion and are rejected
-			// earlier by the version check.
+			// omega-v1 is a strict wire format: unknown fields are
+			// rejected rather than silently dropped. The signature
+			// only covers Canonical() — which contains the known
+			// fields — so accepting unknowns would admit
+			// unauthenticated data into an otherwise-authenticated
+			// record. Any future forward-compatible extension must
+			// bump OmegaVersion.
+			return nil, fmt.Errorf("%w: %s", errUnknownField, key)
 		}
 	}
 
@@ -192,6 +197,14 @@ func (s *SignedList) Verify(pubkey ed25519.PublicKey, now time.Time) error {
 	}
 	if len(pubkey) != ed25519.PublicKeySize {
 		return errInvalidPubkeyLength
+	}
+	// Explicit length guard on top of ed25519.Verify (which also returns
+	// false for wrong-size signatures). Distinguishing a malformed record
+	// from a tampered record helps operators debug: DNS truncation shows
+	// up as errMalformedSignature, whereas real tampering shows up as
+	// errBadSignature.
+	if len(s.Signature) != ed25519.SignatureSize {
+		return errMalformedSignature
 	}
 	if !ed25519.Verify(pubkey, s.Canonical(), s.Signature) {
 		return errBadSignature

--- a/internal/trust/signedlist_test.go
+++ b/internal/trust/signedlist_test.go
@@ -1,0 +1,303 @@
+package trust
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// testKeypair generates an ephemeral Ed25519 keypair for tests. The real
+// omega pubkey (the package-level placeholder) is never used here.
+func testKeypair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	return pub, priv
+}
+
+func validList(expires int64) *SignedList {
+	return &SignedList{
+		Version: OmegaVersion,
+		Expires: expires,
+		Nodes:   []string{"root-c.example:9090", "root-a.example:9090", "root-b.example:9090"},
+	}
+}
+
+// TestCanonicalSortsAndOrdersFields verifies the canonical payload has the
+// fixed field order and lex-sorted nodes regardless of input order.
+func TestCanonicalSortsAndOrdersFields(t *testing.T) {
+	list := validList(1_900_000_000)
+	got := string(list.Canonical())
+	want := "v=omega-v1;exp=1900000000;nodes=root-a.example:9090,root-b.example:9090,root-c.example:9090"
+	if got != want {
+		t.Errorf("canonical mismatch:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// TestCanonicalIsStableAcrossInputPermutations — canonical form is identical
+// for any input node ordering. This is the property signatures depend on.
+func TestCanonicalIsStableAcrossInputPermutations(t *testing.T) {
+	base := validList(1_900_000_000)
+	baseCanonical := string(base.Canonical())
+
+	shuffled := &SignedList{
+		Version: base.Version,
+		Expires: base.Expires,
+		Nodes:   []string{"root-b.example:9090", "root-c.example:9090", "root-a.example:9090"},
+	}
+	if string(shuffled.Canonical()) != baseCanonical {
+		t.Errorf("canonical form not stable across node permutations")
+	}
+}
+
+// TestSignVerifyRoundtrip — a list signed with priv verifies with pub.
+func TestSignVerifyRoundtrip(t *testing.T) {
+	pub, priv := testKeypair(t)
+	list := validList(time.Now().Add(1 * time.Hour).Unix())
+	list.Sign(priv)
+
+	if err := list.Verify(pub, time.Now()); err != nil {
+		t.Fatalf("verify freshly signed list: %v", err)
+	}
+}
+
+// TestSignVerifyAcrossEncodeParse — a signed list survives encode/parse
+// roundtrip and still verifies.
+func TestSignVerifyAcrossEncodeParse(t *testing.T) {
+	pub, priv := testKeypair(t)
+	list := validList(time.Now().Add(1 * time.Hour).Unix())
+	list.Sign(priv)
+
+	encoded := list.Encode()
+	parsed, err := Parse(encoded)
+	if err != nil {
+		t.Fatalf("parse encoded list: %v", err)
+	}
+
+	if err := parsed.Verify(pub, time.Now()); err != nil {
+		t.Fatalf("verify parsed list: %v", err)
+	}
+}
+
+// TestParseToleratesFieldReordering — tolerate arbitrary field order on the
+// wire; canonicalization is what matters for signature.
+func TestParseToleratesFieldReordering(t *testing.T) {
+	pub, priv := testKeypair(t)
+	list := validList(time.Now().Add(1 * time.Hour).Unix())
+	list.Sign(priv)
+
+	sigB64 := base64.StdEncoding.EncodeToString(list.Signature)
+	reordered := "sig=" + sigB64 + ";nodes=root-a.example:9090,root-b.example:9090,root-c.example:9090;exp=" +
+		strconv.FormatInt(list.Expires, 10) + ";v=" + OmegaVersion
+
+	parsed, err := Parse(reordered)
+	if err != nil {
+		t.Fatalf("parse reordered: %v", err)
+	}
+	if err := parsed.Verify(pub, time.Now()); err != nil {
+		t.Fatalf("verify reordered: %v", err)
+	}
+}
+
+// TestParseRejectsDuplicateFields — a record with two v= or two sig= fields
+// is malformed. Defends against a splicer trying to confuse field resolution.
+func TestParseRejectsDuplicateFields(t *testing.T) {
+	raw := "v=omega-v1;v=omega-v1;exp=1900000000;nodes=a:9090;sig=" +
+		base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize))
+	_, err := Parse(raw)
+	if !errors.Is(err, errDuplicateField) {
+		t.Errorf("want errDuplicateField, got %v", err)
+	}
+}
+
+// TestParseRejectsMissingFields — each required field is individually
+// required.
+func TestParseRejectsMissingFields(t *testing.T) {
+	cases := map[string]string{
+		"missing v":     "exp=1900000000;nodes=a:9090;sig=AAAA",
+		"missing exp":   "v=omega-v1;nodes=a:9090;sig=AAAA",
+		"missing nodes": "v=omega-v1;exp=1900000000;sig=AAAA",
+		"missing sig":   "v=omega-v1;exp=1900000000;nodes=a:9090",
+	}
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := Parse(raw)
+			if !errors.Is(err, errMissingField) {
+				t.Errorf("want errMissingField, got %v", err)
+			}
+		})
+	}
+}
+
+// TestParseRejectsMalformedExp — exp must parse as int64.
+func TestParseRejectsMalformedExp(t *testing.T) {
+	raw := "v=omega-v1;exp=not-a-number;nodes=a:9090;sig=AAAA"
+	_, err := Parse(raw)
+	if !errors.Is(err, errMalformedField) {
+		t.Errorf("want errMalformedField, got %v", err)
+	}
+}
+
+// TestParseRejectsMalformedSignature — sig must decode as base64.
+func TestParseRejectsMalformedSignature(t *testing.T) {
+	raw := "v=omega-v1;exp=1900000000;nodes=a:9090;sig=!!!not-base64!!!"
+	_, err := Parse(raw)
+	if !errors.Is(err, errMalformedSignature) {
+		t.Errorf("want errMalformedSignature, got %v", err)
+	}
+}
+
+// TestParseRejectsEmptyNodes — nodes= with empty value is rejected.
+func TestParseRejectsEmptyNodes(t *testing.T) {
+	raw := "v=omega-v1;exp=1900000000;nodes=;sig=AAAA"
+	_, err := Parse(raw)
+	if !errors.Is(err, errEmptyNodes) {
+		t.Errorf("want errEmptyNodes, got %v", err)
+	}
+}
+
+// TestParseIgnoresUnknownFields — forward-compatible additions that don't
+// bump OmegaVersion are tolerated. Breaking changes bump the version and
+// fail earlier.
+func TestParseIgnoresUnknownFields(t *testing.T) {
+	pub, priv := testKeypair(t)
+	list := validList(time.Now().Add(1 * time.Hour).Unix())
+	list.Sign(priv)
+
+	raw := list.Encode() + ";future_field=whatever"
+	parsed, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("parse with unknown field: %v", err)
+	}
+	if err := parsed.Verify(pub, time.Now()); err != nil {
+		t.Fatalf("verify with unknown field: %v", err)
+	}
+}
+
+// TestVerifyRejectsVersionMismatch — a signed list built for a future
+// omega-v2 is rejected by an omega-v1 binary.
+func TestVerifyRejectsVersionMismatch(t *testing.T) {
+	pub, priv := testKeypair(t)
+	list := validList(time.Now().Add(1 * time.Hour).Unix())
+	list.Version = "omega-v2"
+	list.Sign(priv)
+
+	err := list.Verify(pub, time.Now())
+	if !errors.Is(err, errVersionMismatch) {
+		t.Errorf("want errVersionMismatch, got %v", err)
+	}
+}
+
+// TestVerifyRejectsExpiredList — exp at or before now is invalid.
+func TestVerifyRejectsExpiredList(t *testing.T) {
+	pub, priv := testKeypair(t)
+	expiresAt := time.Now().Add(-1 * time.Second).Unix()
+	list := validList(expiresAt)
+	list.Sign(priv)
+
+	err := list.Verify(pub, time.Now())
+	if !errors.Is(err, errExpiredList) {
+		t.Errorf("want errExpiredList, got %v", err)
+	}
+}
+
+// TestVerifyRejectsTamperedNodes — flipping a node address invalidates the
+// signature. This is the whole point.
+func TestVerifyRejectsTamperedNodes(t *testing.T) {
+	pub, priv := testKeypair(t)
+	list := validList(time.Now().Add(1 * time.Hour).Unix())
+	list.Sign(priv)
+
+	list.Nodes[0] = "attacker.example:9090"
+
+	err := list.Verify(pub, time.Now())
+	if !errors.Is(err, errBadSignature) {
+		t.Errorf("want errBadSignature, got %v", err)
+	}
+}
+
+// TestVerifyRejectsTamperedExpiration — moving exp forward without re-signing
+// is detected.
+func TestVerifyRejectsTamperedExpiration(t *testing.T) {
+	pub, priv := testKeypair(t)
+	list := validList(time.Now().Add(1 * time.Hour).Unix())
+	list.Sign(priv)
+
+	list.Expires += 86400
+
+	err := list.Verify(pub, time.Now())
+	if !errors.Is(err, errBadSignature) {
+		t.Errorf("want errBadSignature, got %v", err)
+	}
+}
+
+// TestVerifyRejectsWrongPubkey — a list signed by key A does not verify
+// under key B.
+func TestVerifyRejectsWrongPubkey(t *testing.T) {
+	_, privA := testKeypair(t)
+	pubB, _ := testKeypair(t)
+
+	list := validList(time.Now().Add(1 * time.Hour).Unix())
+	list.Sign(privA)
+
+	err := list.Verify(pubB, time.Now())
+	if !errors.Is(err, errBadSignature) {
+		t.Errorf("want errBadSignature, got %v", err)
+	}
+}
+
+// TestVerifyRejectsWrongPubkeyLength — guards against a corrupted baked-in
+// value being silently accepted.
+func TestVerifyRejectsWrongPubkeyLength(t *testing.T) {
+	_, priv := testKeypair(t)
+	list := validList(time.Now().Add(1 * time.Hour).Unix())
+	list.Sign(priv)
+
+	err := list.Verify(ed25519.PublicKey{0x00, 0x01}, time.Now())
+	if !errors.Is(err, errInvalidPubkeyLength) {
+		t.Errorf("want errInvalidPubkeyLength, got %v", err)
+	}
+}
+
+// TestDecodedOmegaPubkeyShape — the placeholder parses to the correct length.
+// When the real key is baked in, this test continues to pass as long as the
+// constant remains a valid Ed25519 pubkey.
+func TestDecodedOmegaPubkeyShape(t *testing.T) {
+	pub, err := DecodedOmegaPubkey()
+	if err != nil {
+		t.Fatalf("decode baked-in pubkey: %v", err)
+	}
+	if len(pub) != ed25519.PublicKeySize {
+		t.Errorf("baked-in pubkey length = %d, want %d", len(pub), ed25519.PublicKeySize)
+	}
+}
+
+// TestEncodeRoundTrip — Encode produces the exact canonical form plus a
+// trailing sig field, parseable back.
+func TestEncodeRoundTrip(t *testing.T) {
+	_, priv := testKeypair(t)
+	list := validList(1_900_000_000)
+	list.Sign(priv)
+
+	encoded := list.Encode()
+	// Canonical form is a prefix of the encoded record.
+	if !strings.HasPrefix(encoded, string(list.Canonical())+";sig=") {
+		t.Errorf("encoded form does not start with canonical+sig separator: %s", encoded)
+	}
+
+	parsed, err := Parse(encoded)
+	if err != nil {
+		t.Fatalf("parse encoded: %v", err)
+	}
+	if parsed.Version != list.Version || parsed.Expires != list.Expires {
+		t.Errorf("roundtrip fields differ: got %+v want %+v", parsed, list)
+	}
+}
+

--- a/internal/trust/signedlist_test.go
+++ b/internal/trust/signedlist_test.go
@@ -163,21 +163,21 @@ func TestParseRejectsEmptyNodes(t *testing.T) {
 	}
 }
 
-// TestParseIgnoresUnknownFields — forward-compatible additions that don't
-// bump OmegaVersion are tolerated. Breaking changes bump the version and
-// fail earlier.
-func TestParseIgnoresUnknownFields(t *testing.T) {
-	pub, priv := testKeypair(t)
+// TestParseRejectsUnknownFields — omega-v1 is a strict wire format.
+// Unknown fields are rejected rather than silently dropped, because the
+// signature only covers Canonical() (which includes just the known
+// fields); accepting unknowns would admit unauthenticated data into an
+// authenticated record. Forward-compatible extensions must bump the
+// omega version.
+func TestParseRejectsUnknownFields(t *testing.T) {
+	_, priv := testKeypair(t)
 	list := validList(time.Now().Add(1 * time.Hour).Unix())
 	list.Sign(priv)
 
 	raw := list.Encode() + ";future_field=whatever"
-	parsed, err := Parse(raw)
-	if err != nil {
-		t.Fatalf("parse with unknown field: %v", err)
-	}
-	if err := parsed.Verify(pub, time.Now()); err != nil {
-		t.Fatalf("verify with unknown field: %v", err)
+	_, err := Parse(raw)
+	if !errors.Is(err, errUnknownField) {
+		t.Errorf("want errUnknownField, got %v", err)
 	}
 }
 
@@ -250,6 +250,54 @@ func TestVerifyRejectsWrongPubkey(t *testing.T) {
 	err := list.Verify(pubB, time.Now())
 	if !errors.Is(err, errBadSignature) {
 		t.Errorf("want errBadSignature, got %v", err)
+	}
+}
+
+// TestVerifyRejectsVersionSubstringVariants — exact-match only. "omega-v11"
+// and "omega-v1 " (trailing space) both claim the omega-v1 scheme loosely,
+// but neither is the string the binary recognizes. Rejected.
+func TestVerifyRejectsVersionSubstringVariants(t *testing.T) {
+	pub, priv := testKeypair(t)
+	for _, v := range []string{"omega-v11", "omega-v1 ", " omega-v1", "omega-v10"} {
+		t.Run(v, func(t *testing.T) {
+			list := validList(time.Now().Add(1 * time.Hour).Unix())
+			list.Version = v
+			list.Sign(priv)
+			err := list.Verify(pub, time.Now())
+			if !errors.Is(err, errVersionMismatch) {
+				t.Errorf("want errVersionMismatch, got %v", err)
+			}
+		})
+	}
+}
+
+// TestParseTrimsWhitespaceBetweenNodes — operator-side whitespace in the
+// comma-separated node list is tolerated. The canonical form is still
+// whitespace-free, so signatures remain valid end-to-end.
+func TestParseTrimsWhitespaceBetweenNodes(t *testing.T) {
+	_, priv := testKeypair(t)
+	list := validList(time.Now().Add(1 * time.Hour).Unix())
+	list.Sign(priv)
+
+	// Re-emit with interstitial whitespace in the nodes field. A strict
+	// parser must still produce the same Nodes slice.
+	wireWithSpaces := "v=omega-v1;exp=" +
+		strconv.FormatInt(list.Expires, 10) +
+		";nodes= root-a.example:9090 , root-b.example:9090 , root-c.example:9090 ;sig=" +
+		base64.StdEncoding.EncodeToString(list.Signature)
+
+	parsed, err := Parse(wireWithSpaces)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	want := []string{"root-a.example:9090", "root-b.example:9090", "root-c.example:9090"}
+	if len(parsed.Nodes) != len(want) {
+		t.Fatalf("nodes length = %d, want %d", len(parsed.Nodes), len(want))
+	}
+	for i := range want {
+		if parsed.Nodes[i] != want[i] {
+			t.Errorf("Nodes[%d] = %q, want %q", i, parsed.Nodes[i], want[i])
+		}
 	}
 }
 

--- a/repram-mcp/src/index.ts
+++ b/repram-mcp/src/index.ts
@@ -13,7 +13,11 @@ import { RepramClient, InProcessClient, type RepramClientInterface } from "./cli
 import { HTTPServer, loadConfig, type ServerConfig } from "./node/server.js";
 import { HTTPTransport } from "./node/transport.js";
 import { Logger } from "./node/logger.js";
-import { bootstrapFromPeers, resolveBootstrapDNS } from "./node/bootstrap.js";
+import { bootstrapFromPeers, resolveOmegaBootstrap } from "./node/bootstrap.js";
+import { publicKeyFromBase64, SignedList } from "./node/trust/signed-list.js";
+import { OMEGA_PUBKEY } from "./node/trust/omega.js";
+import { Refresher } from "./node/trust/refresher.js";
+import { defaultCacheDir } from "./node/trust/cache.js";
 import { connectToSubstrate, type WebSocketConnection } from "./node/ws-transport.js";
 
 const isStandalone =
@@ -25,7 +29,8 @@ let embeddedServer: HTTPServer | null = null;
 // ─── Bootstrap ──────────────────────────────────────────────────────
 
 async function bootstrap(server: HTTPServer, config: ServerConfig, logger: Logger): Promise<void> {
-  // Resolve seed peers: REPRAM_PEERS env var, then DNS for public network
+  // Resolve seed peers: REPRAM_PEERS env var first, then the omega signed
+  // root list for the public network. Private networks never consult DNS.
   const seedPeers: string[] = [];
 
   const peersEnv = process.env.REPRAM_PEERS;
@@ -33,14 +38,40 @@ async function bootstrap(server: HTTPServer, config: ServerConfig, logger: Logge
     seedPeers.push(...peersEnv.split(",").map((p) => p.trim()).filter(Boolean));
   }
 
-  // DNS-based bootstrap for public network (when no manual peers)
+  let rootList: SignedList | null = null;
   if (config.network === "public" && seedPeers.length === 0) {
-    const dnsResolved = await resolveBootstrapDNS(
-      "bootstrap.repram.network",
-      9090,
-      logger,
+    rootList = await resolveOmegaBootstrap(logger);
+    seedPeers.push(...rootList.nodes);
+  }
+
+  // Self-recognition + refresh loop. Only public-network deployments with
+  // a verified signed list participate.
+  if (rootList) {
+    const applyRootStatus = (list: SignedList) => {
+      const selfAdvertised = `${config.address}:${config.gossipPort}`;
+      const wasRoot = server.clusterNode.isRoot();
+      const isRoot = list.nodes.includes(selfAdvertised);
+      server.clusterNode.setRoot(isRoot);
+      if (isRoot !== wasRoot) {
+        logger.info(
+          isRoot
+            ? "Root status changed: this node is now a bootstrap root"
+            : "Root status changed: this node is no longer a bootstrap root",
+        );
+      }
+    };
+    applyRootStatus(rootList);
+
+    const refresher = new Refresher(
+      {
+        pubKey: publicKeyFromBase64(OMEGA_PUBKEY),
+        cacheDir: defaultCacheDir(),
+        onUpdate: applyRootStatus,
+        onError: (err) => logger.warn(`Omega refresh: ${err}`),
+      },
+      rootList,
     );
-    seedPeers.push(...dnsResolved);
+    void refresher.run();
   }
 
   if (seedPeers.length === 0) return;

--- a/repram-mcp/src/index.ts
+++ b/repram-mcp/src/index.ts
@@ -17,7 +17,7 @@ import { bootstrapFromPeers, resolveOmegaBootstrap } from "./node/bootstrap.js";
 import { publicKeyFromBase64, SignedList } from "./node/trust/signed-list.js";
 import { OMEGA_PUBKEY } from "./node/trust/omega.js";
 import { Refresher } from "./node/trust/refresher.js";
-import { defaultCacheDir } from "./node/trust/cache.js";
+import { resolveCacheDir } from "./node/trust/cache.js";
 import { connectToSubstrate, type WebSocketConnection } from "./node/ws-transport.js";
 
 const isStandalone =
@@ -42,6 +42,15 @@ async function bootstrap(server: HTTPServer, config: ServerConfig, logger: Logge
   if (config.network === "public" && seedPeers.length === 0) {
     rootList = await resolveOmegaBootstrap(logger);
     seedPeers.push(...rootList.nodes);
+  } else if (config.network === "public" && seedPeers.length > 0) {
+    // REPRAM_PEERS short-circuits omega resolution, which in turn leaves
+    // isRoot() false and causes /v1/bootstrap to 403. Fine for local
+    // testing; wrong for a real public-network root node.
+    logger.warn(
+      "REPRAM_NETWORK=public with REPRAM_PEERS set: skipping omega verification. " +
+        "This node will not be recognized as a bootstrap root and will return 403 " +
+        "for /v1/bootstrap requests.",
+    );
   }
 
   // Self-recognition + refresh loop. Only public-network deployments with
@@ -61,11 +70,26 @@ async function bootstrap(server: HTTPServer, config: ServerConfig, logger: Logge
       }
     };
     applyRootStatus(rootList);
+    const selfAdvertised = `${config.address}:${config.gossipPort}`;
+    if (server.clusterNode.isRoot()) {
+      logger.info(`Initial root status: bootstrap root (advertised as ${selfAdvertised})`);
+    } else {
+      logger.info(
+        `Initial root status: not a root (advertised as ${selfAdvertised}); /v1/bootstrap returns 403`,
+      );
+    }
 
+    const { dir: cacheDir, usedLastResort } = resolveCacheDir();
+    if (usedLastResort) {
+      logger.warn(
+        `Using ${cacheDir} as cache directory; this typically requires root write access. ` +
+          "Set REPRAM_CACHE_DIR for a writable location if refresh writes start failing.",
+      );
+    }
     const refresher = new Refresher(
       {
         pubKey: publicKeyFromBase64(OMEGA_PUBKEY),
-        cacheDir: defaultCacheDir(),
+        cacheDir,
         onUpdate: applyRootStatus,
         onError: (err) => logger.warn(`Omega refresh: ${err}`),
       },

--- a/repram-mcp/src/node/bootstrap.test.ts
+++ b/repram-mcp/src/node/bootstrap.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { resolveBootstrapDNS, bootstrapFromPeers, notifyPeerAboutNewNode } from "./bootstrap.js";
-import type { DnsResolver } from "./bootstrap.js";
+import { bootstrapFromPeers, notifyPeerAboutNewNode } from "./bootstrap.js";
 import { Logger } from "./logger.js";
 import type { NodeInfo } from "./types.js";
 
@@ -23,70 +22,10 @@ function makeLocalNode(overrides: Partial<NodeInfo> = {}): NodeInfo {
   };
 }
 
-// --- DNS resolution ---
-
-describe("resolveBootstrapDNS", () => {
-  it("resolves SRV records", async () => {
-    const resolver: DnsResolver = {
-      resolveSrv: vi.fn().mockResolvedValue([
-        { name: "node1.example.com.", port: 8080 },
-        { name: "node2.example.com.", port: 9090 },
-      ]),
-      resolve4: vi.fn(),
-    };
-
-    const logger = silentLogger();
-    vi.spyOn(logger, "info").mockImplementation(() => {});
-
-    const result = await resolveBootstrapDNS("example.com", 8080, logger, resolver);
-
-    expect(result).toEqual(["node1.example.com:8080", "node2.example.com:9090"]);
-  });
-
-  it("falls back to A records when SRV fails", async () => {
-    const resolver: DnsResolver = {
-      resolveSrv: vi.fn().mockRejectedValue(new Error("ENOTFOUND")),
-      resolve4: vi.fn().mockResolvedValue(["10.0.0.1", "10.0.0.2"]),
-    };
-
-    const logger = silentLogger();
-    vi.spyOn(logger, "info").mockImplementation(() => {});
-
-    const result = await resolveBootstrapDNS("example.com", 8080, logger, resolver);
-
-    expect(result).toEqual(["10.0.0.1:8080", "10.0.0.2:8080"]);
-  });
-
-  it("returns empty array when all DNS fails", async () => {
-    const resolver: DnsResolver = {
-      resolveSrv: vi.fn().mockRejectedValue(new Error("ENOTFOUND")),
-      resolve4: vi.fn().mockRejectedValue(new Error("ENOTFOUND")),
-    };
-
-    const logger = silentLogger();
-    vi.spyOn(logger, "warn").mockImplementation(() => {});
-
-    const result = await resolveBootstrapDNS("bogus.local", 8080, logger, resolver);
-
-    expect(result).toEqual([]);
-    expect(logger.warn).toHaveBeenCalled();
-  });
-
-  it("strips trailing dot from SRV target", async () => {
-    const resolver: DnsResolver = {
-      resolveSrv: vi.fn().mockResolvedValue([
-        { name: "host.example.com.", port: 8080 },
-      ]),
-      resolve4: vi.fn(),
-    };
-
-    const logger = silentLogger();
-    vi.spyOn(logger, "info").mockImplementation(() => {});
-
-    const result = await resolveBootstrapDNS("example.com", 8080, logger, resolver);
-    expect(result[0]).toBe("host.example.com:8080");
-  });
-});
+// Note: the omega-based signed-root-list discovery path
+// (resolveOmegaBootstrap) is exercised under src/node/trust/ — see
+// resolver.test.ts, cache.test.ts, and refresher.test.ts. The legacy
+// unsigned-DNS path was removed as part of REPRAM 2.1.
 
 // --- Bootstrap handshake ---
 

--- a/repram-mcp/src/node/bootstrap.ts
+++ b/repram-mcp/src/node/bootstrap.ts
@@ -1,23 +1,18 @@
 /**
- * Bootstrap — DNS resolution and cluster join handshake.
+ * Bootstrap — signed-root-list resolution and cluster join handshake.
  *
- * Port of internal/gossip/bootstrap.go and resolveBootstrapDNS from cmd/repram/main.go.
+ * Port of internal/gossip/bootstrap.go and cmd/repram/main.go's
+ * resolveOmegaBootstrap. The unsigned SRV/A-based bootstrap was removed
+ * as part of REPRAM 2.1 (see docs/internal/REPRAM-2.1-Spec.md).
  */
 
-import * as dns from "node:dns/promises";
 import { signBody } from "./auth.js";
 import type { Logger } from "./logger.js";
 import type { NodeInfo } from "./types.js";
-
-export interface DnsResolver {
-  resolveSrv(hostname: string): Promise<{ name: string; port: number }[]>;
-  resolve4(hostname: string): Promise<string[]>;
-}
-
-const defaultResolver: DnsResolver = {
-  resolveSrv: (hostname) => dns.resolveSrv(hostname),
-  resolve4: (hostname) => dns.resolve4(hostname),
-};
+import { fetchSigned } from "./trust/resolver.js";
+import { loadCache, saveCache, defaultCacheDir } from "./trust/cache.js";
+import { publicKeyFromBase64, SignedList } from "./trust/signed-list.js";
+import { OMEGA_PUBKEY } from "./trust/omega.js";
 
 // --- Wire format for bootstrap handshake ---
 
@@ -42,37 +37,47 @@ interface WireBootstrapPeer {
   enclave?: string;
 }
 
-// --- DNS resolution ---
+// --- Omega signed-root-list discovery ---
 
-export async function resolveBootstrapDNS(
-  hostname: string,
-  defaultPort: number,
-  logger: Logger,
-  resolver: DnsResolver = defaultResolver,
-): Promise<string[]> {
-  // Try SRV records first
+/**
+ * resolveOmegaBootstrap returns a verified signed root list for the public
+ * network, fetching over DNS with on-disk cache fallback. Rejects when no
+ * valid trust anchor is available — a node that cannot verify must not
+ * join the public network.
+ *
+ * Callers use `result.nodes` as the seed peer list and additionally check
+ * `result` against their own advertised address to determine root status.
+ */
+export async function resolveOmegaBootstrap(logger: Logger): Promise<SignedList> {
+  const pubKey = publicKeyFromBase64(OMEGA_PUBKEY);
+  const cacheDir = defaultCacheDir();
+  const now = new Date();
+
   try {
-    const srvRecords = await resolver.resolveSrv(`_gossip._tcp.${hostname}`);
-    if (srvRecords.length > 0) {
-      const peers = srvRecords.map(
-        (srv) => `${srv.name.replace(/\.$/, "")}:${srv.port}`,
-      );
-      logger.info(`Resolved ${peers.length} bootstrap peers via SRV`);
-      return peers;
+    const list = await fetchSigned({}, pubKey, now);
+    try {
+      await saveCache(cacheDir, list);
+    } catch (err) {
+      logger.warn(`Failed to update omega cache at ${cacheDir}: ${err} (continuing)`);
     }
-  } catch {
-    // SRV lookup failed — fall through to A records
-  }
-
-  // Fall back to A/AAAA records
-  try {
-    const addrs = await resolver.resolve4(hostname);
-    const peers = addrs.map((addr) => `${addr}:${defaultPort}`);
-    logger.info(`Resolved ${peers.length} bootstrap peers via DNS`);
-    return peers;
-  } catch {
-    logger.warn(`DNS bootstrap resolution failed for ${hostname} (starting as first node)`);
-    return [];
+    logger.info(
+      `Omega bootstrap: verified signed root list (${list.nodes.length} nodes, expires ${new Date(list.expires * 1000).toISOString()})`,
+    );
+    return list;
+  } catch (fetchErr) {
+    logger.warn(`Omega DNS fetch failed: ${fetchErr} — trying cached list at ${cacheDir}`);
+    const cached = await loadCache(cacheDir);
+    if (!cached) {
+      throw new Error(`no DNS record and no cache available: ${(fetchErr as Error).message}`);
+    }
+    const verifyErr = cached.verify(pubKey, now);
+    if (verifyErr) {
+      throw new Error(`cached omega list invalid: ${verifyErr.message} (dns: ${(fetchErr as Error).message})`);
+    }
+    logger.info(
+      `Omega bootstrap: using cached signed root list (${cached.nodes.length} nodes, expires ${new Date(cached.expires * 1000).toISOString()})`,
+    );
+    return cached;
   }
 }
 

--- a/repram-mcp/src/node/cluster.ts
+++ b/repram-mcp/src/node/cluster.ts
@@ -62,6 +62,11 @@ export class ClusterNode {
   private logger: Logger;
   private treeManager: TreeManager | null = null;
 
+  // Set to true when this node's advertised address is present in the
+  // currently-trusted omega signed root list. Gates the bootstrap handler.
+  // See docs/internal/REPRAM-2.1-Spec.md.
+  private _isRoot = false;
+
   constructor(options: ClusterNodeOptions, logger: Logger) {
     const enclave = options.enclave || "default";
     this.localNode = {
@@ -96,6 +101,17 @@ export class ClusterNode {
 
   setTreeManager(tree: TreeManager): void {
     this.treeManager = tree;
+  }
+
+  /** Reports whether this node is a bootstrap root per the current signed
+   *  omega list. Checked by HTTPServer.bootstrapHandler. */
+  isRoot(): boolean {
+    return this._isRoot;
+  }
+
+  /** Update root status after a verified refresh of the signed root list. */
+  setRoot(v: boolean): void {
+    this._isRoot = v;
   }
 
   start(): void {

--- a/repram-mcp/src/node/server.bootstrap-gate.test.ts
+++ b/repram-mcp/src/node/server.bootstrap-gate.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import http from "node:http";
+import { HTTPServer, type ServerConfig } from "./server.js";
+import { Logger } from "./logger.js";
+import type { Transport } from "./gossip.js";
+
+function silentLogger(): Logger {
+  return new Logger("error");
+}
+
+function mockTransport(): Transport {
+  return {
+    send: vi.fn().mockResolvedValue(undefined),
+    setMessageHandler: vi.fn(),
+  };
+}
+
+function publicConfig(overrides: Partial<ServerConfig> = {}): ServerConfig {
+  return {
+    httpPort: 0,
+    gossipPort: 9999,
+    address: "localhost",
+    nodeId: "bootstrap-gate-test",
+    network: "public",
+    enclave: "default",
+    replicationFactor: 3,
+    minTTL: 60,
+    maxTTL: 86400,
+    writeTimeoutMs: 200,
+    clusterSecret: "",
+    rateLimit: 1000,
+    trustProxy: false,
+    maxStorageBytes: 0,
+    logLevel: "error",
+    inbound: "false",
+    maxChildren: 100,
+    ...overrides,
+  };
+}
+
+function request(
+  server: HTTPServer,
+  method: string,
+  path: string,
+  body: string,
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const addr = server.getServer().address();
+    if (!addr || typeof addr === "string") return reject(new Error("server not started"));
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port: addr.port,
+        method,
+        path,
+        headers: { "Content-Type": "application/json" },
+      },
+      (res) => {
+        let data = "";
+        res.on("data", (c) => (data += c));
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, body: data }));
+      },
+    );
+    req.on("error", reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+const bootstrapBody = JSON.stringify({
+  node_id: "joiner",
+  address: "x",
+  gossip_port: 9090,
+  http_port: 8080,
+});
+
+describe("bootstrap 403 gate (public network)", () => {
+  let server: HTTPServer;
+
+  beforeEach(async () => {
+    server = new HTTPServer(publicConfig(), silentLogger());
+    server.setTransport(mockTransport());
+    await server.start();
+  });
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  it("rejects with 403 when the node is not a root", async () => {
+    // Default state: isRoot() === false.
+    expect(server.clusterNode.isRoot()).toBe(false);
+    const res = await request(server, "POST", "/v1/bootstrap", bootstrapBody);
+    expect(res.status).toBe(403);
+    expect(JSON.parse(res.body)).toEqual({ error: "not a bootstrap root" });
+  });
+
+  it("answers normally once the node is marked root", async () => {
+    server.clusterNode.setRoot(true);
+    const res = await request(server, "POST", "/v1/bootstrap", bootstrapBody);
+    expect(res.status).toBe(200);
+    const parsed = JSON.parse(res.body);
+    expect(parsed.success).toBe(true);
+  });
+});
+
+describe("bootstrap 403 gate (private network bypass)", () => {
+  let server: HTTPServer;
+
+  beforeEach(async () => {
+    server = new HTTPServer(publicConfig({ network: "private" }), silentLogger());
+    server.setTransport(mockTransport());
+    await server.start();
+  });
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  it("answers bootstrap without a root flag — private networks bypass", async () => {
+    expect(server.clusterNode.isRoot()).toBe(false);
+    const res = await request(server, "POST", "/v1/bootstrap", bootstrapBody);
+    expect(res.status).toBe(200);
+  });
+});

--- a/repram-mcp/src/node/server.ts
+++ b/repram-mcp/src/node/server.ts
@@ -498,6 +498,14 @@ export class HTTPServer {
   }
 
   private bootstrapHandler(req: IncomingMessage, res: ServerResponse): void {
+    // Public-network gate: only signed-root-list members answer bootstrap.
+    // Private networks drive peer discovery via REPRAM_PEERS and bypass
+    // the root concept entirely.
+    if (this.config.network === "public" && !this.clusterNode.isRoot()) {
+      sendJSON(res, 403, { error: "not a bootstrap root" });
+      return;
+    }
+
     readBody(req, (err, body) => {
       if (err) {
         const status = err.message === "Request body too large" ? 413 : 400;

--- a/repram-mcp/src/node/trust/cache.test.ts
+++ b/repram-mcp/src/node/trust/cache.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { generateKeyPairSync } from "node:crypto";
+import { SignedList } from "./signed-list.js";
+import { OMEGA_VERSION } from "./omega.js";
+import { loadCache, saveCache, defaultCacheDir, CACHE_FILE_NAME } from "./cache.js";
+
+async function makeTempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "trust-cache-test-"));
+}
+
+function makeSignedList(): SignedList {
+  const { privateKey } = generateKeyPairSync("ed25519");
+  const list = new SignedList({
+    version: OMEGA_VERSION,
+    expires: Math.floor(Date.now() / 1000) + 3600,
+    nodes: ["a:9090", "b:9090"],
+  });
+  list.sign(privateKey);
+  return list;
+}
+
+describe("saveCache + loadCache", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await makeTempDir();
+  });
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("roundtrips fields and signature", async () => {
+    const list = makeSignedList();
+    await saveCache(dir, list);
+    const loaded = await loadCache(dir);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.version).toBe(list.version);
+    expect(loaded!.expires).toBe(list.expires);
+    expect(loaded!.nodes).toEqual(list.nodes);
+    expect(loaded!.signature!.equals(list.signature!)).toBe(true);
+  });
+
+  it("returns null when the cache file is absent", async () => {
+    const loaded = await loadCache(dir);
+    expect(loaded).toBeNull();
+  });
+
+  it("writes atomically — no leftover temp files after success", async () => {
+    const list = makeSignedList();
+    await saveCache(dir, list);
+    const entries = await fs.readdir(dir);
+    expect(entries).toEqual([CACHE_FILE_NAME]);
+  });
+
+  it("refuses to save a list without a signature", async () => {
+    const list = new SignedList({
+      version: OMEGA_VERSION,
+      expires: 123,
+      nodes: ["a:9090"],
+    });
+    await expect(saveCache(dir, list)).rejects.toThrow(/no signature/);
+  });
+});
+
+describe("defaultCacheDir", () => {
+  it("honors REPRAM_CACHE_DIR", () => {
+    const prev = process.env.REPRAM_CACHE_DIR;
+    process.env.REPRAM_CACHE_DIR = "/tmp/explicit-override";
+    try {
+      expect(defaultCacheDir()).toBe("/tmp/explicit-override");
+    } finally {
+      if (prev === undefined) delete process.env.REPRAM_CACHE_DIR;
+      else process.env.REPRAM_CACHE_DIR = prev;
+    }
+  });
+
+  it("falls back to $HOME/.repram/cache when REPRAM_CACHE_DIR is unset", () => {
+    const prev = process.env.REPRAM_CACHE_DIR;
+    delete process.env.REPRAM_CACHE_DIR;
+    try {
+      const got = defaultCacheDir();
+      expect(got.endsWith(path.join(".repram", "cache"))).toBe(true);
+    } finally {
+      if (prev !== undefined) process.env.REPRAM_CACHE_DIR = prev;
+    }
+  });
+});

--- a/repram-mcp/src/node/trust/cache.ts
+++ b/repram-mcp/src/node/trust/cache.ts
@@ -1,0 +1,88 @@
+/**
+ * On-disk cache for verified signed root lists. Mirrors Go's internal/trust/cache.go
+ * schema so both implementations could in principle share a cache directory.
+ */
+
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { SignedList } from "./signed-list.js";
+
+export const CACHE_FILE_NAME = "root-list.json";
+
+interface CachedList {
+  version: string;
+  expires: number;
+  nodes: string[];
+  signature: string; // base64
+}
+
+/**
+ * Resolve the cache directory with the priority defined in the 2.1 spec:
+ *   REPRAM_CACHE_DIR  >  $HOME/.repram/cache  >  /var/cache/repram
+ */
+export function defaultCacheDir(): string {
+  const explicit = process.env.REPRAM_CACHE_DIR;
+  if (explicit) return explicit;
+  const home = os.homedir();
+  if (home) return path.join(home, ".repram", "cache");
+  return "/var/cache/repram";
+}
+
+/**
+ * loadCache reads the persisted list at `${dir}/root-list.json`. Returns
+ * `null` when the file is absent (normal first-run condition). Throws on
+ * other I/O or parse failures. Callers must still verify the returned list
+ * — an attacker with filesystem write access could swap in another signed
+ * list from the same omega version.
+ */
+export async function loadCache(dir: string): Promise<SignedList | null> {
+  const filePath = path.join(dir, CACHE_FILE_NAME);
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+  const parsed = JSON.parse(raw) as CachedList;
+  return new SignedList({
+    version: parsed.version,
+    expires: parsed.expires,
+    nodes: parsed.nodes,
+    signature: Buffer.from(parsed.signature, "base64"),
+  });
+}
+
+/**
+ * saveCache writes atomically via tempfile+rename so a partial write can
+ * never produce a malformed cache file.
+ */
+export async function saveCache(dir: string, list: SignedList): Promise<void> {
+  await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+
+  if (!list.signature) {
+    throw new Error("saveCache: list has no signature — refusing to persist unsigned data");
+  }
+
+  const payload: CachedList = {
+    version: list.version,
+    expires: list.expires,
+    nodes: list.nodes,
+    signature: list.signature.toString("base64"),
+  };
+
+  const finalPath = path.join(dir, CACHE_FILE_NAME);
+  const tmpPath = path.join(
+    dir,
+    `${CACHE_FILE_NAME}.${process.pid}.${Date.now()}.tmp`,
+  );
+
+  await fs.writeFile(tmpPath, JSON.stringify(payload), { mode: 0o600 });
+  try {
+    await fs.rename(tmpPath, finalPath);
+  } catch (err) {
+    await fs.rm(tmpPath, { force: true });
+    throw err;
+  }
+}

--- a/repram-mcp/src/node/trust/cache.ts
+++ b/repram-mcp/src/node/trust/cache.ts
@@ -20,13 +20,22 @@ interface CachedList {
 /**
  * Resolve the cache directory with the priority defined in the 2.1 spec:
  *   REPRAM_CACHE_DIR  >  $HOME/.repram/cache  >  /var/cache/repram
+ *
+ * Prefer resolveCacheDir(), which additionally reports whether the
+ * last-resort fallback was used; /var/cache/repram typically requires root
+ * write access and non-root containers on that path will produce refresh
+ * log spam.
  */
 export function defaultCacheDir(): string {
+  return resolveCacheDir().dir;
+}
+
+export function resolveCacheDir(): { dir: string; usedLastResort: boolean } {
   const explicit = process.env.REPRAM_CACHE_DIR;
-  if (explicit) return explicit;
+  if (explicit) return { dir: explicit, usedLastResort: false };
   const home = os.homedir();
-  if (home) return path.join(home, ".repram", "cache");
-  return "/var/cache/repram";
+  if (home) return { dir: path.join(home, ".repram", "cache"), usedLastResort: false };
+  return { dir: "/var/cache/repram", usedLastResort: true };
 }
 
 /**

--- a/repram-mcp/src/node/trust/cross-lang.test.ts
+++ b/repram-mcp/src/node/trust/cross-lang.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Cross-language compatibility check: the Go signer (cmd/repram-omega) must
+ * produce TXT-record lines that the TS verifier accepts. This is the
+ * canonical-format guard: if either side changes field order, separators,
+ * or sort rules, this test fails.
+ *
+ * Skipped when the repram-omega binary isn't built yet (e.g. fresh clone
+ * that hasn't run `make build`). CI builds both.
+ */
+
+import { describe, it, expect } from "vitest";
+import { execFileSync, spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { publicKeyFromBase64, parseSignedList, SignedList } from "./signed-list.js";
+
+const omegaBinary = path.resolve(__dirname, "..", "..", "..", "..", "bin", "repram-omega");
+const hasBinary = fs.existsSync(omegaBinary);
+
+describe.skipIf(!hasBinary)("cross-language: Go signer → TS verifier", () => {
+  it("Go-signed list parses and verifies with the TS parser", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "omega-xlang-"));
+    try {
+      const privPath = path.join(tmp, "omega-v1.key");
+      const pubPath = path.join(tmp, "omega-v1.pub");
+
+      execFileSync(omegaBinary, [
+        "keygen",
+        "--out-private",
+        privPath,
+        "--out-public",
+        pubPath,
+      ], { stdio: "pipe" });
+
+      const signResult = spawnSync(omegaBinary, [
+        "sign",
+        "--key",
+        privPath,
+        "--expires-in",
+        "1h",
+        "--nodes",
+        "root-a.example:9090,root-b.example:9090",
+      ]);
+      if (signResult.status !== 0) {
+        throw new Error(`repram-omega sign failed: ${signResult.stderr.toString()}`);
+      }
+      // The signed TXT-record line is the first line of stdout.
+      const txt = signResult.stdout.toString().split(/\r?\n/)[0].trim();
+
+      const pubB64 = fs.readFileSync(pubPath, "utf8").trim();
+      const pubKey = publicKeyFromBase64(pubB64);
+
+      const parsed = parseSignedList(txt);
+      expect(parsed).toBeInstanceOf(SignedList);
+
+      const verifyErr = (parsed as SignedList).verify(pubKey, new Date());
+      expect(verifyErr).toBeNull();
+
+      // Sanity: parsed nodes match what we asked the signer to embed.
+      expect((parsed as SignedList).nodes.sort()).toEqual([
+        "root-a.example:9090",
+        "root-b.example:9090",
+      ]);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/repram-mcp/src/node/trust/omega.ts
+++ b/repram-mcp/src/node/trust/omega.ts
@@ -1,0 +1,20 @@
+/**
+ * Baked-in trust anchor for REPRAM's public network. These constants MUST
+ * match the Go side (internal/trust/omega.go) — they're replaced in lockstep
+ * when the omega key is rotated (Phase 6 / release cutover).
+ *
+ * The omega private key is held offline by the network operator and never
+ * touches a running node. See docs/internal/REPRAM-2.1-Spec.md and
+ * docs/omega-operations.md.
+ */
+
+/** Signing-scheme identifier. Version bumps are breaking changes. */
+export const OMEGA_VERSION = "omega-v1";
+
+/**
+ * PLACEHOLDER base64-encoded Ed25519 public key. The real key is baked in
+ * during the 2.1 release cutover. Tests inject ephemeral keypairs and never
+ * rely on this value.
+ */
+export const OMEGA_PUBKEY =
+  "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";

--- a/repram-mcp/src/node/trust/refresher.test.ts
+++ b/repram-mcp/src/node/trust/refresher.test.ts
@@ -234,17 +234,21 @@ describe("Refresher", () => {
       );
       const runP = r.run();
 
-      // Let the loop register the first wait.
+      // Let the loop register its first scheduled wait.
       await clock.waitForPending();
-      // Fire trigger #1: wakes waitOrTrigger → enters refreshOnce → blocks
-      // on firstFetchGate.
+      // Trigger #1 wakes the current waitOrTrigger — this is the normal
+      // wake-from-wait path, not the behavior under test. After this,
+      // the loop enters refreshOnce and blocks on firstFetchGate.
       r.trigger();
       // Yield so the loop actually proceeds into refreshOnce.
       for (let i = 0; i < 5; i++) await new Promise((res) => setImmediate(res));
-      // Fire trigger #2 while refreshOnce is in-flight. Without the
-      // pendingTrigger buffer this signal is dropped.
+      // Trigger #2 is the critical case: no waitOrTrigger is active
+      // (the loop is mid-refresh), so without the pendingTrigger buffer
+      // this signal is dropped and the next wait proceeds normally.
       r.trigger();
-      // Release the first fetch so refreshOnce completes.
+      // Release the first fetch so refreshOnce completes and the loop
+      // re-enters waitOrTrigger, where pendingTrigger should fire it
+      // immediately into a second refresh.
       resolveFirstFetch();
 
       // If the buffer works, the loop re-enters waitOrTrigger, sees

--- a/repram-mcp/src/node/trust/refresher.test.ts
+++ b/repram-mcp/src/node/trust/refresher.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { generateKeyPairSync } from "node:crypto";
+import { SignedList, publicKeyFromBase64 } from "./signed-list.js";
+import { OMEGA_VERSION } from "./omega.js";
+import { Refresher, type Clock } from "./refresher.js";
+import type { TXTResolver } from "./resolver.js";
+
+function testKeypair() {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const spki = publicKey.export({ format: "der", type: "spki" }) as Buffer;
+  const rawPub = spki.subarray(spki.length - 32);
+  return { pubKey: publicKeyFromBase64(rawPub.toString("base64")), privateKey };
+}
+
+async function makeTempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "trust-refresh-test-"));
+}
+
+// fakeClock drives setTimeout calls from the test. advance() fires all
+// pending callbacks scheduled to fire at or before the advanced time.
+class FakeClock implements Clock {
+  private _now: number;
+  private pending: Array<{ fireAt: number; fn: () => void }> = [];
+
+  constructor(startMs: number) {
+    this._now = startMs;
+  }
+
+  now(): number {
+    return this._now;
+  }
+
+  setTimeout(fn: () => void, ms: number): unknown {
+    const entry = { fireAt: this._now + ms, fn };
+    this.pending.push(entry);
+    return entry;
+  }
+
+  clearTimeout(handle: unknown): void {
+    this.pending = this.pending.filter((p) => p !== handle);
+  }
+
+  advance(ms: number): void {
+    this._now += ms;
+    const ready = this.pending.filter((p) => p.fireAt <= this._now);
+    this.pending = this.pending.filter((p) => p.fireAt > this._now);
+    for (const p of ready) p.fn();
+  }
+
+  /** Wait until there's at least one pending timer — resolves a race
+   *  between the test calling advance() and the refresher registering. */
+  async waitForPending(): Promise<void> {
+    for (let i = 0; i < 50; i++) {
+      if (this.pending.length > 0) return;
+      await new Promise((r) => setImmediate(r));
+    }
+  }
+}
+
+class StubResolver implements TXTResolver {
+  constructor(private records: Record<string, string[][]>, private errors: Record<string, Error> = {}) {}
+  async resolveTxt(name: string): Promise<string[][]> {
+    if (this.errors[name]) throw this.errors[name];
+    return this.records[name] ?? [];
+  }
+}
+
+function makeSignedList(privateKey: Parameters<SignedList["sign"]>[0], expiresSec: number, nodes: string[]): SignedList {
+  const list = new SignedList({ version: OMEGA_VERSION, expires: expiresSec, nodes });
+  list.sign(privateKey);
+  return list;
+}
+
+describe("Refresher", () => {
+  it("invokes onUpdate on scheduled refresh", async () => {
+    const { pubKey, privateKey } = testKeypair();
+    const start = 1_800_000_000_000;
+    const clock = new FakeClock(start);
+    const initial = makeSignedList(privateKey, Math.floor(start / 1000) + 3600, ["a:9090"]);
+    // Refreshed list must remain valid after the clock advance below,
+    // otherwise verify() fails with "expired" and onUpdate never fires.
+    const refreshed = makeSignedList(
+      privateKey,
+      Math.floor(start / 1000) + 86400,
+      ["a:9090", "b:9090"],
+    );
+
+    const resolver = new StubResolver({
+      "_bootstrap.repram.io": [["omega=_omega.repram.io"]],
+      "_omega.repram.io": [[refreshed.encode()]],
+    });
+
+    const dir = await makeTempDir();
+    try {
+      let resolveUpdate!: (l: SignedList) => void;
+      const updatePromise = new Promise<SignedList>((r) => {
+        resolveUpdate = r;
+      });
+      const r = new Refresher(
+        {
+          pubKey,
+          cacheDir: dir,
+          dns: { resolver },
+          onUpdate: resolveUpdate,
+          onError: (err) => {
+            throw err;
+          },
+          clock,
+          random: () => 0.5, // deterministic jitter: zero-centered
+        },
+        initial,
+      );
+
+      const runPromise = r.run();
+      await clock.waitForPending();
+      clock.advance(2 * 3600 * 1000);
+
+      const latest = await updatePromise;
+      expect(latest.nodes.length).toBe(2);
+
+      r.stop();
+      await runPromise;
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("retains current list on refresh failure", async () => {
+    const { pubKey, privateKey } = testKeypair();
+    const start = 1_800_000_000_000;
+    const clock = new FakeClock(start);
+    const initial = makeSignedList(privateKey, Math.floor(start / 1000) + 3600, ["a:9090"]);
+
+    const resolver = new StubResolver({}, {
+      "_bootstrap.repram.io": new Error("dns-down"),
+    });
+
+    const dir = await makeTempDir();
+    try {
+      let resolveError!: (err: unknown) => void;
+      const errorPromise = new Promise<unknown>((r) => {
+        resolveError = r;
+      });
+      const r = new Refresher(
+        {
+          pubKey,
+          cacheDir: dir,
+          dns: { resolver },
+          onUpdate: () => {
+            throw new Error("onUpdate should not fire on failure");
+          },
+          onError: resolveError,
+          clock,
+          random: () => 0.5,
+        },
+        initial,
+      );
+      const runP = r.run();
+
+      await clock.waitForPending();
+      clock.advance(2 * 3600 * 1000);
+
+      const errorSeen = await errorPromise;
+      expect(errorSeen).not.toBeNull();
+      expect(r.currentList.expires).toBe(initial.expires);
+
+      r.stop();
+      await runP;
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("trigger() forces immediate refresh without waiting for schedule", async () => {
+    const { pubKey, privateKey } = testKeypair();
+    const start = 1_800_000_000_000;
+    const clock = new FakeClock(start);
+    const initial = makeSignedList(privateKey, Math.floor(start / 1000) + 86400, ["a:9090"]);
+    const fresh = makeSignedList(privateKey, Math.floor(start / 1000) + 172800, ["a:9090", "b:9090"]);
+
+    const resolver = new StubResolver({
+      "_bootstrap.repram.io": [["omega=_omega.repram.io"]],
+      "_omega.repram.io": [[fresh.encode()]],
+    });
+
+    const dir = await makeTempDir();
+    try {
+      let resolveUpdate!: (l: SignedList) => void;
+      const updatePromise = new Promise<SignedList>((r) => {
+        resolveUpdate = r;
+      });
+      const r = new Refresher(
+        {
+          pubKey,
+          cacheDir: dir,
+          dns: { resolver },
+          onUpdate: resolveUpdate,
+          onError: (err) => {
+            throw err;
+          },
+          clock,
+          random: () => 0.5,
+        },
+        initial,
+      );
+      const runP = r.run();
+      await clock.waitForPending();
+
+      r.trigger();
+
+      const latest = await updatePromise;
+      expect(latest.nodes.length).toBe(2);
+
+      r.stop();
+      await runP;
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/repram-mcp/src/node/trust/refresher.test.ts
+++ b/repram-mcp/src/node/trust/refresher.test.ts
@@ -174,6 +174,94 @@ describe("Refresher", () => {
     }
   });
 
+  it("trigger() fired during an in-flight refresh is captured and pre-empts the next wait", async () => {
+    // Matches Go's buffered triggerCh: signaling during refreshOnce must
+    // not be dropped. Without the pendingTrigger buffer, the second
+    // trigger fires into nothing and the loop sleeps for the full
+    // scheduled delay after the first refresh completes.
+    const { pubKey, privateKey } = testKeypair();
+    const start = 1_800_000_000_000;
+    const clock = new FakeClock(start);
+    const initial = makeSignedList(privateKey, Math.floor(start / 1000) + 86400, ["a:9090"]);
+
+    // Resolver with a resolveTxt that we can gate from the test — lets us
+    // catch the loop mid-refresh and fire a second trigger before the
+    // first refresh completes.
+    let resolveFirstFetch!: () => void;
+    const firstFetchGate = new Promise<void>((r) => {
+      resolveFirstFetch = r;
+    });
+    let callCount = 0;
+    const fresh1 = makeSignedList(privateKey, Math.floor(start / 1000) + 172800, ["a:9090", "b:9090"]);
+    const fresh2 = makeSignedList(privateKey, Math.floor(start / 1000) + 172800, ["a:9090", "b:9090", "c:9090"]);
+
+    const resolver: TXTResolver = {
+      async resolveTxt(name: string): Promise<string[][]> {
+        if (name === "_bootstrap.repram.io") return [["omega=_omega.repram.io"]];
+        callCount++;
+        if (callCount === 1) {
+          await firstFetchGate;
+          return [[fresh1.encode()]];
+        }
+        return [[fresh2.encode()]];
+      },
+    };
+
+    const dir = await makeTempDir();
+    try {
+      const updates: SignedList[] = [];
+      let resolveSecondUpdate!: () => void;
+      const secondUpdatePromise = new Promise<void>((r) => {
+        resolveSecondUpdate = r;
+      });
+
+      const r = new Refresher(
+        {
+          pubKey,
+          cacheDir: dir,
+          dns: { resolver },
+          onUpdate: (l) => {
+            updates.push(l);
+            if (updates.length === 2) resolveSecondUpdate();
+          },
+          onError: (err) => {
+            throw err;
+          },
+          clock,
+          random: () => 0.5,
+        },
+        initial,
+      );
+      const runP = r.run();
+
+      // Let the loop register the first wait.
+      await clock.waitForPending();
+      // Fire trigger #1: wakes waitOrTrigger → enters refreshOnce → blocks
+      // on firstFetchGate.
+      r.trigger();
+      // Yield so the loop actually proceeds into refreshOnce.
+      for (let i = 0; i < 5; i++) await new Promise((res) => setImmediate(res));
+      // Fire trigger #2 while refreshOnce is in-flight. Without the
+      // pendingTrigger buffer this signal is dropped.
+      r.trigger();
+      // Release the first fetch so refreshOnce completes.
+      resolveFirstFetch();
+
+      // If the buffer works, the loop re-enters waitOrTrigger, sees
+      // pendingTrigger=true, and immediately does a second refresh.
+      await secondUpdatePromise;
+      expect(updates.length).toBe(2);
+      // The two updates came from the two distinct fixtures.
+      expect(updates[0].nodes.length).toBe(2);
+      expect(updates[1].nodes.length).toBe(3);
+
+      r.stop();
+      await runP;
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("trigger() forces immediate refresh without waiting for schedule", async () => {
     const { pubKey, privateKey } = testKeypair();
     const start = 1_800_000_000_000;

--- a/repram-mcp/src/node/trust/refresher.ts
+++ b/repram-mcp/src/node/trust/refresher.ts
@@ -57,6 +57,12 @@ export class Refresher {
   private triggerResolve: (() => void) | null = null;
   private triggerPromise: Promise<void> | null = null;
 
+  // Set when trigger() fires while no waitOrTrigger is active (e.g. during
+  // an in-flight refreshOnce). Consumed at the top of the next
+  // waitOrTrigger to make it return immediately. Mirrors the buffered
+  // triggerCh in Go's Refresher so peer-count-drop signals are never lost.
+  private pendingTrigger = false;
+
   constructor(cfg: RefresherConfig, initial: SignedList) {
     this.cfg = cfg;
     this.clock = cfg.clock ?? realClock;
@@ -69,8 +75,12 @@ export class Refresher {
     return this.current;
   }
 
-  /** Request an immediate refresh. Safe to call concurrently. */
+  /** Request an immediate refresh. Safe to call concurrently. If no
+   *  waitOrTrigger is currently active (e.g. trigger fires during an
+   *  in-flight refreshOnce), the signal is buffered and consumed by the
+   *  next waitOrTrigger. */
   trigger(): void {
+    this.pendingTrigger = true;
     const resolve = this.triggerResolve;
     this.resetTrigger();
     if (resolve) resolve();
@@ -144,6 +154,12 @@ export class Refresher {
   }
 
   private waitOrTrigger(ms: number): Promise<"timer" | "trigger"> {
+    // Fast path: a trigger fired while we were busy. Consume it and
+    // return immediately.
+    if (this.pendingTrigger) {
+      this.pendingTrigger = false;
+      return Promise.resolve("trigger");
+    }
     return new Promise((resolve) => {
       const triggerP = this.triggerPromise!;
       this.timerHandle = this.clock.setTimeout(() => {
@@ -151,6 +167,7 @@ export class Refresher {
         resolve("timer");
       }, ms);
       triggerP.then(() => {
+        this.pendingTrigger = false;
         if (this.timerHandle !== null) {
           this.clock.clearTimeout(this.timerHandle);
           this.timerHandle = null;

--- a/repram-mcp/src/node/trust/refresher.ts
+++ b/repram-mcp/src/node/trust/refresher.ts
@@ -1,0 +1,162 @@
+/**
+ * Periodic refresher for the omega signed root list. Mirror of Go's
+ * internal/trust/refresher.go. A Refresher holds the currently-verified list
+ * and re-fetches it at 90% of its remaining lifetime (±10% jitter), invoking
+ * `onUpdate` each time a newly-verified list is adopted.
+ */
+
+import type { KeyObject } from "node:crypto";
+import { fetchSigned, type DnsConfig } from "./resolver.js";
+import { saveCache } from "./cache.js";
+import type { SignedList } from "./signed-list.js";
+
+const REFRESH_ROTATION_FRACTION = 0.9;
+const REFRESH_JITTER = 0.1;
+const REFRESH_BACKOFF_MIN_MS = 30_000;
+const REFRESH_BACKOFF_MAX_MS = 10 * 60_000;
+
+/**
+ * Clock is a minimal abstraction so tests can drive timing deterministically.
+ * The default (real clock) just delegates to setTimeout / Date.now.
+ */
+export interface Clock {
+  now(): number;
+  /** setTimeout-style: returns a handle usable with clearTimeout. */
+  setTimeout(fn: () => void, ms: number): unknown;
+  clearTimeout(handle: unknown): void;
+}
+
+export const realClock: Clock = {
+  now: () => Date.now(),
+  setTimeout: (fn, ms) => setTimeout(fn, ms),
+  clearTimeout: (h) => clearTimeout(h as NodeJS.Timeout),
+};
+
+export interface RefresherConfig {
+  pubKey: KeyObject;
+  cacheDir: string;
+  dns?: DnsConfig;
+  onUpdate: (list: SignedList) => void;
+  onError?: (err: unknown) => void;
+  clock?: Clock;
+  /** For tests: override randomness for deterministic jitter. */
+  random?: () => number;
+}
+
+export class Refresher {
+  private cfg: RefresherConfig;
+  private clock: Clock;
+  private random: () => number;
+  private current: SignedList;
+
+  private stopped = false;
+  private timerHandle: unknown = null;
+
+  // Resolved when Trigger() is called; reset on each use. The run loop
+  // races this against the scheduled delay.
+  private triggerResolve: (() => void) | null = null;
+  private triggerPromise: Promise<void> | null = null;
+
+  constructor(cfg: RefresherConfig, initial: SignedList) {
+    this.cfg = cfg;
+    this.clock = cfg.clock ?? realClock;
+    this.random = cfg.random ?? Math.random;
+    this.current = initial;
+    this.resetTrigger();
+  }
+
+  get currentList(): SignedList {
+    return this.current;
+  }
+
+  /** Request an immediate refresh. Safe to call concurrently. */
+  trigger(): void {
+    const resolve = this.triggerResolve;
+    this.resetTrigger();
+    if (resolve) resolve();
+  }
+
+  private resetTrigger(): void {
+    this.triggerPromise = new Promise((resolve) => {
+      this.triggerResolve = resolve;
+    });
+  }
+
+  /**
+   * run() drives the refresh loop until stop() is called. Fire-and-forget
+   * for callers; they do not need to await it. Errors from refresh failures
+   * go to cfg.onError — the loop itself never rejects.
+   */
+  async run(): Promise<void> {
+    let backoffMs = REFRESH_BACKOFF_MIN_MS;
+    while (!this.stopped) {
+      const delayMs = this.nextDelayMs();
+      const woken = await this.waitOrTrigger(delayMs);
+      if (this.stopped) return;
+      void woken; // whether we woke via timer or trigger is immaterial
+
+      try {
+        await this.refreshOnce();
+        backoffMs = REFRESH_BACKOFF_MIN_MS;
+      } catch (err) {
+        this.cfg.onError?.(err);
+        const retryWait = await this.waitOrTrigger(backoffMs);
+        if (this.stopped) return;
+        void retryWait;
+        backoffMs = Math.min(backoffMs * 2, REFRESH_BACKOFF_MAX_MS);
+      }
+    }
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.timerHandle !== null) {
+      this.clock.clearTimeout(this.timerHandle);
+      this.timerHandle = null;
+    }
+    // Unblock any pending waitOrTrigger so run() can exit promptly.
+    this.trigger();
+  }
+
+  private async refreshOnce(): Promise<void> {
+    const now = new Date(this.clock.now());
+    const list = await fetchSigned(this.cfg.dns ?? {}, this.cfg.pubKey, now);
+    try {
+      await saveCache(this.cfg.cacheDir, list);
+    } catch (err) {
+      // Cache write failure is non-fatal. The verified list is still
+      // valid in memory; surface via onError for operator visibility.
+      this.cfg.onError?.(err);
+    }
+    this.current = list;
+    this.cfg.onUpdate(list);
+  }
+
+  private nextDelayMs(): number {
+    const nowSec = Math.floor(this.clock.now() / 1000);
+    const remainingSec = this.current.expires - nowSec;
+    if (remainingSec <= 0) return 0;
+
+    const target = remainingSec * 1000 * REFRESH_ROTATION_FRACTION;
+    const jitterSpan = target * REFRESH_JITTER * 2;
+    const jittered = target + (this.random() * jitterSpan - jitterSpan / 2);
+    return Math.max(0, Math.floor(jittered));
+  }
+
+  private waitOrTrigger(ms: number): Promise<"timer" | "trigger"> {
+    return new Promise((resolve) => {
+      const triggerP = this.triggerPromise!;
+      this.timerHandle = this.clock.setTimeout(() => {
+        this.timerHandle = null;
+        resolve("timer");
+      }, ms);
+      triggerP.then(() => {
+        if (this.timerHandle !== null) {
+          this.clock.clearTimeout(this.timerHandle);
+          this.timerHandle = null;
+        }
+        resolve("trigger");
+      });
+    });
+  }
+}

--- a/repram-mcp/src/node/trust/resolver.test.ts
+++ b/repram-mcp/src/node/trust/resolver.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { generateKeyPairSync } from "node:crypto";
+import { fetchSigned, type TXTResolver } from "./resolver.js";
+import { publicKeyFromBase64, SignedList, TrustError } from "./signed-list.js";
+import { OMEGA_VERSION } from "./omega.js";
+
+function testKeypair() {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const spki = publicKey.export({ format: "der", type: "spki" }) as Buffer;
+  const rawPub = spki.subarray(spki.length - 32);
+  return { pubKey: publicKeyFromBase64(rawPub.toString("base64")), privateKey };
+}
+
+class StubResolver implements TXTResolver {
+  constructor(
+    private records: Record<string, string[][]>,
+    private errors: Record<string, Error> = {},
+  ) {}
+  async resolveTxt(name: string): Promise<string[][]> {
+    if (this.errors[name]) throw this.errors[name];
+    return this.records[name] ?? [];
+  }
+}
+
+describe("fetchSigned", () => {
+  it("returns a verified list on the happy path", async () => {
+    const { pubKey, privateKey } = testKeypair();
+    const list = new SignedList({
+      version: OMEGA_VERSION,
+      expires: Math.floor(Date.now() / 1000) + 3600,
+      nodes: ["root-a.example:9090", "root-b.example:9090"],
+    });
+    list.sign(privateKey);
+
+    const resolver = new StubResolver({
+      "_bootstrap.repram.io": [["omega=_omega.repram.io"]],
+      "_omega.repram.io": [[list.encode()]],
+    });
+
+    const got = await fetchSigned({ resolver }, pubKey, new Date());
+    expect(got.nodes.length).toBe(2);
+  });
+
+  it("rejects when the bootstrap TXT has no omega= entry", async () => {
+    const { pubKey } = testKeypair();
+    const resolver = new StubResolver({
+      "_bootstrap.repram.io": [["something-else=value"]],
+    });
+    await expect(fetchSigned({ resolver }, pubKey, new Date())).rejects.toThrow(
+      /no omega= entry/,
+    );
+  });
+
+  it("propagates an expired-list verify failure", async () => {
+    const { pubKey, privateKey } = testKeypair();
+    const list = new SignedList({
+      version: OMEGA_VERSION,
+      expires: Math.floor(Date.now() / 1000) - 60,
+      nodes: ["a:9090"],
+    });
+    list.sign(privateKey);
+    const resolver = new StubResolver({
+      "_bootstrap.repram.io": [["omega=_omega.repram.io"]],
+      "_omega.repram.io": [[list.encode()]],
+    });
+    await expect(fetchSigned({ resolver }, pubKey, new Date())).rejects.toThrow(
+      TrustError.Expired,
+    );
+  });
+
+  it("propagates a signature-mismatch verify failure", async () => {
+    const { privateKey } = testKeypair();
+    const { pubKey: attackerPub } = testKeypair();
+    const list = new SignedList({
+      version: OMEGA_VERSION,
+      expires: Math.floor(Date.now() / 1000) + 3600,
+      nodes: ["a:9090"],
+    });
+    list.sign(privateKey);
+    const resolver = new StubResolver({
+      "_bootstrap.repram.io": [["omega=_omega.repram.io"]],
+      "_omega.repram.io": [[list.encode()]],
+    });
+    await expect(fetchSigned({ resolver }, attackerPub, new Date())).rejects.toThrow(
+      TrustError.BadSignature,
+    );
+  });
+
+  it("propagates DNS errors", async () => {
+    const { pubKey } = testKeypair();
+    const resolver = new StubResolver({}, {
+      "_bootstrap.repram.io": new Error("dns-down"),
+    });
+    await expect(fetchSigned({ resolver }, pubKey, new Date())).rejects.toThrow("dns-down");
+  });
+
+  it("joins multi-segment TXT records", async () => {
+    const { pubKey, privateKey } = testKeypair();
+    const list = new SignedList({
+      version: OMEGA_VERSION,
+      expires: Math.floor(Date.now() / 1000) + 3600,
+      nodes: ["a:9090"],
+    });
+    list.sign(privateKey);
+    const full = list.encode();
+    const half = Math.floor(full.length / 2);
+    const resolver = new StubResolver({
+      "_bootstrap.repram.io": [["omega=_omega.repram.io"]],
+      // Simulate resolver splitting at 255-byte boundary.
+      "_omega.repram.io": [[full.slice(0, half), full.slice(half)]],
+    });
+    const got = await fetchSigned({ resolver }, pubKey, new Date());
+    expect(got.nodes).toEqual(["a:9090"]);
+  });
+});

--- a/repram-mcp/src/node/trust/resolver.ts
+++ b/repram-mcp/src/node/trust/resolver.ts
@@ -58,8 +58,12 @@ async function lookupSingleTxt(
   name: string,
 ): Promise<string> {
   const records = await resolver.resolveTxt(name);
-  // Node returns string[][] — each record is an array of segments that the
-  // DNS protocol splits at 255-byte boundaries. Re-join before parsing.
+  // Node returns string[][] — each record is an array of 255-byte
+  // character-strings that the DNS wire format splits a single logical
+  // record into. We must re-join the segments here before parsing.
+  // (The Go parallel in internal/trust/resolver.go does not need to do
+  // this: net.Resolver.LookupTXT concatenates segments internally and
+  // returns []string where each element is already a complete record.)
   for (const record of records) {
     const joined = record.join("").trim();
     if (joined) return joined;

--- a/repram-mcp/src/node/trust/resolver.ts
+++ b/repram-mcp/src/node/trust/resolver.ts
@@ -1,0 +1,82 @@
+/**
+ * DNS-layer resolver for REPRAM 2.1 signed root discovery. Walks
+ * `_bootstrap.repram.io` → `_omega.repram.io` and returns a verified list,
+ * or an Error. Wire-compatible with internal/trust/resolver.go.
+ */
+
+import * as dns from "node:dns/promises";
+import type { KeyObject } from "node:crypto";
+import { parseSignedList, SignedList } from "./signed-list.js";
+
+export const DEFAULT_BOOTSTRAP_NAME = "_bootstrap.repram.io";
+
+/** Minimal TXT-resolver interface. Node's dns.promises satisfies it. */
+export interface TXTResolver {
+  resolveTxt(hostname: string): Promise<string[][]>;
+}
+
+export interface DnsConfig {
+  /** Resolver override; defaults to node:dns/promises. */
+  resolver?: TXTResolver;
+  /** Indirection entry point; defaults to _bootstrap.repram.io. */
+  bootstrapName?: string;
+}
+
+const defaultResolver: TXTResolver = {
+  resolveTxt: (name) => dns.resolveTxt(name),
+};
+
+/**
+ * fetchSigned performs the two-hop TXT lookup and returns a verified list.
+ * Rejects with a single Error on any failure (DNS, parse, verify) — no
+ * partial success states.
+ */
+export async function fetchSigned(
+  cfg: DnsConfig,
+  pubKey: KeyObject,
+  now: Date,
+): Promise<SignedList> {
+  const resolver = cfg.resolver ?? defaultResolver;
+  const bootstrapName = cfg.bootstrapName ?? DEFAULT_BOOTSTRAP_NAME;
+
+  const indirection = await lookupSingleTxt(resolver, bootstrapName);
+  const target = parseBootstrapIndirection(indirection);
+  if (target instanceof Error) throw target;
+
+  const raw = await lookupSingleTxt(resolver, target);
+  const list = parseSignedList(raw);
+  if (list instanceof Error) throw list;
+
+  const verifyErr = list.verify(pubKey, now);
+  if (verifyErr) throw verifyErr;
+
+  return list;
+}
+
+async function lookupSingleTxt(
+  resolver: TXTResolver,
+  name: string,
+): Promise<string> {
+  const records = await resolver.resolveTxt(name);
+  // Node returns string[][] — each record is an array of segments that the
+  // DNS protocol splits at 255-byte boundaries. Re-join before parsing.
+  for (const record of records) {
+    const joined = record.join("").trim();
+    if (joined) return joined;
+  }
+  throw new Error(`trust: TXT lookup for ${name} returned no usable records`);
+}
+
+function parseBootstrapIndirection(raw: string): string | Error {
+  for (const part of raw.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq < 0) continue;
+    const key = part.slice(0, eq).trim();
+    const value = part.slice(eq + 1).trim();
+    if (key === "omega") {
+      if (!value) return new Error("trust: bootstrap TXT record has empty omega= entry");
+      return value;
+    }
+  }
+  return new Error("trust: bootstrap TXT record has no omega= entry");
+}

--- a/repram-mcp/src/node/trust/signed-list.test.ts
+++ b/repram-mcp/src/node/trust/signed-list.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+import { generateKeyPairSync } from "node:crypto";
+import {
+  parseSignedList,
+  publicKeyFromBase64,
+  SignedList,
+  TrustError,
+} from "./signed-list.js";
+import { OMEGA_VERSION } from "./omega.js";
+
+// Ed25519 keypair → (spki pubkey base64, KeyObject priv)
+function testKeypair() {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  // Extract raw 32-byte pubkey from SPKI so we can round-trip through
+  // publicKeyFromBase64 (the production path).
+  const spki = publicKey.export({ format: "der", type: "spki" }) as Buffer;
+  const rawPub = spki.subarray(spki.length - 32);
+  const pubKey = publicKeyFromBase64(rawPub.toString("base64"));
+  return { pubKey, privateKey };
+}
+
+function validList(expires: number): SignedList {
+  return new SignedList({
+    version: OMEGA_VERSION,
+    expires,
+    nodes: ["root-c.example:9090", "root-a.example:9090", "root-b.example:9090"],
+  });
+}
+
+describe("canonical", () => {
+  it("emits fields in fixed order with nodes lex-sorted", () => {
+    const got = validList(1_900_000_000).canonical().toString("utf8");
+    const want =
+      "v=omega-v1;exp=1900000000;nodes=root-a.example:9090,root-b.example:9090,root-c.example:9090";
+    expect(got).toBe(want);
+  });
+
+  it("is stable across input permutations", () => {
+    const a = new SignedList({
+      version: OMEGA_VERSION,
+      expires: 1_900_000_000,
+      nodes: ["b", "a", "c"],
+    });
+    const b = new SignedList({
+      version: OMEGA_VERSION,
+      expires: 1_900_000_000,
+      nodes: ["c", "a", "b"],
+    });
+    expect(a.canonical().equals(b.canonical())).toBe(true);
+  });
+});
+
+describe("sign + verify", () => {
+  it("roundtrips a freshly signed list", () => {
+    const { pubKey, privateKey } = testKeypair();
+    const list = validList(Math.floor(Date.now() / 1000) + 3600);
+    list.sign(privateKey);
+    expect(list.verify(pubKey, new Date())).toBeNull();
+  });
+
+  it("survives encode/parse", () => {
+    const { pubKey, privateKey } = testKeypair();
+    const list = validList(Math.floor(Date.now() / 1000) + 3600);
+    list.sign(privateKey);
+    const parsed = parseSignedList(list.encode());
+    expect(parsed).toBeInstanceOf(SignedList);
+    expect((parsed as SignedList).verify(pubKey, new Date())).toBeNull();
+  });
+
+  it("tolerates field reordering on input", () => {
+    const { pubKey, privateKey } = testKeypair();
+    const list = validList(Math.floor(Date.now() / 1000) + 3600);
+    list.sign(privateKey);
+    const nodes = [...list.nodes].sort().join(",");
+    const raw = `sig=${list.signature!.toString("base64")};nodes=${nodes};exp=${list.expires};v=${OMEGA_VERSION}`;
+    const parsed = parseSignedList(raw);
+    expect(parsed).toBeInstanceOf(SignedList);
+    expect((parsed as SignedList).verify(pubKey, new Date())).toBeNull();
+  });
+
+  it("rejects duplicate fields", () => {
+    const raw = `v=omega-v1;v=omega-v1;exp=1900000000;nodes=a:9090;sig=${"A".repeat(88)}`;
+    const err = parseSignedList(raw);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain(TrustError.DuplicateField);
+  });
+
+  it("rejects missing fields", () => {
+    const cases = [
+      "exp=1900000000;nodes=a:9090;sig=AAAA",
+      "v=omega-v1;nodes=a:9090;sig=AAAA",
+      "v=omega-v1;exp=1900000000;sig=AAAA",
+      "v=omega-v1;exp=1900000000;nodes=a:9090",
+    ];
+    for (const raw of cases) {
+      const err = parseSignedList(raw);
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toContain(TrustError.MissingField);
+    }
+  });
+
+  it("rejects malformed exp", () => {
+    const err = parseSignedList("v=omega-v1;exp=not-a-number;nodes=a:9090;sig=AAAA");
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain(TrustError.MalformedField);
+  });
+
+  it("rejects empty nodes", () => {
+    const err = parseSignedList("v=omega-v1;exp=1900000000;nodes=;sig=AAAA");
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain(TrustError.EmptyNodes);
+  });
+
+  it("rejects version mismatch", () => {
+    const { pubKey, privateKey } = testKeypair();
+    const list = validList(Math.floor(Date.now() / 1000) + 3600);
+    list.version = "omega-v99";
+    list.sign(privateKey);
+    const err = list.verify(pubKey, new Date());
+    expect(err).not.toBeNull();
+    expect(err!.message).toContain(TrustError.VersionMismatch);
+  });
+
+  it("rejects expired list", () => {
+    const { pubKey, privateKey } = testKeypair();
+    const list = validList(Math.floor(Date.now() / 1000) - 1);
+    list.sign(privateKey);
+    const err = list.verify(pubKey, new Date());
+    expect(err).not.toBeNull();
+    expect(err!.message).toContain(TrustError.Expired);
+  });
+
+  it("rejects tampered nodes", () => {
+    const { pubKey, privateKey } = testKeypair();
+    const list = validList(Math.floor(Date.now() / 1000) + 3600);
+    list.sign(privateKey);
+    list.nodes[0] = "attacker.example:9090";
+    const err = list.verify(pubKey, new Date());
+    expect(err).not.toBeNull();
+    expect(err!.message).toContain(TrustError.BadSignature);
+  });
+
+  it("rejects wrong pubkey", () => {
+    const { privateKey } = testKeypair();
+    const other = testKeypair().pubKey;
+    const list = validList(Math.floor(Date.now() / 1000) + 3600);
+    list.sign(privateKey);
+    const err = list.verify(other, new Date());
+    expect(err).not.toBeNull();
+    expect(err!.message).toContain(TrustError.BadSignature);
+  });
+
+  it("rejects invalid pubkey length", () => {
+    expect(() => publicKeyFromBase64("AAAA")).toThrow(/wrong length/);
+  });
+});

--- a/repram-mcp/src/node/trust/signed-list.test.ts
+++ b/repram-mcp/src/node/trust/signed-list.test.ts
@@ -153,4 +153,44 @@ describe("sign + verify", () => {
   it("rejects invalid pubkey length", () => {
     expect(() => publicKeyFromBase64("AAAA")).toThrow(/wrong length/);
   });
+
+  it("rejects unknown fields (strict omega-v1)", () => {
+    const { privateKey } = testKeypair();
+    const list = validList(Math.floor(Date.now() / 1000) + 3600);
+    list.sign(privateKey);
+    const raw = list.encode() + ";future_field=whatever";
+    const err = parseSignedList(raw);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain(TrustError.UnknownField);
+  });
+
+  it.each(["omega-v11", "omega-v1 ", " omega-v1", "omega-v10"])(
+    "rejects version-substring variant %s",
+    (v) => {
+      const { pubKey, privateKey } = testKeypair();
+      const list = validList(Math.floor(Date.now() / 1000) + 3600);
+      list.version = v;
+      list.sign(privateKey);
+      const err = list.verify(pubKey, new Date());
+      expect(err).not.toBeNull();
+      expect(err!.message).toContain(TrustError.VersionMismatch);
+    },
+  );
+
+  it("trims whitespace between nodes and still verifies", () => {
+    const { pubKey, privateKey } = testKeypair();
+    const list = validList(Math.floor(Date.now() / 1000) + 3600);
+    list.sign(privateKey);
+
+    const raw =
+      `v=omega-v1;exp=${list.expires};nodes= root-a.example:9090 , root-b.example:9090 , root-c.example:9090 ;sig=${list.signature!.toString("base64")}`;
+    const parsed = parseSignedList(raw);
+    expect(parsed).toBeInstanceOf(SignedList);
+    expect((parsed as SignedList).nodes).toEqual([
+      "root-a.example:9090",
+      "root-b.example:9090",
+      "root-c.example:9090",
+    ]);
+    expect((parsed as SignedList).verify(pubKey, new Date())).toBeNull();
+  });
 });

--- a/repram-mcp/src/node/trust/signed-list.ts
+++ b/repram-mcp/src/node/trust/signed-list.ts
@@ -26,6 +26,7 @@ export const TrustError = {
   BadSignature: "trust: signed list signature verification failed",
   EmptyNodes: "trust: signed list contains no nodes",
   InvalidPubkey: "trust: omega pubkey has wrong length",
+  UnknownField: "trust: signed list has unknown field",
 } as const;
 
 export interface SignedListFields {
@@ -192,8 +193,13 @@ export function parseSignedList(raw: string): SignedList | Error {
         }
         break;
       }
-      // Unknown fields: ignored; forward-compatible within the same
-      // omega version. Breaking changes bump OMEGA_VERSION.
+      default:
+        // omega-v1 is a strict wire format: unknown fields are rejected.
+        // The signature only covers canonical() — which contains the known
+        // fields — so accepting unknowns would admit unauthenticated data
+        // into an authenticated record. Forward-compatible extensions must
+        // bump OMEGA_VERSION.
+        return new Error(`${TrustError.UnknownField}: ${key}`);
     }
   }
 

--- a/repram-mcp/src/node/trust/signed-list.ts
+++ b/repram-mcp/src/node/trust/signed-list.ts
@@ -132,8 +132,11 @@ const fieldKey = {
 /**
  * parseSignedList deserializes a TXT-record payload. Field order on the
  * wire is tolerated; canonical() re-normalizes for signature verification.
- * Duplicate fields are rejected; unknown fields are ignored so future
- * additions within the same omega version remain forward-compatible.
+ * Duplicate fields are rejected. Unknown fields are rejected too — the
+ * signature only covers canonical() (which contains just the known
+ * fields), so tolerating unknowns would admit unauthenticated data into
+ * an authenticated record. Forward-compatible extensions must bump
+ * OMEGA_VERSION.
  */
 export function parseSignedList(raw: string): SignedList | Error {
   if (!raw) {

--- a/repram-mcp/src/node/trust/signed-list.ts
+++ b/repram-mcp/src/node/trust/signed-list.ts
@@ -1,0 +1,245 @@
+/**
+ * SignedList — parse, canonicalize, and verify REPRAM 2.1 omega-signed root
+ * lists. Mirrors internal/trust/signedlist.go byte-for-byte; both sides must
+ * produce the same canonical form so a single signed record is accepted by
+ * Go and TypeScript nodes alike.
+ */
+
+import { createPublicKey, createPrivateKey, verify as nodeVerify, sign as nodeSign, type KeyObject } from "node:crypto";
+import { OMEGA_VERSION } from "./omega.js";
+
+const FIELD_SEPARATOR = ";";
+const KV_SEPARATOR = "=";
+const NODE_SEPARATOR = ",";
+
+const ED25519_PUBLIC_KEY_LENGTH = 32;
+const ED25519_SIGNATURE_LENGTH = 64;
+
+/** Sentinel errors so callers can branch on failure mode. */
+export const TrustError = {
+  MissingField: "trust: signed list missing required field",
+  DuplicateField: "trust: signed list has duplicate field",
+  MalformedField: "trust: signed list has malformed field",
+  MalformedSignature: "trust: signed list signature is not valid base64",
+  Expired: "trust: signed list has expired",
+  VersionMismatch: "trust: signed list version does not match binary",
+  BadSignature: "trust: signed list signature verification failed",
+  EmptyNodes: "trust: signed list contains no nodes",
+  InvalidPubkey: "trust: omega pubkey has wrong length",
+} as const;
+
+export interface SignedListFields {
+  version: string;
+  expires: number; // Unix seconds
+  nodes: string[];
+  signature?: Buffer;
+}
+
+export class SignedList implements SignedListFields {
+  version: string;
+  expires: number;
+  nodes: string[];
+  signature?: Buffer;
+
+  constructor(fields: SignedListFields) {
+    this.version = fields.version;
+    this.expires = fields.expires;
+    this.nodes = fields.nodes;
+    this.signature = fields.signature;
+  }
+
+  /**
+   * canonical() emits the exact byte sequence that sign() signs and verify()
+   * verifies. Field order is fixed (v;exp;nodes), nodes are lex-sorted, no
+   * whitespace, no signature.
+   */
+  canonical(): Buffer {
+    const sorted = [...this.nodes].sort();
+    const payload =
+      `${fieldKey.version}${KV_SEPARATOR}${this.version}${FIELD_SEPARATOR}` +
+      `${fieldKey.expires}${KV_SEPARATOR}${this.expires}${FIELD_SEPARATOR}` +
+      `${fieldKey.nodes}${KV_SEPARATOR}${sorted.join(NODE_SEPARATOR)}`;
+    return Buffer.from(payload, "utf8");
+  }
+
+  /**
+   * encode() returns the full TXT-record value including a base64-encoded
+   * signature. Intended for the operator signing tool (not published from
+   * this package, but useful for cross-language tests).
+   */
+  encode(): string {
+    if (!this.signature) {
+      throw new Error("SignedList.encode called without a signature — call sign() first");
+    }
+    return (
+      this.canonical().toString("utf8") +
+      FIELD_SEPARATOR +
+      fieldKey.sig +
+      KV_SEPARATOR +
+      this.signature.toString("base64")
+    );
+  }
+
+  /**
+   * sign() computes an Ed25519 signature over canonical() using the
+   * provided private key and stores it on this instance. privKey must be a
+   * Node KeyObject for an Ed25519 key.
+   */
+  sign(privKey: KeyObject): Buffer {
+    const sig = nodeSign(null, this.canonical(), privKey);
+    this.signature = sig;
+    return sig;
+  }
+
+  /**
+   * verify() fails fast on version mismatch, expiration, or signature
+   * mismatch. Callers MUST check the returned error before trusting
+   * this.nodes.
+   *
+   * @param pubKey Ed25519 public key (KeyObject, spki-wrapped).
+   * @param now   Reference time; tests inject deterministic clocks.
+   */
+  verify(pubKey: KeyObject, now: Date): Error | null {
+    if (this.version !== OMEGA_VERSION) {
+      return new Error(`${TrustError.VersionMismatch}: got ${this.version} want ${OMEGA_VERSION}`);
+    }
+    const nowSec = Math.floor(now.getTime() / 1000);
+    if (nowSec >= this.expires) {
+      return new Error(`${TrustError.Expired}: exp=${this.expires} now=${nowSec}`);
+    }
+    if (this.nodes.length === 0) {
+      return new Error(TrustError.EmptyNodes);
+    }
+    if (!this.signature || this.signature.length !== ED25519_SIGNATURE_LENGTH) {
+      return new Error(TrustError.BadSignature);
+    }
+    const ok = nodeVerify(null, this.canonical(), pubKey, this.signature);
+    if (!ok) {
+      return new Error(TrustError.BadSignature);
+    }
+    return null;
+  }
+}
+
+const fieldKey = {
+  version: "v",
+  expires: "exp",
+  nodes: "nodes",
+  sig: "sig",
+} as const;
+
+/**
+ * parseSignedList deserializes a TXT-record payload. Field order on the
+ * wire is tolerated; canonical() re-normalizes for signature verification.
+ * Duplicate fields are rejected; unknown fields are ignored so future
+ * additions within the same omega version remain forward-compatible.
+ */
+export function parseSignedList(raw: string): SignedList | Error {
+  if (!raw) {
+    return new Error(`${TrustError.MalformedField}: empty record`);
+  }
+
+  const seen = new Set<string>();
+  let version: string | undefined;
+  let expires: number | undefined;
+  let nodes: string[] | undefined;
+  let signature: Buffer | undefined;
+
+  for (const part of raw.split(FIELD_SEPARATOR)) {
+    if (!part) continue;
+    const eq = part.indexOf(KV_SEPARATOR);
+    if (eq < 0) {
+      return new Error(`${TrustError.MalformedField}: ${part}`);
+    }
+    const key = part.slice(0, eq).trim();
+    const value = part.slice(eq + 1).trim();
+
+    if (seen.has(key)) {
+      return new Error(`${TrustError.DuplicateField}: ${key}`);
+    }
+    seen.add(key);
+
+    switch (key) {
+      case fieldKey.version:
+        version = value;
+        break;
+      case fieldKey.expires: {
+        const n = parseInt(value, 10);
+        if (!Number.isFinite(n) || String(n) !== value) {
+          return new Error(`${TrustError.MalformedField}: exp=${value}`);
+        }
+        expires = n;
+        break;
+      }
+      case fieldKey.nodes: {
+        if (!value) return new Error(TrustError.EmptyNodes);
+        nodes = value
+          .split(NODE_SEPARATOR)
+          .map((n) => n.trim())
+          .filter((n) => n.length > 0);
+        if (nodes.length === 0) return new Error(TrustError.EmptyNodes);
+        break;
+      }
+      case fieldKey.sig: {
+        if (!/^[A-Za-z0-9+/=]*$/.test(value)) {
+          return new Error(TrustError.MalformedSignature);
+        }
+        signature = Buffer.from(value, "base64");
+        // Node silently tolerates garbage base64 by producing empty buffers
+        // with shorter length; use re-encode roundtrip as a sanity check.
+        if (signature.toString("base64").replace(/=+$/, "") !== value.replace(/=+$/, "")) {
+          return new Error(TrustError.MalformedSignature);
+        }
+        break;
+      }
+      // Unknown fields: ignored; forward-compatible within the same
+      // omega version. Breaking changes bump OMEGA_VERSION.
+    }
+  }
+
+  if (version === undefined) return new Error(`${TrustError.MissingField}: v`);
+  if (expires === undefined) return new Error(`${TrustError.MissingField}: exp`);
+  if (nodes === undefined) return new Error(`${TrustError.MissingField}: nodes`);
+  if (signature === undefined) return new Error(`${TrustError.MissingField}: sig`);
+
+  return new SignedList({ version, expires, nodes, signature });
+}
+
+/**
+ * Decode the baked-in or operator-supplied base64 Ed25519 public key into
+ * a Node KeyObject suitable for verify(). Throws if the key length is wrong.
+ */
+export function publicKeyFromBase64(b64: string): KeyObject {
+  const raw = Buffer.from(b64, "base64");
+  if (raw.length !== ED25519_PUBLIC_KEY_LENGTH) {
+    throw new Error(`${TrustError.InvalidPubkey}: got ${raw.length} want ${ED25519_PUBLIC_KEY_LENGTH}`);
+  }
+  // Node only accepts Ed25519 keys via SPKI-wrapped DER or JWK; construct
+  // the SPKI prefix ourselves so the raw 32-byte key can come from anywhere.
+  const SPKI_PREFIX = Buffer.from([
+    0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
+  ]);
+  const spki = Buffer.concat([SPKI_PREFIX, raw]);
+  return createPublicKey({ key: spki, format: "der", type: "spki" });
+}
+
+/**
+ * Build a Node KeyObject for an Ed25519 private key, given the 64-byte
+ * libsodium-style seed||pubkey concatenation that `repram-omega keygen`
+ * writes out (base64 on disk).
+ */
+export function privateKeyFromBase64(b64: string): KeyObject {
+  const raw = Buffer.from(b64, "base64");
+  // Node's ed25519 private key is 32 bytes of seed; the 64-byte go form is
+  // seed||pubkey. Take the first 32 bytes.
+  if (raw.length !== 64 && raw.length !== 32) {
+    throw new Error(`trust: private key has wrong length: got ${raw.length}`);
+  }
+  const seed = raw.length === 64 ? raw.subarray(0, 32) : raw;
+  const PKCS8_PREFIX = Buffer.from([
+    0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70,
+    0x04, 0x22, 0x04, 0x20,
+  ]);
+  const pkcs8 = Buffer.concat([PKCS8_PREFIX, seed]);
+  return createPrivateKey({ key: pkcs8, format: "der", type: "pkcs8" });
+}


### PR DESCRIPTION
## Summary

Implements REPRAM 2.1 per `docs/internal/REPRAM-2.1-Spec.md`: the public network's unsigned DNS bootstrap is replaced with a signed root list verified against a baked-in Ed25519 "omega" pubkey. Nodes self-recognize as roots by matching their advertised address against the signed list; non-roots return 403 from `/v1/bootstrap`.

Private-network deployments (`REPRAM_NETWORK=private` + `REPRAM_PEERS`) are unchanged.

## Phases (one commit per phase)

- **Phase 1 — #75** `internal/trust` package: SignedList parse/canonical/sign/verify + placeholder omega pubkey. 19 unit tests.
- **Phase 2 — #76** `cmd/repram-omega`: offline `keygen` + `sign` binary. Private key written mode 0600. Operator docs at `docs/omega-operations.md`.
- **Phase 3 — #77** Startup wiring: `resolveOmegaBootstrap` (DNS fetch → verify → cache → fail-closed), self-recognition, and the 403 gate on `/v1/bootstrap`. **Unsigned DNS path removed** — breaking change for anyone depending on the pre-2.1 public bootstrap (no such operator exists yet; public network is not live).
- **Phase 4 — #78** Periodic refresh goroutine: 90% rotation fraction with ±10% jitter, 30s..10m exponential backoff, retains prior list on failure. Race-clean under `-race`.
- **Phase 5 — #79** TS parity in `repram-mcp/src/node/trust/`: full port using Node's native Ed25519 (zero new deps). Cross-language test runs the Go `repram-omega` binary and verifies its output in TS.

## Deferred

- **Phase 6 — #80** (operator cutover — real keygen on air-gapped machine, bake real pubkey into both Go and TS, stand up roots, publish DNS). Out of scope for this PR; tracked separately.

## Design decisions (resolved vs. spec's open questions)

- Unsigned DNS path removed entirely (no dual-path retention).
- Cache dir: `REPRAM_CACHE_DIR` > `\$HOME/.repram/cache` > `/var/cache/repram`.
- Non-root response: **403** with `{\"error\":\"not a bootstrap root\"}`.
- Omega tooling ships as a separate binary (not a subcommand of the node).
- Placeholder pubkey in this PR; real key generated + baked at release time.

## Test plan

- [ ] `make build` succeeds and produces both `bin/repram` and `bin/repram-omega`.
- [ ] `go test ./...` green (all 7 packages).
- [ ] `go test -race ./internal/trust/... ./cmd/repram/...` green.
- [ ] `cd repram-mcp && npm test` green (345 tests across 22 files).
- [ ] Cross-language test (`src/node/trust/cross-lang.test.ts`) verifies a Go-signed TXT line under the TS parser.
- [ ] Manual: `./bin/repram-omega keygen` + `./bin/repram-omega sign` round-trips through `trust.SignedList.Verify`.
- [ ] Review `docs/omega-operations.md` for the operator-facing language.

// ticktockbent