### PR TITLE
fix(burnin): collapse k6 PUT URL cardinality with explicit name param

### DIFF
--- a/test/burnin/workload.js
+++ b/test/burnin/workload.js
@@ -107,12 +107,15 @@ function doPut(node) {
     const key = `bench-agent-${agentId}-${__ITER}`;
     const ttlSec = 300 + Math.floor(Math.random() * (7200 - 300));
     const body = JSON.stringify({ vu: __VU, iter: __ITER, ts: Date.now() });
+    // `name` collapses unique URLs into one metric series; without it k6's
+    // per-URL metric map grows unbounded (#95: OOM at 27 GB after 2.4M URLs).
     const res = http.put(
         `${node}/v1/data/${key}`,
         body,
         {
             headers: { 'Content-Type': 'application/json', 'X-TTL': String(ttlSec) },
             tags: { op: 'put' },
+            name: 'PUT /v1/data/{key}',
         },
     );
     if (res.status === 202) soft202.add(1);


### PR DESCRIPTION
## Summary

- Adds `name: 'PUT /v1/data/{key}'` to the k6 PUT call in `test/burnin/workload.js`
- Two-line comment cites #95 so future readers understand why the seemingly redundant `name` is mandatory
- That's the entire change — three lines including the comment

## Background

During the 2.1 burn-in (2026-04-25 → 2026-04-27), k6 was OOM-killed by the kernel at ~33h after consuming 27 GB of resident memory. Cause: every PUT URL is unique (`bench-agent-X-{iter}`), and k6 keys per-URL metric state by URL when no explicit `name` is set. After 5.97M iterations × 40% PUT rate = ~2.4M unique URLs, k6's metric map exhausted host memory.

Same root cause as the dashboard panel timeout we fixed earlier (5,900 series for one panel-time-window) — just at a process-lifetime scale instead of a panel scale.

Full postmortem in #95.

## Test plan

- [ ] Run a 1h smoke test at 50 ops/sec on a host with k6 installed
- [ ] Confirm k6 RSS stays bounded (target: <500 MB after 1h of PUT load)
- [ ] Confirm Prometheus exposes a single `k6_http_reqs_total{op="put"}` series instead of one per URL
- [ ] Confirm Grafana panel queries on PUT metrics return in <1s instead of timing out

(I don't have k6 installed locally to run the smoke test myself — leaving the verification checklist for whoever has a k6 host handy.)

## Closes
Closes #95
Closes #96

// ticktockbent