### PR TITLE
fix(gossip): F7 self-rejection chokepoint in addPeer + bootstrap caller skip

### DIFF
--- a/internal/gossip/bootstrap.go
+++ b/internal/gossip/bootstrap.go
@@ -148,7 +148,10 @@ func (p *Protocol) HandleBootstrap(req *BootstrapRequest) *BootstrapResponse {
 		Enclave:  enclave,
 	}
 
-	// Add the new node as a peer
+	// Add the new node as a peer. addPeer is a no-op when newNode.ID
+	// matches our own (e.g., a node bootstrapping against an omega list
+	// that contains itself); the chokepoint warns and the self-skip in
+	// Bootstrap normally prevents that path from being reached at all (#87).
 	p.addPeer(newNode)
 	logging.Info("[%s] Node %s joined via bootstrap", p.localNode.ID, req.NodeID)
 

--- a/internal/gossip/bootstrap.go
+++ b/internal/gossip/bootstrap.go
@@ -47,10 +47,21 @@ func (p *Protocol) Bootstrap(ctx context.Context, seedNodes []string) error {
 		Enclave:    p.localNode.Enclave,
 	}
 
+	// The omega signed list contains every root, so a root bootstrapping
+	// against the list will see its own advertised address in seedNodes.
+	// Skip self-bootstrap: it succeeds (we'd be POSTing to our own listener)
+	// but pollutes our peer map with self until #87's addPeer self-filter
+	// rejects it. Skipping here also avoids a wasted round-trip.
+	selfAdvertised := fmt.Sprintf("%s:%d", p.localNode.Address, p.localNode.HTTPPort)
+
 	seen := make(map[NodeID]struct{})
 	successfulSeeds := 0
 
 	for _, seed := range seedNodes {
+		if seed == selfAdvertised {
+			logging.Debug("[%s] Skipping self in seed list (%s)", p.localNode.ID, seed)
+			continue
+		}
 		logging.Debug("[%s] Attempting to bootstrap from %s", p.localNode.ID, seed)
 
 		peers, err := p.sendBootstrapRequest(ctx, seed, req)

--- a/internal/gossip/bootstrap_test.go
+++ b/internal/gossip/bootstrap_test.go
@@ -3,6 +3,7 @@ package gossip
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -169,6 +170,102 @@ func TestBootstrap_ContinuesAfterSeedFailure(t *testing.T) {
 	}
 	if peers := p.GetPeers(); len(peers) != 1 || peers[0].ID != "good" {
 		t.Fatalf("expected to discover peer 'good' from the working seed, got %v", nodeIDs(peers))
+	}
+}
+
+// TestAddPeer_RejectsSelf locks in #87 (F7): addPeer must refuse to add
+// the local node and return false. This is the single chokepoint that
+// keeps self out of every iterator that touches p.peers.
+func TestAddPeer_RejectsSelf(t *testing.T) {
+	p, _ := newTestProtocol()
+
+	added := p.addPeer(p.localNode)
+	if added {
+		t.Fatalf("addPeer(localNode) returned true; expected false (self should be rejected)")
+	}
+	if peers := p.GetPeers(); len(peers) != 0 {
+		t.Fatalf("expected 0 peers after self-add attempt, got %d: %v", len(peers), nodeIDs(peers))
+	}
+}
+
+// TestAddPeer_AcceptsOthers verifies the rejection is specific to self
+// and does not regress the normal addPeer path.
+func TestAddPeer_AcceptsOthers(t *testing.T) {
+	p, _ := newTestProtocol()
+	other := &Node{ID: "other", Address: "10.0.0.1", Port: 9090, HTTPPort: 8080, Enclave: "default"}
+
+	added := p.addPeer(other)
+	if !added {
+		t.Fatalf("addPeer(other) returned false; expected true")
+	}
+	if peers := p.GetPeers(); len(peers) != 1 || peers[0].ID != "other" {
+		t.Fatalf("expected [other], got %v", nodeIDs(peers))
+	}
+}
+
+// TestBootstrap_SkipsSelfInSeedList locks in #87 option C: when the seed
+// list contains the bootstrapping node's own advertised address (which is
+// always true for omega-listed roots), the loop must skip it rather than
+// POST a self-bootstrap. The httptest server here would record the hit if
+// the loop didn't skip.
+func TestBootstrap_SkipsSelfInSeedList(t *testing.T) {
+	otherHits := 0
+	srvOther := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		otherHits++
+		resp := BootstrapResponse{Success: true, Peers: []*Node{
+			{ID: "other", Address: "10.0.0.2", Port: 9090, HTTPPort: 8080, Enclave: "default"},
+		}}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srvOther.Close)
+
+	p, _ := newTestProtocol()
+	// Self-advertised address per #82 spec: address:HTTPPort
+	selfAdvertised := fmt.Sprintf("%s:%d", p.localNode.Address, p.localNode.HTTPPort)
+
+	if err := p.Bootstrap(context.Background(), []string{
+		selfAdvertised,             // would self-bootstrap if not skipped
+		stripScheme(srvOther.URL),  // real seed
+	}); err != nil {
+		t.Fatalf("bootstrap failed: %v", err)
+	}
+
+	if otherHits != 1 {
+		t.Fatalf("real seed hit %d times; expected 1", otherHits)
+	}
+	got := nodeIDs(p.GetPeers())
+	if len(got) != 1 || got[0] != "other" {
+		t.Fatalf("peers = %v, want [other]", got)
+	}
+}
+
+// TestSelfBootstrapResponseDoesNotPolluteMap reproduces the F7 burn-in
+// scenario in isolation: a seed sends back a response that includes the
+// joiner's own ID (because the seed addPeer'd it then included it in the
+// response). Even with the option-C skip in place, this defends against
+// a non-omega seed list where self might still slip through, or any other
+// path where a seed legitimately echoes the joiner's ID. addPeer's
+// self-filter must catch it.
+func TestSelfBootstrapResponseDoesNotPolluteMap(t *testing.T) {
+	p, _ := newTestProtocol()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Buggy / hostile seed includes the joiner's own ID in its response
+		resp := BootstrapResponse{Success: true, Peers: []*Node{
+			{ID: p.localNode.ID, Address: "evil", Port: 1, HTTPPort: 1, Enclave: "default"},
+			{ID: "real", Address: "real", Port: 9090, HTTPPort: 8080, Enclave: "default"},
+		}}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+
+	if err := p.Bootstrap(context.Background(), []string{stripScheme(srv.URL)}); err != nil {
+		t.Fatalf("bootstrap failed: %v", err)
+	}
+
+	for _, peer := range p.GetPeers() {
+		if peer.ID == p.localNode.ID {
+			t.Fatalf("self leaked into peer set despite caller-side filter and addPeer self-filter")
+		}
 	}
 }
 

