### PR TITLE
docs(omega): F8 dnsmasq SIGHUP operator note + post-#100 port consistency

### DIFF
--- a/docs/omega-operations.md
+++ b/docs/omega-operations.md
@@ -61,8 +61,12 @@ REPRAM node.
      --key omega-v1.key \
      --version omega-v1 \
      --expires-in 24h \
-     --nodes root-a.example:9090,root-b.example:9090,root-c.example:9090
+     --nodes root-a.example:8080,root-b.example:8080,root-c.example:8080
    ```
+
+   The `--nodes` addresses are `host:http-port` form, not gossip-port —
+   `/v1/bootstrap` listens on the HTTP port. See the `nodes` field
+   description in `docs/REPRAM-2.1-Spec.md` for rationale.
 
 2. The command prints the full TXT-record value on stdout and the
    publication checklist on stderr. Transfer only the stdout line (it is
@@ -85,10 +89,38 @@ REPRAM node.
 5. Nodes pick up the new record on their next refresh cycle (before the
    previous record's `exp`). There is no need to restart nodes.
 
+## Publishing via dnsmasq (operator footgun)
+
+If your DNS provider is dnsmasq with `txt-record=` lines in a config
+file, **`SIGHUP` does not reload TXT records.** Per `man 8 dnsmasq`,
+`SIGHUP` re-loads `/etc/hosts`, `/etc/ethers`, and the various
+`--*-hostsfile`/`--addn-hosts`/`--hostsdir` paths — but it does not
+re-read the main config or `conf-dir` entries, including `txt-record`
+lines. The signal is accepted without error and the old TXT record
+keeps serving silently.
+
+Workarounds (pick one):
+
+- `sudo systemctl restart dnsmasq` after rewriting the config. Fast
+  (sub-second on most systems). The publish loop needs passwordless
+  sudo on the `restart` verb only — not full sudo — so configure
+  `/etc/sudoers.d/dnsmasq-publish` with the narrowest possible rule.
+- Move the TXT record into a file referenced via `--addn-hosts` or
+  similar, and use `SIGHUP` only on those paths. Workable but adds
+  indirection; the `restart` approach is simpler.
+- Switch off dnsmasq entirely. Any nameserver that exposes a proper API
+  (nsupdate, BIND control, cloud DNS provider APIs) avoids this class
+  of issue.
+
+The burn-in's `test/burnin/sign-loop.sh` uses the systemctl-restart
+approach; it documents the passwordless-sudo requirement in the script
+header and is a working reference if you're rolling your own publishing
+loop.
+
 ## Changing the root node set
 
 Run `sign` with the new `--nodes` list, publish the new TXT record. A node
-whose advertised `REPRAM_ADDRESS:REPRAM_GOSSIP_PORT` is removed from the
+whose advertised `REPRAM_ADDRESS:REPRAM_HTTP_PORT` is removed from the
 list stops answering `/v1/bootstrap` requests within one refresh cycle; a
 newly-added node starts answering on the same schedule.
 


### PR DESCRIPTION
## Summary

Closes #88. Two changes, both in `docs/omega-operations.md`:

### F8 — dnsmasq SIGHUP gotcha

New "Publishing via dnsmasq" section documents that `SIGHUP` does not reload `txt-record` entries — only `/etc/hosts` and the various `--*-hostsfile`/`--addn-hosts` paths get reloaded. The signal is accepted without error and the old record keeps serving silently. Workarounds enumerated (systemctl restart with narrowed passwordless sudo, `--addn-hosts` indirection, a non-dnsmasq nameserver) and cross-references `test/burnin/sign-loop.sh` as a working example of the restart approach.

This bit operators silently during the 2.1 burn-in: `sign-loop.sh` originally used `pkill -HUP dnsmasq` and rotation appeared to work — until we noticed nodes weren't picking up new lists.

### Post-#100 sweep (port consistency)

Two stale `REPRAM_GOSSIP_PORT` references in this doc that the F1/F2 fix should have updated but missed:
- The `repram-omega sign` example (`--nodes root-a.example:9090,...`) — now `:8080` with a brief note pointing to the spec's field description.
- The "Changing the root node set" prose: `REPRAM_ADDRESS:REPRAM_GOSSIP_PORT` → `REPRAM_HTTP_PORT`.

Same flavor of leftover the PR-#100 reviewer caught in the spec doc; this finishes the sweep across operator-facing docs.

## F9 status

F9 (spec port pinning) was the spec-side half of #88 per combination B. That edit shipped in #100 (the bootstrap-protocol PR) per the Q6 decision to land spec changes alongside their code. So #88's remaining work was just F8 + the doc-side port-consistency cleanup, which is what this PR contains.

## Test plan
- [ ] Visual review of the new "Publishing via dnsmasq" section
- [ ] Confirm port references are now consistently `http-port` across `docs/` (spec + omega-operations)

## Closes
Closes #88

// ticktockbent