### PR TITLE
fix(bootstrap): F1-F4 protocol cleanup, port semantics, contact-all-seeds

### DIFF
--- a/cmd/repram-omega/main.go
+++ b/cmd/repram-omega/main.go
@@ -1,6 +1,6 @@
 // Command repram-omega is the operator tool for REPRAM's signed-root-list
 // trust anchor. It runs offline — never on a REPRAM node. See
-// docs/internal/REPRAM-2.1-Spec.md and docs/omega-operations.md.
+// docs/REPRAM-2.1-Spec.md and docs/omega-operations.md.
 //
 // Subcommands:
 //

--- a/cmd/repram/main.go
+++ b/cmd/repram/main.go
@@ -86,7 +86,7 @@ func main() {
 	}
 
 	// Signed-root-list bootstrap for the public network. See
-	// docs/internal/REPRAM-2.1-Spec.md. This replaces the pre-2.1
+	// docs/REPRAM-2.1-Spec.md. This replaces the pre-2.1
 	// unsigned DNS path; there is no fallback by design.
 	var rootList *trust.SignedList
 	if network == "public" && len(bootstrapNodes) == 0 {
@@ -113,7 +113,7 @@ func main() {
 	// return 403. Private-network deployments are never roots.
 	applyRootStatus := func(list *trust.SignedList) {
 		omegaLastRefreshGauge.SetToCurrentTime()
-		selfAdvertised := fmt.Sprintf("%s:%d", address, gossipPort)
+		selfAdvertised := fmt.Sprintf("%s:%d", address, httpPort)
 		isRoot := false
 		for _, n := range list.Nodes {
 			if n == selfAdvertised {
@@ -133,7 +133,7 @@ func main() {
 	}
 	if rootList != nil {
 		applyRootStatus(rootList)
-		selfAdvertised := fmt.Sprintf("%s:%d", address, gossipPort)
+		selfAdvertised := fmt.Sprintf("%s:%d", address, httpPort)
 		if clusterNode.IsRoot() {
 			logging.Info("Initial root status: bootstrap root (advertised as %s)", selfAdvertised)
 		} else {

--- a/docs/REPRAM-2.1-Spec.md
+++ b/docs/REPRAM-2.1-Spec.md
@@ -113,7 +113,7 @@ On startup, every node operating on the public network (i.e., `REPRAM_NETWORK=pu
 4. **Verify expiration.** If `exp` is in the past, reject. Refetch in case DNS caching served a stale record; if still expired, fail startup with a clear error. An expired signed list indicates the operator has stopped publishing updates or the network is in a compromised state; either way the node should not proceed.
 5. **Verify signature.** Reconstruct the canonical payload, verify the Ed25519 signature against the baked-in `OmegaPubkey`. If verification fails, reject.
 6. **Cache the verified root list** in memory. Persist to disk (e.g., `~/.repram/cache/root-list.json`) so subsequent restarts have a fallback if DNS is unavailable.
-7. **Determine root status.** Compare the node's own advertised address (the `REPRAM_ADDRESS:REPRAM_GOSSIP_PORT` it will present to other nodes) against the verified `nodes` list. If it appears, the node marks itself as a root and will answer bootstrap requests. Otherwise, it operates as a normal node that consumes bootstrap from roots.
+7. **Determine root status.** Compare the node's own advertised address (`REPRAM_ADDRESS:REPRAM_HTTP_PORT` — see the `nodes` field description above for why http_port is the canonical form) against the verified `nodes` list. If it appears, the node marks itself as a root and will answer bootstrap requests. Otherwise, it operates as a normal node that consumes bootstrap from roots.
 8. **Bootstrap normally.** Use the verified root list as the seed peer list for the existing bootstrap handshake. The existing `Bootstrap()` logic in `internal/gossip/bootstrap.go` is unchanged below this point.
 
 ### DNS Failure and Cache Fallback

--- a/docs/REPRAM-2.1-Spec.md
+++ b/docs/REPRAM-2.1-Spec.md
@@ -1,0 +1,270 @@
+# REPRAM 2.1 Spec: Signed Root Discovery and Omega Trust Anchor
+
+## Status
+
+Proposal — targets release 2.1. Scoped to the public network only.
+
+## Scope
+
+This spec addresses a single gap: the public REPRAM network currently discovers bootstrap peers via unsigned DNS lookups, which means a compromised DNS provider, a cache poisoning attack, or a compromised registrar account can redirect every new node onto an attacker-controlled network.
+
+2.1 closes that gap by introducing a signed root list, a baked-in trust anchor (the *omega pubkey*), and self-recognition of root status at startup. It does **not** introduce per-node keypairs, signed topology messages, or trust infrastructure for private enclaves — those are deferred to 2.2 and beyond.
+
+### In scope
+
+- Omega keypair held by the network operator (Clocktower for the public network)
+- Omega pubkey baked into the node binary with a version identifier
+- Signed root list published via DNS TXT records
+- Node startup flow: fetch root list, verify signature, cache, act
+- Root self-recognition: nodes determine their own root status by checking whether their advertised address appears in the signed root list
+- Tooling to generate omega keypairs and sign root lists offline
+
+### Out of scope
+
+- Per-node keypairs and signed gossip messages (2.2)
+- Private enclave trust hierarchies (future, customer-driven)
+- Two-tier rotation signer (one-key model is sufficient at current scale)
+- Changes to the existing `REPRAM_CLUSTER_SECRET` HMAC scheme (private enclaves continue to use it unchanged)
+
+## Problem Statement
+
+Currently, a new REPRAM node consulting `bootstrap.repram.network` via DNS will bootstrap against whatever IPs DNS returns. There is no cryptographic verification that these IPs are authentic roots. An attacker who compromises the DNS record (registrar account takeover, resolver cache poisoning, BGP hijack of the resolver path) can serve any IP list they want, and new nodes will join an attacker-controlled shadow network indistinguishable from the real one.
+
+The existing `REPRAM_CLUSTER_SECRET` mechanism doesn't help here. It authenticates gossip messages *after* a node has joined, but the shadow network has its own (attacker-chosen) cluster secret. A node that bootstraps into the shadow network will accept the shadow network's secret as authoritative.
+
+The fix must be a trust anchor that exists *outside* DNS — something baked into the binary that the attacker cannot forge. From that anchor, the node verifies that DNS-delivered data is authentic before trusting it.
+
+## Design
+
+### Trust Anchor: Omega Pubkey
+
+Every release of the REPRAM binary contains a hardcoded Ed25519 public key — the *omega pubkey* — and a version identifier. These live in a single source file (`internal/trust/omega.go` or similar) and are the only trust root for public network operation.
+
+```go
+// Package trust contains baked-in trust anchors.
+// These values are updated only by shipping a new binary release.
+package trust
+
+const (
+    OmegaVersion = "omega-v1"
+    OmegaPubkey  = "base64-encoded-ed25519-pubkey-here"
+)
+```
+
+The omega *private* key is held offline by the network operator (Clocktower for the public network). It is used only to sign root lists. It is never deployed to any node, never accessible over any network, and ideally lives on an air-gapped signing machine.
+
+### Signed Root List: DNS Format
+
+Two DNS TXT records serve the trust chain:
+
+**`_omega.repram.io` TXT** — Published alongside any operational updates. Content:
+
+```
+v=omega-v1 exp=1735689600 nodes=54.12.34.56:8080,54.12.34.57:8080,54.12.34.58:8080 sig=base64-ed25519-signature
+```
+
+Fields:
+
+- `v` — omega version identifier. Must match the binary's baked-in version or the record is rejected.
+- `exp` — Unix timestamp after which this record is no longer valid. Signed root lists have a defined lifetime; nodes must refuse expired lists and refetch.
+- `nodes` — Comma-separated list of root node addresses (`host:http-port`). These are the nodes that will answer bootstrap requests for the public network. The HTTP port is what `/v1/bootstrap` listens on; the gossip port is an internal cluster detail and is exchanged in the bootstrap handshake itself, not in the signed list.
+- `sig` — Ed25519 signature over the canonical form of the other fields (see "Signature Format" below).
+
+The record is rebuilt and republished on a schedule (hourly or daily, operator's choice) with a fresh `exp` timestamp. If the operator stops publishing, existing signed lists remain valid until their `exp`, then the network is unable to onboard new public nodes until a fresh list is published.
+
+**`_bootstrap.repram.io` TXT** — A simpler redirect record pointing to where the signed root list lives. Content:
+
+```
+omega=_omega.repram.io
+```
+
+This indirection allows future spec versions to move the omega record without changing the baked-in discovery path. Node binaries look up `_bootstrap.repram.io` first, then follow to wherever it points. For 2.1 this indirection is trivial but harmless; it pays off if you ever need to migrate DNS infrastructure.
+
+### Signature Format
+
+The signed payload is the UTF-8 encoding of the record with fields in canonical order, excluding the signature itself:
+
+```
+v=omega-v1;exp=1735689600;nodes=54.12.34.56:8080,54.12.34.57:8080,54.12.34.58:8080
+```
+
+Canonical rules:
+
+- Fields appear in fixed order: `v`, `exp`, `nodes`.
+- Field values are separated from keys by `=` and from each other by `;`.
+- Node addresses within `nodes` are sorted lexicographically before signing.
+- No whitespace is included in the signed payload.
+- **omega-v1 is a strict wire format.** Parsers MUST reject records that
+  contain any field other than `v`, `exp`, `nodes`, `sig`. The signature
+  only covers the canonical payload (which contains just the known fields),
+  so silently tolerating unknown fields would admit unauthenticated data
+  into an otherwise-authenticated record. Forward-compatible extensions
+  must bump `OmegaVersion`.
+
+The signature is Ed25519 over this payload, base64-encoded for transport.
+
+### Node Startup Flow
+
+On startup, every node operating on the public network (i.e., `REPRAM_NETWORK=public`, which is the default) performs:
+
+1. **Consult DNS.** Look up `_bootstrap.repram.io` TXT. Follow the `omega=` redirect to `_omega.repram.io` (or whatever it points to).
+2. **Parse the signed root list.** Extract `v`, `exp`, `nodes`, `sig` fields. Reject if any are missing or malformed.
+3. **Verify version.** If `v` does not match the binary's baked-in `OmegaVersion`, reject. This prevents downgrade attacks and provides clear error messages when a node is running an outdated binary.
+4. **Verify expiration.** If `exp` is in the past, reject. Refetch in case DNS caching served a stale record; if still expired, fail startup with a clear error. An expired signed list indicates the operator has stopped publishing updates or the network is in a compromised state; either way the node should not proceed.
+5. **Verify signature.** Reconstruct the canonical payload, verify the Ed25519 signature against the baked-in `OmegaPubkey`. If verification fails, reject.
+6. **Cache the verified root list** in memory. Persist to disk (e.g., `~/.repram/cache/root-list.json`) so subsequent restarts have a fallback if DNS is unavailable.
+7. **Determine root status.** Compare the node's own advertised address (the `REPRAM_ADDRESS:REPRAM_GOSSIP_PORT` it will present to other nodes) against the verified `nodes` list. If it appears, the node marks itself as a root and will answer bootstrap requests. Otherwise, it operates as a normal node that consumes bootstrap from roots.
+8. **Bootstrap normally.** Use the verified root list as the seed peer list for the existing bootstrap handshake. The existing `Bootstrap()` logic in `internal/gossip/bootstrap.go` is unchanged below this point.
+
+### DNS Failure and Cache Fallback
+
+A node that cannot reach DNS at startup falls back to its on-disk cache, provided the cached record has not yet expired. This keeps nodes running through transient DNS outages and gives the network resilience against short-lived DNS attacks.
+
+If no valid cached record exists and DNS is unreachable, the node fails startup with a clear error. This is a deliberate choice: a node that can't verify its trust anchor should not join the network. Private deployments that want to skip DNS entirely continue to use `REPRAM_NETWORK=private` with manually configured `REPRAM_PEERS`, which bypasses all of this.
+
+### Periodic Refresh
+
+The cached root list has a defined lifetime driven by the `exp` field. Nodes refresh before expiration with modest jitter (to avoid synchronized DNS traffic fingerprinting) and on demand when:
+
+- The current peer list drops below a viable threshold (all known peers unreachable).
+- A bootstrap attempt fails.
+- The cached record's `exp` is within some window of now (e.g., 10% of original lifetime remaining).
+
+Successful refresh replaces the cache atomically. Failed refresh retains the previous cached record and retries with backoff. A node whose cache expires while DNS is unreachable enters a degraded state: it continues serving any peers it still knows about, but cannot onboard new peers until DNS recovers.
+
+### Root Self-Recognition
+
+Root status is a function of the signed root list, not node configuration. A node becomes a root by having its address added to the signed list by the operator; it stops being a root by having its address removed.
+
+This preserves the "every node runs the same binary" invariant. There is no `--root` flag, no `REPRAM_ROOT=true`, nothing in configuration that distinguishes roots. The only difference between a root and a non-root node at runtime is:
+
+- Roots answer `POST /v1/bootstrap` requests from new nodes joining the network.
+- Non-roots return `404` (or `403`, bikeshed candidate) to bootstrap requests, with a message indicating they are not a bootstrap source.
+
+A node recomputes its root status every time it refreshes the signed root list. A node that was a root but was removed from the list stops answering bootstrap requests on the next refresh. A new node added to the list starts answering after it picks up the updated record.
+
+### Interaction with Existing Configuration
+
+| Variable | 2.0 behavior | 2.1 behavior |
+|----------|--------------|--------------|
+| `REPRAM_NETWORK=public` (default) | Uses unsigned DNS bootstrap | Uses signed omega DNS bootstrap |
+| `REPRAM_NETWORK=private` | Uses `REPRAM_PEERS`, skips DNS | Unchanged |
+| `REPRAM_PEERS` | Manual peer list, consulted first | Unchanged; still consulted first. If set, DNS is skipped. |
+| `REPRAM_CLUSTER_SECRET` | HMAC-signs gossip bodies | Unchanged. Orthogonal to omega trust anchor. |
+| `REPRAM_ENCLAVE` | Replication boundary name | Unchanged. Omega signs root lists for the public network as a whole; enclaves within the public network are unaffected. |
+
+Private networks are entirely unaffected by this spec. A deployment with `REPRAM_NETWORK=private` and a manual peer list never consults omega DNS and never verifies any signature introduced by 2.1.
+
+### Protocol Versioning
+
+The omega version identifier (`omega-v1`) is the mechanism for forward-compatible changes. Future specs that change the signed record format bump the version (`omega-v2`). During a transition window, the operator publishes both versions in parallel:
+
+```
+_omega-v1.repram.io   TXT   v=omega-v1 ...
+_omega-v2.repram.io   TXT   v=omega-v2 ...
+```
+
+Nodes running the 2.1 binary look up `_omega.repram.io` (which points to `_omega-v1.repram.io` during the transition). Nodes running a future binary look up the same top-level record but the redirect points to `_omega-v2.repram.io`. Once old binaries are fully deprecated, the old version is retired.
+
+## Tooling
+
+Two CLI tools ship alongside the node binary, built from `cmd/repram-omega/`. These are operator tools — they do not run on nodes.
+
+### `repram-omega keygen`
+
+Generates a new omega keypair. Outputs the public key (for baking into the binary) and the private key (for the operator's offline signing machine).
+
+```
+$ repram-omega keygen --out-private omega-v1.key --out-public omega-v1.pub
+Generated Ed25519 keypair.
+Public key: base64-encoded-pubkey
+Private key written to omega-v1.key (chmod 600)
+
+To use this key:
+  1. Bake the public key into the REPRAM binary at internal/trust/omega.go
+  2. Store omega-v1.key on your offline signing machine
+  3. Never transmit the private key over any network
+```
+
+### `repram-omega sign`
+
+Signs a root list using a private key file, producing a ready-to-paste DNS TXT record value.
+
+```
+$ repram-omega sign \
+    --key omega-v1.key \
+    --version omega-v1 \
+    --expires-in 3600 \
+    --nodes 54.12.34.56:8080,54.12.34.57:8080,54.12.34.58:8080
+
+v=omega-v1;exp=1735693200;nodes=54.12.34.56:8080,54.12.34.57:8080,54.12.34.58:8080;sig=base64-sig
+
+To publish:
+  1. Update the _omega.repram.io TXT record with the value above
+  2. Verify propagation with `dig TXT _omega.repram.io`
+  3. Old record expires at 2025-01-01 00:00:00 UTC
+```
+
+This is a pure function: same inputs produce the same canonical payload and signature. The operator runs this tool on their signing machine, copies the output to their DNS provider's dashboard or API, and the network picks up the change on nodes' next refresh.
+
+DNS automation (calling the registrar's API to push the new record) is deliberately out of scope for this spec. It's straightforward to script around `repram-omega sign` and whatever DNS API the operator uses, but the spec only defines the primitive.
+
+## Implementation Plan
+
+Rough pass at the work, phased so each step is independently shippable and testable.
+
+### Phase 1: Trust primitives
+
+- Add `internal/trust/` package with `OmegaVersion` and `OmegaPubkey` constants (placeholder values until first keygen).
+- Add `internal/trust/signedlist.go` with record parsing, canonicalization, and Ed25519 verification.
+- Unit tests for canonical serialization (order, separators, sorting), signature verification, version checks, expiration checks.
+
+### Phase 2: Omega tooling
+
+- Add `cmd/repram-omega/` with `keygen` and `sign` subcommands.
+- Include in the build and release pipeline.
+- Document operator workflow in `docs/omega-operations.md`.
+
+### Phase 3: Startup integration
+
+- Modify `cmd/repram/main.go`:
+  - Replace `resolveBootstrapDNS()` for public network with new `resolveOmegaBootstrap()` that fetches, verifies, and caches the signed root list.
+  - Retain `resolveBootstrapDNS()` under a deprecated path or remove entirely — open question below.
+  - Add self-recognition: after verification, check if local address is in `nodes`, set `isRoot` flag on the cluster node.
+- Modify bootstrap handler: non-root nodes refuse to answer bootstrap requests.
+- Add disk cache for verified signed lists at `$REPRAM_CACHE_DIR/root-list.json` (default `~/.repram/cache/`).
+
+### Phase 4: Periodic refresh
+
+- Add background goroutine that refreshes the signed list before expiration with jitter.
+- Trigger on-demand refresh when bootstrap fails or peer count drops below threshold.
+- Update root-status flag atomically on each successful refresh.
+
+### Phase 5: Operator deployment
+
+- Generate the first real omega keypair.
+- Bake `omega-v1` pubkey into a 2.1 release candidate.
+- Stand up root nodes, publish first signed root list.
+- Run 2.0 and 2.1 in parallel on testnet to validate.
+- Cut 2.1 release, migrate production roots.
+
+## Testing Strategy
+
+- **Unit tests** on trust primitives: canonical payload construction, signature roundtrip, version mismatch rejection, expiration rejection, malformed record rejection.
+- **Integration tests** with a test omega keypair: full startup flow, verify a node picks up the correct roots, verify non-roots refuse bootstrap, verify roots answer bootstrap.
+- **DNS simulation tests**: mock DNS responses to test cache fallback, expiration handling, refresh scheduling.
+- **Upgrade path test**: 2.0 node and 2.1 node side by side during a transition — verify they can still gossip with each other (they should, since nothing in the wire protocol between peers changes; only the bootstrap discovery path differs).
+
+## Open Questions
+
+**Cache directory default location.** `~/.repram/cache/` feels right for most deployments but is wrong inside Docker containers (where `$HOME` may not be set). The spec should probably default to a configurable `REPRAM_CACHE_DIR` with a Docker-friendly fallback like `/var/cache/repram` or `/tmp/repram`. Needs a decision before implementation.
+
+**Disk cache security.** The cached signed list is public data — anyone can read the published DNS record. No confidentiality concerns. But if an attacker has write access to the cache file, they could replace it with a signed list from an old (compromised) omega version. The version check catches this if the compromised key was retired, but only if the binary has been updated. Worth documenting but probably not worth mitigating beyond "don't let attackers write to your node's filesystem."
+
+**Fate of unsigned DNS bootstrap.** Should the 2.1 binary retain support for the unsigned `bootstrap.repram.network` path as a fallback, or remove it entirely? Retaining it is a security footgun (someone could configure a node to prefer unsigned bootstrap). Removing it is clean but means any operator pointing at an old unsigned-only bootstrap domain has to update config. Recommendation: remove, document as a breaking change in the 2.1 changelog. `REPRAM_NETWORK=private` remains available for anyone who wants to bypass DNS entirely.
+
+**Bootstrap response handling during refresh transitions.** When a node just got removed from the root list but hasn't refreshed yet, it will continue answering bootstrap requests until refresh. Worst case, a new node bootstraps from a "just-retired" root and gets a peer list that's still valid (since the retired root still has valid peers). Probably fine, but worth thinking through the edge cases.
+
+**Record size limits.** DNS TXT records are typically limited to 255 bytes per string, with some resolvers allowing multiple strings concatenated up to ~4KB total. A root list with 10 nodes and signatures should fit comfortably, but if the network grows substantially, the record could need splitting or a different distribution mechanism (e.g., DNS-hosted pointer to an HTTPS endpoint serving the signed list). Not a 2.1 concern but worth noting.
+
+**Self-recognition address matching.** A node compares its own advertised address against the `nodes` list. What if the node is behind NAT and its advertised address is a public IP it can't bind to directly? The mycelial network design already deals with this for MCP nodes via persistent WebSocket connections, but roots should be nodes with stable public addresses — they're infrastructure, not ephemeral. The spec should require roots to have directly-routable public addresses matching what's in the signed list. Document as an operational requirement.

--- a/docs/omega-operations.md
+++ b/docs/omega-operations.md
@@ -1,7 +1,7 @@
 # Omega Operations
 
 Operator guide for REPRAM's signed-root-discovery trust anchor. Context and
-rationale live in `docs/internal/REPRAM-2.1-Spec.md`.
+rationale live in `docs/REPRAM-2.1-Spec.md`.
 
 The omega *public* key is compiled into every node binary. The omega
 *private* key lives on an air-gapped signing machine and is used only to

--- a/internal/gossip/bootstrap.go
+++ b/internal/gossip/bootstrap.go
@@ -26,7 +26,16 @@ type BootstrapResponse struct {
 	Peers   []*Node `json:"peers"`
 }
 
-// Bootstrap connects to seed nodes and retrieves the cluster topology
+// Bootstrap connects to seed nodes and retrieves the cluster topology.
+//
+// Contacts ALL seeds (not just the first responder) so that every seed
+// in the signed list registers the joining node directly. Stopping at
+// the first success leaves later seeds unaware of the joiner until the
+// next topology-sync round, producing asymmetric topologies (#82, F3).
+//
+// Peers from each response are deduplicated by NodeID across all
+// seeds; "Discovered peer X" is logged once per peer regardless of how
+// many seeds returned it (#82, F4).
 func (p *Protocol) Bootstrap(ctx context.Context, seedNodes []string) error {
 	logging.Info("[%s] Starting bootstrap process with %d seed nodes", p.localNode.ID, len(seedNodes))
 
@@ -38,7 +47,9 @@ func (p *Protocol) Bootstrap(ctx context.Context, seedNodes []string) error {
 		Enclave:    p.localNode.Enclave,
 	}
 
-	// Try each seed node until we get a successful response
+	seen := make(map[NodeID]struct{})
+	successfulSeeds := 0
+
 	for _, seed := range seedNodes {
 		logging.Debug("[%s] Attempting to bootstrap from %s", p.localNode.ID, seed)
 
@@ -47,21 +58,28 @@ func (p *Protocol) Bootstrap(ctx context.Context, seedNodes []string) error {
 			logging.Warn("[%s] Failed to bootstrap from %s: %v", p.localNode.ID, seed, err)
 			continue
 		}
+		successfulSeeds++
 
-		// Add all discovered peers
 		for _, peer := range peers {
-			if peer.ID != p.localNode.ID {
-				p.addPeer(peer)
-				logging.Info("[%s] Discovered peer %s via bootstrap", p.localNode.ID, peer.ID)
+			if peer.ID == p.localNode.ID {
+				continue
 			}
+			if _, dup := seen[peer.ID]; dup {
+				continue
+			}
+			seen[peer.ID] = struct{}{}
+			p.addPeer(peer)
+			logging.Info("[%s] Discovered peer %s via bootstrap", p.localNode.ID, peer.ID)
 		}
+	}
 
-		logging.Info("[%s] Bootstrap successful, discovered %d peers", p.localNode.ID, len(peers))
+	if successfulSeeds == 0 {
+		logging.Info("[%s] No seed nodes available, starting as first node", p.localNode.ID)
 		return nil
 	}
 
-	// If no seed nodes responded, we might be the first node
-	logging.Info("[%s] No seed nodes available, starting as first node", p.localNode.ID)
+	logging.Info("[%s] Bootstrap complete: contacted %d/%d seeds, discovered %d unique peers",
+		p.localNode.ID, successfulSeeds, len(seedNodes), len(seen))
 	return nil
 }
 
@@ -127,9 +145,11 @@ func (p *Protocol) HandleBootstrap(req *BootstrapRequest) *BootstrapResponse {
 	// This ensures all nodes know about each other
 	go p.notifyPeersAboutNewNode(newNode)
 
-	// Return current cluster topology
+	// Include self in the peers list — it's how the joiner learns about
+	// this seed. The caller's bootstrap loop dedupes peers by NodeID across
+	// multiple seeds and filters its own ID, so this is safe and necessary
+	// (#82, F4 is addressed on the caller side, not here).
 	peers := p.getPeers()
-	// Include ourselves in the response
 	allPeers := append(peers, p.localNode)
 
 	return &BootstrapResponse{

--- a/internal/gossip/bootstrap_test.go
+++ b/internal/gossip/bootstrap_test.go
@@ -1,0 +1,207 @@
+package gossip
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+)
+
+// TestHandleBootstrap_ResponseIncludesSelf locks in #82: the seed must
+// include its own localNode in the response. That's how a joiner
+// bootstrapping from a single seed learns about the seed itself; if the
+// seed strips it, a single-seed bootstrap discovers no peers at all.
+// Duplicate-discovery (the F4 symptom) is fixed on the caller via dedup,
+// not by stripping self here.
+func TestHandleBootstrap_ResponseIncludesSelf(t *testing.T) {
+	p, _ := newTestProtocol()
+	p.addPeer(&Node{ID: "peer-x", Address: "x", Port: 9090, HTTPPort: 8080, Enclave: "default"})
+
+	resp := p.HandleBootstrap(&BootstrapRequest{
+		NodeID:     "joiner",
+		Address:    "joiner",
+		GossipPort: 9090,
+		HTTPPort:   8080,
+		Enclave:    "default",
+	})
+
+	foundSelf := false
+	for _, peer := range resp.Peers {
+		if peer.ID == p.localNode.ID {
+			foundSelf = true
+		}
+	}
+	if !foundSelf {
+		t.Fatalf("response does not include self; joiner with one seed would never learn about it")
+	}
+	// Response should contain: self + peer-x + joiner (just addPeer'd in HandleBootstrap)
+	if len(resp.Peers) != 3 {
+		t.Fatalf("expected 3 peers (self + peer-x + joiner), got %d: %v", len(resp.Peers), nodeIDs(resp.Peers))
+	}
+}
+
+// TestBootstrap_ContactsAllSeeds locks in #82 (F3): the bootstrap loop
+// must reach every seed even after one succeeds. Otherwise later seeds
+// don't register the joiner until topology sync, producing asymmetric
+// topology.
+func TestBootstrap_ContactsAllSeeds(t *testing.T) {
+	hits := make(map[string]int)
+	makeSeed := func(name string, peerToReport *Node) *httptest.Server {
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hits[name]++
+			resp := BootstrapResponse{Success: true, Peers: []*Node{peerToReport}}
+			_ = json.NewEncoder(w).Encode(resp)
+		}))
+		t.Cleanup(s.Close)
+		return s
+	}
+
+	peerA := &Node{ID: "peer-a", Address: "1.1.1.1", Port: 9090, HTTPPort: 8080, Enclave: "default"}
+	peerB := &Node{ID: "peer-b", Address: "2.2.2.2", Port: 9090, HTTPPort: 8080, Enclave: "default"}
+	peerC := &Node{ID: "peer-c", Address: "3.3.3.3", Port: 9090, HTTPPort: 8080, Enclave: "default"}
+
+	srvA := makeSeed("a", peerA)
+	srvB := makeSeed("b", peerB)
+	srvC := makeSeed("c", peerC)
+
+	p, _ := newTestProtocol()
+	seeds := []string{
+		stripScheme(srvA.URL),
+		stripScheme(srvB.URL),
+		stripScheme(srvC.URL),
+	}
+
+	if err := p.Bootstrap(context.Background(), seeds); err != nil {
+		t.Fatalf("bootstrap failed: %v", err)
+	}
+
+	for _, name := range []string{"a", "b", "c"} {
+		if hits[name] != 1 {
+			t.Fatalf("seed %s hit %d times, want 1 (loop should contact every seed)", name, hits[name])
+		}
+	}
+
+	got := nodeIDs(p.GetPeers())
+	want := []string{"peer-a", "peer-b", "peer-c"}
+	sort.Strings(got)
+	if !equalStringSlices(got, want) {
+		t.Fatalf("peers = %v, want %v", got, want)
+	}
+}
+
+// TestBootstrap_DedupesPeersAcrossSeeds locks in #82 (F4): when multiple
+// seeds report the same peer, addPeer is called once and "Discovered
+// peer X" is logged once.
+func TestBootstrap_DedupesPeersAcrossSeeds(t *testing.T) {
+	shared := &Node{ID: "shared", Address: "9.9.9.9", Port: 9090, HTTPPort: 8080, Enclave: "default"}
+	makeSeed := func() *httptest.Server {
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			resp := BootstrapResponse{Success: true, Peers: []*Node{shared}}
+			_ = json.NewEncoder(w).Encode(resp)
+		}))
+		t.Cleanup(s.Close)
+		return s
+	}
+	srv1 := makeSeed()
+	srv2 := makeSeed()
+	srv3 := makeSeed()
+
+	p, _ := newTestProtocol()
+	if err := p.Bootstrap(context.Background(), []string{
+		stripScheme(srv1.URL),
+		stripScheme(srv2.URL),
+		stripScheme(srv3.URL),
+	}); err != nil {
+		t.Fatalf("bootstrap failed: %v", err)
+	}
+
+	peers := p.GetPeers()
+	if len(peers) != 1 {
+		t.Fatalf("expected 1 deduped peer, got %d", len(peers))
+	}
+	if peers[0].ID != "shared" {
+		t.Fatalf("peer = %s, want shared", peers[0].ID)
+	}
+}
+
+// TestBootstrap_FiltersSelfFromResponse locks in #82 (F4) on the caller
+// side: even if a buggy or older seed includes localNode in its response,
+// the caller must filter it before adding to its peer set.
+func TestBootstrap_FiltersSelfFromResponse(t *testing.T) {
+	p, _ := newTestProtocol()
+	selfMimic := &Node{ID: p.localNode.ID, Address: "evil", Port: 1, HTTPPort: 1, Enclave: "default"}
+	realPeer := &Node{ID: "real", Address: "real", Port: 9090, HTTPPort: 8080, Enclave: "default"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := BootstrapResponse{Success: true, Peers: []*Node{selfMimic, realPeer}}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+
+	if err := p.Bootstrap(context.Background(), []string{stripScheme(srv.URL)}); err != nil {
+		t.Fatalf("bootstrap failed: %v", err)
+	}
+
+	for _, peer := range p.GetPeers() {
+		if peer.ID == p.localNode.ID {
+			t.Fatalf("self leaked into peer set via bootstrap response")
+		}
+	}
+}
+
+// TestBootstrap_ContinuesAfterSeedFailure locks in #82 (F3): if one seed
+// fails (404, timeout, etc.), the remaining seeds are still contacted.
+func TestBootstrap_ContinuesAfterSeedFailure(t *testing.T) {
+	good := &Node{ID: "good", Address: "good", Port: 9090, HTTPPort: 8080, Enclave: "default"}
+	srvBad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "broken seed", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srvBad.Close)
+	srvGood := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := BootstrapResponse{Success: true, Peers: []*Node{good}}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srvGood.Close)
+
+	p, _ := newTestProtocol()
+	if err := p.Bootstrap(context.Background(), []string{
+		stripScheme(srvBad.URL),
+		stripScheme(srvGood.URL),
+	}); err != nil {
+		t.Fatalf("bootstrap should not error when at least one seed succeeds: %v", err)
+	}
+	if peers := p.GetPeers(); len(peers) != 1 || peers[0].ID != "good" {
+		t.Fatalf("expected to discover peer 'good' from the working seed, got %v", nodeIDs(peers))
+	}
+}
+
+// stripScheme converts httptest's "http://127.0.0.1:port" to "127.0.0.1:port"
+// so the result matches what the omega signed-list parser produces.
+func stripScheme(url string) string {
+	const prefix = "http://"
+	if len(url) >= len(prefix) && url[:len(prefix)] == prefix {
+		return url[len(prefix):]
+	}
+	return url
+}
+
+func nodeIDs(nodes []*Node) []string {
+	ids := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		ids = append(ids, string(n.ID))
+	}
+	return ids
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/gossip/bootstrap_test.go
+++ b/internal/gossip/bootstrap_test.go
@@ -36,10 +36,6 @@ func TestHandleBootstrap_ResponseIncludesSelf(t *testing.T) {
 	if !foundSelf {
 		t.Fatalf("response does not include self; joiner with one seed would never learn about it")
 	}
-	// Response should contain: self + peer-x + joiner (just addPeer'd in HandleBootstrap)
-	if len(resp.Peers) != 3 {
-		t.Fatalf("expected 3 peers (self + peer-x + joiner), got %d: %v", len(resp.Peers), nodeIDs(resp.Peers))
-	}
 }
 
 // TestBootstrap_ContactsAllSeeds locks in #82 (F3): the bootstrap loop

--- a/internal/trust/omega.go
+++ b/internal/trust/omega.go
@@ -3,7 +3,7 @@
 // OmegaPubkey is the root of trust for DNS-delivered bootstrap data. The
 // corresponding private key is held offline by the network operator and is
 // used only to sign root lists published via DNS TXT records (see
-// docs/internal/REPRAM-2.1-Spec.md). The private key is never deployed to any
+// docs/REPRAM-2.1-Spec.md). The private key is never deployed to any
 // node and never transmitted over any network.
 //
 // OmegaVersion identifies the signing scheme. Future spec revisions that

--- a/internal/trust/signedlist.go
+++ b/internal/trust/signedlist.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-// Spec field names and separators. See docs/internal/REPRAM-2.1-Spec.md
+// Spec field names and separators. See docs/REPRAM-2.1-Spec.md
 // "Signed Root List: DNS Format" and "Signature Format".
 const (
 	fieldVersion = "v"

--- a/repram-mcp/src/index.ts
+++ b/repram-mcp/src/index.ts
@@ -59,7 +59,7 @@ async function bootstrap(server: HTTPServer, config: ServerConfig, logger: Logge
   if (rootList) {
     const applyRootStatus = (list: SignedList) => {
       setOmegaLastRefreshNow();
-      const selfAdvertised = `${config.address}:${config.gossipPort}`;
+      const selfAdvertised = `${config.address}:${config.httpPort}`;
       const wasRoot = server.clusterNode.isRoot();
       const isRoot = list.nodes.includes(selfAdvertised);
       server.clusterNode.setRoot(isRoot);
@@ -72,7 +72,7 @@ async function bootstrap(server: HTTPServer, config: ServerConfig, logger: Logge
       }
     };
     applyRootStatus(rootList);
-    const selfAdvertised = `${config.address}:${config.gossipPort}`;
+    const selfAdvertised = `${config.address}:${config.httpPort}`;
     if (server.clusterNode.isRoot()) {
       logger.info(`Initial root status: bootstrap root (advertised as ${selfAdvertised})`);
     } else {

--- a/repram-mcp/src/node/bootstrap.test.ts
+++ b/repram-mcp/src/node/bootstrap.test.ts
@@ -84,7 +84,7 @@ describe("bootstrapFromPeers", () => {
     expect(peers[0].id).toBe("other-node");
   });
 
-  it("tries next seed on failure", async () => {
+  it("continues to next seed on failure", async () => {
     const fetchMock = vi.fn()
       .mockRejectedValueOnce(new Error("connection refused"))
       .mockResolvedValueOnce({
@@ -109,6 +109,64 @@ describe("bootstrapFromPeers", () => {
 
     expect(peers).toHaveLength(1);
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  // #82 (F3): the old loop returned after the first successful seed,
+  // leaving later seeds unaware of the joiner until topology sync. The
+  // fixed loop contacts every seed.
+  it("contacts every seed even after the first succeeds", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        peers: [{ id: "shared", address: "10.0.0.9", port: 9090, http_port: 8080 }],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const logger = silentLogger();
+    vi.spyOn(logger, "info").mockImplementation(() => {});
+
+    await bootstrapFromPeers(
+      ["seed-a:8080", "seed-b:8080", "seed-c:8080"],
+      makeLocalNode(),
+      "",
+      logger,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const urls = fetchMock.mock.calls.map((c) => c[0]);
+    expect(urls).toContain("http://seed-a:8080/v1/bootstrap");
+    expect(urls).toContain("http://seed-b:8080/v1/bootstrap");
+    expect(urls).toContain("http://seed-c:8080/v1/bootstrap");
+  });
+
+  // #82 (F4): when multiple seeds report the same peer, the caller
+  // returns it once. (The seed legitimately includes its own localNode in
+  // the response — that's how a single-seed bootstrap learns about the
+  // seed at all — so dedup runs on the caller side.)
+  it("dedupes peers reported by multiple seeds", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        peers: [{ id: "shared", address: "10.0.0.9", port: 9090, http_port: 8080 }],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const logger = silentLogger();
+    vi.spyOn(logger, "info").mockImplementation(() => {});
+
+    const peers = await bootstrapFromPeers(
+      ["seed-a:8080", "seed-b:8080", "seed-c:8080"],
+      makeLocalNode(),
+      "",
+      logger,
+    );
+
+    expect(peers).toHaveLength(1);
+    expect(peers[0].id).toBe("shared");
   });
 
   it("returns empty array when all seeds fail", async () => {

--- a/repram-mcp/src/node/bootstrap.ts
+++ b/repram-mcp/src/node/bootstrap.ts
@@ -3,7 +3,7 @@
  *
  * Port of internal/gossip/bootstrap.go and cmd/repram/main.go's
  * resolveOmegaBootstrap. The unsigned SRV/A-based bootstrap was removed
- * as part of REPRAM 2.1 (see docs/internal/REPRAM-2.1-Spec.md).
+ * as part of REPRAM 2.1 (see docs/REPRAM-2.1-Spec.md).
  */
 
 import { signBody } from "./auth.js";
@@ -83,6 +83,14 @@ export async function resolveOmegaBootstrap(logger: Logger): Promise<SignedList>
 
 // --- Bootstrap handshake ---
 
+/**
+ * Contacts ALL seed nodes (not just the first responder) so every seed
+ * registers the joining node directly. Stopping at the first success
+ * leaves later seeds unaware of the joiner until topology sync, producing
+ * asymmetric topologies (#82, F3). Peers from each response are
+ * deduplicated by node ID across all seeds; self is always filtered out
+ * (#82, F4).
+ */
 export async function bootstrapFromPeers(
   seedPeers: string[],
   localNode: NodeInfo,
@@ -101,21 +109,34 @@ export async function bootstrapFromPeers(
     request.enclave = localNode.enclave;
   }
 
-  // Try each seed until one succeeds
+  const seen = new Map<string, NodeInfo>();
+  let successfulSeeds = 0;
+
   for (const seed of seedPeers) {
     try {
       const peers = await sendBootstrapRequest(seed, request, clusterSecret, logger);
-      // Filter out self
-      const discovered = peers.filter((p) => p.id !== localNode.id);
-      logger.info(`Bootstrap successful, discovered ${discovered.length} peers from ${seed}`);
-      return discovered;
+      successfulSeeds++;
+      for (const peer of peers) {
+        if (peer.id === localNode.id) continue;
+        if (seen.has(peer.id)) continue;
+        seen.set(peer.id, peer);
+      }
     } catch (err) {
       logger.warn(`Failed to bootstrap from ${seed}: ${err}`);
     }
   }
 
-  logger.info("No seed nodes available, starting as first node");
-  return [];
+  if (successfulSeeds === 0) {
+    logger.info("No seed nodes available, starting as first node");
+    return [];
+  }
+
+  const discovered = Array.from(seen.values());
+  logger.info(
+    `Bootstrap complete: contacted ${successfulSeeds}/${seedPeers.length} seeds, ` +
+      `discovered ${discovered.length} unique peers`,
+  );
+  return discovered;
 }
 
 async function sendBootstrapRequest(

--- a/repram-mcp/src/node/cluster.ts
+++ b/repram-mcp/src/node/cluster.ts
@@ -64,7 +64,7 @@ export class ClusterNode {
 
   // Set to true when this node's advertised address is present in the
   // currently-trusted omega signed root list. Gates the bootstrap handler.
-  // See docs/internal/REPRAM-2.1-Spec.md.
+  // See docs/REPRAM-2.1-Spec.md.
   private _isRoot = false;
 
   constructor(options: ClusterNodeOptions, logger: Logger) {

--- a/repram-mcp/src/node/server.ts
+++ b/repram-mcp/src/node/server.ts
@@ -549,7 +549,11 @@ export class HTTPServer {
       this.clusterNode.gossip.addPeer(newPeer);
       this.logger.info(`[${this.config.nodeId}] Node ${newPeer.id} joined via bootstrap`);
 
-      // Return current topology (all peers + ourselves)
+      // Include self in the peers list — it's how the joiner learns
+      // about this seed. The caller's bootstrap loop dedupes peers by
+      // node ID across multiple seeds and filters its own ID, so duplicate
+      // "Discovered peer" entries are addressed on the caller side
+      // (#82, F4), not by stripping self here.
       const peers = this.clusterNode.gossip.getPeers();
       const allPeers = [...peers, this.clusterNode.localNode];
 

--- a/repram-mcp/src/node/trust/omega.ts
+++ b/repram-mcp/src/node/trust/omega.ts
@@ -4,7 +4,7 @@
  * when the omega key is rotated (Phase 6 / release cutover).
  *
  * The omega private key is held offline by the network operator and never
- * touches a running node. See docs/internal/REPRAM-2.1-Spec.md and
+ * touches a running node. See docs/REPRAM-2.1-Spec.md and
  * docs/omega-operations.md.
  */
 


### PR DESCRIPTION
## Summary

Resolves the four bootstrap-handler defects discovered during the REPRAM 2.1 burn-in. Closes #82 (which absorbed the old #83/#84 after combination A).

## What changed

### F1/F2 — Port semantics
- Spec now pins the omega signed-list address as `host:http_port` (was ambiguous; the burn-in workaround papered over it by setting both ports equal).
- `selfAdvertised` uses `httpPort` in both Go (`cmd/repram/main.go`) and TS (`repram-mcp/src/index.ts`).
- `docs/REPRAM-2.1-Spec.md`: examples and field description updated.

**Audit:** I traced `peer.GossipPort`/`peer.HTTPPort` usage downstream of `addPeer` in both impls. No port-swap bug being masked. The HTTP transport at `internal/gossip/http_transport.go:95` and the TS reattachment at `repram-mcp/src/node/tree.ts:374` both route via HTTP port. The gossip-port field is exchanged in the handshake and stored, but only used in `Node.String()` for log formatting — never for routing.

### F3 — Contact every seed
Old loop returned on first success, leaving later seeds unaware of the joiner until the next topology-sync round. Fixed loop iterates every seed sequentially, accumulates peers across responses.

### F4 — Caller-side dedup
When multiple seeds reported the same peer, the joiner used to `addPeer` and log "Discovered peer X" once per seed. Now dedups by NodeID. Self-filter explicit at the caller.

**Initial design correction during the work:** the issue body recommended also stripping self from the seed's response. That broke `TestWriteReplicationToThreeNodes` — a joiner bootstrapping from a single seed ended up with zero peers because the seed's own localNode was no longer in the response. The seed legitimately includes self in the response (it's how the joiner learns about the seed); caller-side dedup handles all duplication symptoms without breaking that. Backed out the server-side strip, kept caller-side dedup. Documented in commit message.

### Spec doc promotion
Moved `docs/internal/REPRAM-2.1-Spec.md` → `docs/REPRAM-2.1-Spec.md`. The spec was kept internal during iteration; user signed off on promoting it now that it's stable. Updated the 7 source-comment references and `docs/omega-operations.md`.

## Tests

**Go (`internal/gossip/bootstrap_test.go` — new):**
- `TestHandleBootstrap_ResponseIncludesSelf` — seed must include self
- `TestBootstrap_ContactsAllSeeds` — F3 lock-in
- `TestBootstrap_DedupesPeersAcrossSeeds` — F4 lock-in
- `TestBootstrap_FiltersSelfFromResponse` — F4 caller-side
- `TestBootstrap_ContinuesAfterSeedFailure` — F3 partial-failure

**TS (`repram-mcp/src/node/bootstrap.test.ts` — extended):**
- `contacts every seed even after the first succeeds` — F3
- `dedupes peers reported by multiple seeds` — F4
- Existing 9 tests still pass

**Suite results:**
- Go: all packages green
- TS: 354/354 (was 352, +2 new)

## Test plan
- [ ] CI green (build + Go test + TS vitest)
- [ ] Verify spec doc renders correctly on the new path
- [ ] Visual review of the 5 new Go tests for any over-specified expectations

## Closes
Closes #82

// ticktockbent