--- a/internal/gossip/protocol.go
+++ b/internal/gossip/protocol.go
@@ -195,7 +195,22 @@ func (p *Protocol) Stop() error {
 	return nil
 }
 
-func (p *Protocol) addPeer(node *Node) {
+// addPeer adds node to the peer set or rejects and warns if node is self.
+// Returns true if the node was added or updated, false if rejected.
+//
+// The self-rejection is the single chokepoint that keeps self out of the
+// peer map across all entry points (handleSync, HandleBootstrap,
+// performTopologySync, etc.). Callers that previously assumed
+// "addPeer always succeeds" are still correct for non-self inputs;
+// the warn log surfaces any caller path that ends up trying to add self,
+// which is always a bug (#82, #87).
+func (p *Protocol) addPeer(node *Node) bool {
+	if node.ID == p.localNode.ID {
+		logging.Warn("[%s] addPeer rejected: attempted to add self (%s) — caller likely missing a self-filter",
+			p.localNode.ID, node.ID)
+		return false
+	}
+
 	p.peersMutex.Lock()
 	p.peers[node.ID] = node
 	delete(p.peerFailures, node.ID) // reset failure counter on (re-)add
@@ -206,6 +221,7 @@ func (p *Protocol) addPeer(node *Node) {
 		p.metrics.peersActive.Set(float64(peerCount))
 		p.metrics.peerJoins.Inc()
 	}
+	return true
 }
 
 func (p *Protocol) removePeer(nodeID NodeID) {

--- a/repram-mcp/src/node/bootstrap.test.ts
+++ b/repram-mcp/src/node/bootstrap.test.ts
@@ -141,6 +141,36 @@ describe("bootstrapFromPeers", () => {
     expect(urls).toContain("http://seed-c:8080/v1/bootstrap");
   });
 
+  // #87 (F7): when the seed list contains the bootstrapping node's own
+  // advertised address (always true for omega-listed roots), the loop
+  // must skip it — otherwise the node POSTs a bootstrap to itself and
+  // pollutes its peer map with self.
+  it("skips self in the seed list", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        peers: [{ id: "other", address: "10.0.0.2", port: 9090, http_port: 8080 }],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const logger = silentLogger();
+    vi.spyOn(logger, "info").mockImplementation(() => {});
+    vi.spyOn(logger, "debug").mockImplementation(() => {});
+
+    const local = makeLocalNode({ address: "10.0.0.1", httpPort: 8080 });
+    await bootstrapFromPeers(
+      ["10.0.0.1:8080", "real-seed:8080"],
+      local,
+      "",
+      logger,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe("http://real-seed:8080/v1/bootstrap");
+  });
+
   // #82 (F4): when multiple seeds report the same peer, the caller
   // returns it once. (The seed legitimately includes its own localNode in
   // the response — that's how a single-seed bootstrap learns about the

--- a/repram-mcp/src/node/bootstrap.ts
+++ b/repram-mcp/src/node/bootstrap.ts
@@ -109,10 +109,21 @@ export async function bootstrapFromPeers(
     request.enclave = localNode.enclave;
   }
 
+  // The omega signed list contains every root, so a root bootstrapping
+  // against the list will see its own advertised address in seedPeers.
+  // Skip self-bootstrap: it would succeed (we'd be POSTing to our own
+  // listener) but pollute the peer map with self until addPeer's self-filter
+  // rejects it (#82, #87). Skipping here also avoids a wasted round-trip.
+  const selfAdvertised = `${localNode.address}:${localNode.httpPort}`;
+
   const seen = new Map<string, NodeInfo>();
   let successfulSeeds = 0;
 
   for (const seed of seedPeers) {
+    if (seed === selfAdvertised) {
+      logger.debug(`Skipping self in seed list (${seed})`);
+      continue;
+    }
     try {
       const peers = await sendBootstrapRequest(seed, request, clusterSecret, logger);
       successfulSeeds++;

--- a/repram-mcp/src/node/gossip.test.ts
+++ b/repram-mcp/src/node/gossip.test.ts
@@ -193,6 +193,32 @@ describe("GossipProtocol peer management", () => {
     proto.removePeer("peer-1");
     expect(metrics.onPeersActive).toHaveBeenCalledWith(0);
   });
+
+  // #87 (F7): addPeer must reject the local node and return false. This
+  // is the single chokepoint that keeps self out of every iterator that
+  // touches this.peers (broadcast, ping, topology sync, etc.).
+  it("rejects self and returns false", () => {
+    const local = makeNode({ id: "test-node" });
+    const proto = new GossipProtocol(local, 3, silentLogger());
+    const metrics = mockMetrics();
+    proto.enableMetrics(metrics);
+
+    const added = proto.addPeer(local);
+
+    expect(added).toBe(false);
+    expect(proto.getPeers()).toHaveLength(0);
+    expect(metrics.onPeersActive).not.toHaveBeenCalled();
+    expect(metrics.onPeerJoin).not.toHaveBeenCalled();
+  });
+
+  it("returns true when adding a non-self peer", () => {
+    const proto = new GossipProtocol(makeNode({ id: "test-node" }), 3, silentLogger());
+
+    const added = proto.addPeer(makeNode({ id: "other" }));
+
+    expect(added).toBe(true);
+    expect(proto.getPeers()).toHaveLength(1);
+  });
 });
 
 // --- Message routing ---

--- a/repram-mcp/src/node/gossip.ts
+++ b/repram-mcp/src/node/gossip.ts
@@ -150,11 +150,27 @@ export class GossipProtocol {
 
   // --- Peer management ---
 
-  addPeer(node: NodeInfo): void {
+  /**
+   * Adds node to the peer set, or rejects and warns if node is self.
+   * Returns true if the node was added or updated, false if rejected.
+   *
+   * Self-rejection is the single chokepoint that keeps self out of the
+   * peer map across all entry points (handleSync, bootstrapHandler,
+   * performTopologySync, etc.). The warn log surfaces any caller path
+   * that ends up trying to add self, which is always a bug (#82, #87).
+   */
+  addPeer(node: NodeInfo): boolean {
+    if (node.id === this.localNode.id) {
+      this.logger.warn(
+        `[${this.localNode.id}] addPeer rejected: attempted to add self (${node.id}) — caller likely missing a self-filter`,
+      );
+      return false;
+    }
     this.peers.set(node.id, node);
     this.peerFailures.delete(node.id); // reset failure counter on (re-)add
     this.metricsCallbacks?.onPeersActive(this.peers.size);
     this.metricsCallbacks?.onPeerJoin();
+    return true;
   }
 
   removePeer(nodeId: string): void {

--- a/repram-mcp/src/node/server.ts
+++ b/repram-mcp/src/node/server.ts
@@ -545,7 +545,11 @@ export class HTTPServer {
         enclave,
       };
 
-      // Add the new node as a peer
+      // Add the new node as a peer. addPeer is a no-op when newPeer.id
+      // matches our own (e.g., a node bootstrapping against an omega list
+      // that contains itself); the chokepoint warns and the self-skip in
+      // bootstrapFromPeers normally prevents that path from being reached
+      // at all (#87).
       this.clusterNode.gossip.addPeer(newPeer);
       this.logger.info(`[${this.config.nodeId}] Node ${newPeer.id} joined via bootstrap`);
 


### PR DESCRIPTION
## Summary

Closes #87. Fixes a defect that surfaced on the TS node during the 2.1 burn-in but is latent in Go too. When a root node bootstraps against the omega signed list, the list contains its own advertised address, so the loop POSTs a bootstrap to itself. The seed-side handler (`HandleBootstrap` in Go, `bootstrapHandler` in TS) calls `addPeer(joiner)` unconditionally — and when `joiner.id == localNode.id`, self lands in the peer map.

The TS node was the only burn-in node that triggered this because lex sort put it first in its own seed list. Go nodes happened to have other nodes ahead of self, so they never self-bootstrapped. **Same root cause, different observable behavior.**

## Approach (A + C, both impls)

**A — single-chokepoint self-filter in `addPeer`.** Returns `bool` now (true = added/updated, false = rejected); warn-logs every self-add attempt. Once self can never enter the peer map, every downstream iterator (broadcast, ping, `getReplicationPeers`, `performTopologySync`, `/v1/topology`, `respondWithPeerList`, etc.) is correct by construction.

The boolean return + warn-log was a design suggestion: surface the bug-smell every time, let callers react if they need to. None of the four current call sites care about the return today, but future ones can.

**C — skip self in the bootstrap caller seed loop.** Pure efficiency: no point POSTing a bootstrap to ourselves. Built `selfAdvertised` from `address:HTTPPort` (matches the post-#82 spec) and skip seeds that match.

## Audit found a third instance — possibly upstream of #85

While auditing every peer-iteration site for self-handling assumptions, I found that `performTopologySync` (Go `protocol.go:680`, TS `gossip.ts:521`) uses `len(p.peers)` as a count with the explicit comment "Don't count ourselves." With F7 active, the count overstated by 1, the threshold was met sooner, and **topology sync may have been silently skipped**. That's exactly the symptom of #85 (F5: "topology sync doesn't refresh peers after eviction"). Recommend revalidating #85 after this lands — it may be partially closed.

Other sites surveyed and found correct or self-protected:
- `handleSync` — explicit self-check
- `selectRandomPeers` — accepts skipID parameter
- ACK routing — filters by `msg.From`
- `respondWithPeerList` and `bootstrapHandler` — use `[...peers, localNode]` pattern, which is now safe by construction since self can't be in `peers`

## Tests

**Go (`internal/gossip/bootstrap_test.go` — +4):**
- `TestAddPeer_RejectsSelf`
- `TestAddPeer_AcceptsOthers`
- `TestBootstrap_SkipsSelfInSeedList`
- `TestSelfBootstrapResponseDoesNotPolluteMap` (defends against a hostile/buggy seed echoing the joiner's ID)

**TS (`repram-mcp/src/node/gossip.test.ts` — +2):**
- `rejects self and returns false`
- `returns true when adding a non-self peer`

**TS (`repram-mcp/src/node/bootstrap.test.ts` — +1):**
- `skips self in the seed list`

**Suite results:**
- Go: all packages green (`TestWriteReplicationToThreeNodes` re-verified)
- TS: 357/357 (was 354, +3 new)

## Test plan
- [ ] CI green
- [ ] Spot-check the warn-log at the addPeer chokepoint in case anything legitimate trips it (none expected — would indicate a real bug)
- [ ] Reassess #85 once this lands; the topology-sync count fix may resolve it

## Closes
Closes #87

// ticktockbent