### PR TITLE
fix(api): F11 reject slash-keys with 400 in both impls (wire-compat)

### DIFF
--- a/cmd/repram/handlers_test.go
+++ b/cmd/repram/handlers_test.go
@@ -627,3 +627,54 @@ func TestKeysSortedOrder(t *testing.T) {
 		t.Fatalf("keys not sorted: %v", keys)
 	}
 }
+
+// --- #91: keys must not contain '/' ---
+
+// TestSlashKeyReturns400_PUT locks in #91: a request to PUT /v1/data/foo%2Fbar
+// must return 400, not gorilla/mux's silent 404 from the route mismatch.
+func TestSlashKeyReturns400_PUT(t *testing.T) {
+	server, cleanup := newTestServer(t)
+	defer cleanup()
+
+	// Client sends an encoded slash; gorilla/mux decodes it before routing,
+	// so the path becomes /v1/data/foo/bar and falls to NotFoundHandler.
+	req := httptest.NewRequest("PUT", "/v1/data/foo%2Fbar", strings.NewReader("data"))
+	w := httptest.NewRecorder()
+	server.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "key must not contain") {
+		t.Fatalf("expected error message about keys with '/', got: %s", w.Body.String())
+	}
+}
+
+// TestSlashKeyReturns400_GET mirrors the PUT test for read paths.
+func TestSlashKeyReturns400_GET(t *testing.T) {
+	server, cleanup := newTestServer(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("GET", "/v1/data/foo%2Fbar", nil)
+	w := httptest.NewRecorder()
+	server.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestUnknownPathStill404 verifies the NotFoundHandler only converts
+// /v1/data/... 404s into 400s — anything else keeps the standard 404.
+func TestUnknownPathStill404(t *testing.T) {
+	server, cleanup := newTestServer(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("GET", "/v1/nonexistent/route", nil)
+	w := httptest.NewRecorder()
+	server.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown route, got %d", w.Code)
+	}
+}

--- a/cmd/repram/handlers_test.go
+++ b/cmd/repram/handlers_test.go
@@ -678,3 +678,31 @@ func TestUnknownPathStill404(t *testing.T) {
 		t.Fatalf("expected 404 for unknown route, got %d", w.Code)
 	}
 }
+
+// TestSlashOnlyKeyReturns400_NotRedirect locks in the parity-gap fix
+// surfaced by PR #104 review: /v1/data/%2F (slash-only key) decodes
+// to /v1/data//. Without SkipClean(true), gorilla/mux normalizes the
+// double slash to /v1/data/ and returns 301 before NotFoundHandler
+// can fire, so a PUT client sees a redirect that converts to GET per
+// RFC 9110 and never gets a coherent 400 for the original PUT. With
+// SkipClean, the original path reaches the router and 400 is returned
+// directly. TS already returned 400 here; this brings Go to parity.
+func TestSlashOnlyKeyReturns400_NotRedirect(t *testing.T) {
+	server, cleanup := newTestServer(t)
+	defer cleanup()
+
+	for _, method := range []string{"PUT", "GET"} {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/v1/data/%2F", strings.NewReader("data"))
+			w := httptest.NewRecorder()
+			server.Router().ServeHTTP(w, req)
+
+			if w.Code == http.StatusMovedPermanently || w.Code == http.StatusPermanentRedirect {
+				t.Fatalf("got %d redirect — SkipClean should prevent this; PUT clients can't follow without losing the body", w.Code)
+			}
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}

--- a/cmd/repram/main.go
+++ b/cmd/repram/main.go
@@ -313,6 +313,16 @@ type HTTPServer struct {
 func (s *HTTPServer) Router() *mux.Router {
 	r := mux.NewRouter()
 
+	// Disable gorilla's default path cleaning. Without this, a request to
+	// `/v1/data/%2F` decodes to `/v1/data//`, gorilla cleans it to
+	// `/v1/data/`, and returns 301 — pre-empting the NotFoundHandler. PUT
+	// clients then see a redirect that converts to GET (RFC 9110), so the
+	// PUT never gets a coherent 400. With SkipClean, the original path
+	// reaches the router, fails the `{key}` route, and lands in the
+	// NotFoundHandler that returns 400. None of REPRAM's routes need
+	// path cleaning (no `..`, no double-slash semantics) (#91).
+	r.SkipClean(true)
+
 	// Apply middleware
 	r.Use(corsMiddleware)
 	r.Use(s.securityMW.Middleware)

--- a/cmd/repram/main.go
+++ b/cmd/repram/main.go
@@ -332,7 +332,24 @@ func (s *HTTPServer) Router() *mux.Router {
 	r.HandleFunc("/v1/gossip/message", s.gossipHandler).Methods("POST", "OPTIONS")
 	r.HandleFunc("/v1/bootstrap", s.bootstrapHandler).Methods("POST", "OPTIONS")
 
+	r.NotFoundHandler = http.HandlerFunc(s.notFoundHandler)
+
 	return r
+}
+
+// notFoundHandler turns the implicit 404 from gorilla/mux on slash-containing
+// keys into an explicit 400 with a useful message. Keys are opaque, single-
+// segment strings (see docs/patterns.md); a request to `/v1/data/foo%2Fbar`
+// gets the path decoded by gorilla/mux to `/v1/data/foo/bar` before route
+// matching, which fails the `{key}` pattern. Without this handler clients
+// see a generic 404 and can't tell whether the key expired or was malformed
+// at the wire (#91).
+func (s *HTTPServer) notFoundHandler(w http.ResponseWriter, r *http.Request) {
+	if strings.HasPrefix(r.URL.Path, "/v1/data/") {
+		http.Error(w, "key must not contain '/'", http.StatusBadRequest)
+		return
+	}
+	http.NotFound(w, r)
 }
 
 func (s *HTTPServer) healthHandler(w http.ResponseWriter, r *http.Request) {

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -34,7 +34,7 @@ The agent patterns above are the primary motivation, but the primitive is genera
 
 ## Key Naming Conventions
 
-REPRAM doesn't enforce key structure — keys are opaque strings. But consistent naming helps agents discover each other's data and avoids collisions across unrelated workloads. These conventions are suggestions, not protocol requirements.
+Keys are opaque, single-segment strings. The server enforces one rule: **keys must not contain `/`** (the request returns 400). Everything else is convention — consistent naming helps agents discover each other's data and avoids collisions across unrelated workloads. These conventions are suggestions, not protocol requirements.
 
 ### Namespace prefixes
 
@@ -49,7 +49,7 @@ Use a prefix to indicate the key's role:
 | `state:` | State machine / job status | `state:job-9f3a` |
 | `broadcast:` | Ephemeral broadcast channel | `broadcast:config:feature-flags` |
 
-Separate hierarchy levels with `:` (colon). This is a convention, not a separator the server understands — but it plays well with prefix-based listing (`/v1/keys?prefix=lock:`).
+Separate hierarchy levels with `:` (colon) or `-` (hyphen). The server doesn't parse hierarchy — these are just convention — but `:` plays well with prefix-based listing (`/v1/keys?prefix=lock:`). Don't use `/`: the server rejects it with 400.
 
 ### Key generation strategies
 

--- a/repram-mcp/src/node/server.test.ts
+++ b/repram-mcp/src/node/server.test.ts
@@ -201,6 +201,25 @@ describe("GET handler", () => {
   });
 });
 
+// #91: keys must not contain '/'. Pre-fix, TS silently accepted and stored
+// multi-segment keys while Go 404'd them — a wire-compat divergence.
+// Both impls now return 400.
+describe("slash-key rejection (#91)", () => {
+  it("PUT /v1/data/foo%2Fbar returns 400", async () => {
+    const res = await request(server, "PUT", "/v1/data/foo%2Fbar", {
+      body: "data",
+      headers: { "X-TTL": "3600" },
+    });
+    expect(res.status).toBe(400);
+    expect(res.body).toContain("must not contain");
+  });
+
+  it("GET /v1/data/foo%2Fbar returns 400", async () => {
+    const res = await request(server, "GET", "/v1/data/foo%2Fbar");
+    expect(res.status).toBe(400);
+  });
+});
+
 describe("HEAD handler", () => {
   it("returns headers without body", async () => {
     await request(server, "PUT", "/v1/data/head-test", {

--- a/repram-mcp/src/node/server.ts
+++ b/repram-mcp/src/node/server.ts
@@ -282,6 +282,15 @@ export class HTTPServer {
     const dataMatch = path.match(/^\/v1\/data\/(.+)$/);
     if (dataMatch) {
       const key = decodeURIComponent(dataMatch[1]);
+      // Keys are opaque, single-segment strings (see docs/patterns.md).
+      // Reject anything containing '/' so TS and Go agree on the wire —
+      // pre-fix, TS silently stored multi-segment keys while Go 404'd
+      // the request because gorilla/mux normalized %2F to / before
+      // routing (#91).
+      if (key.includes("/")) {
+        sendJSON(res, 400, { error: "key must not contain '/'" });
+        return;
+      }
       if (method === "PUT") {
         this.putHandler(req, res, key);
         return;

--- a/test/burnin/workload.js
+++ b/test/burnin/workload.js
@@ -21,10 +21,9 @@ const REF_SET_SIZE = 200;
 const GRAVEYARD_SIZE = 200;
 const AGENT_COUNT = 100;
 
-// IMPORTANT: keys cannot contain '/' — see preflight finding F11.
-// gorilla/mux on the Go server doesn't UseEncodedPath, so URL-encoded
-// slashes get normalized back into path separators and never match the
-// /v1/data/{key} route. Use '-' as the hierarchy delimiter instead.
+// Keys must not contain '/' — server returns 400. Keys are opaque,
+// single-segment strings; use ':' or '-' as a hierarchy delimiter
+// (see docs/patterns.md "Key Naming Conventions").
 
 // REPRAM_MIN_TTL defaults to 300 (5 min). Graveyard set is written with this
 // TTL and the setup() sleeps long enough for it to expire before the main

--- a/test/live-wire-compat/run.sh
+++ b/test/live-wire-compat/run.sh
@@ -332,6 +332,23 @@ assert_status "go-node1 rejects GET with encoded-slash key" "400" "$go_get_statu
 
 ts_get_status=$(curl -s -o /dev/null -w '%{http_code}' "$TS1/v1/data/foo%2Fbar")
 assert_status "ts-node1 rejects GET with encoded-slash key" "400" "$ts_get_status"
+
+go_head_status=$(curl -s -o /dev/null -w '%{http_code}' -I "$GO1/v1/data/foo%2Fbar")
+assert_status "go-node1 rejects HEAD with encoded-slash key" "400" "$go_head_status"
+
+ts_head_status=$(curl -s -o /dev/null -w '%{http_code}' -I "$TS1/v1/data/foo%2Fbar")
+assert_status "ts-node1 rejects HEAD with encoded-slash key" "400" "$ts_head_status"
+
+# Slash-only key (#104 review parity gap): without SkipClean(true) on the
+# Go side, /v1/data/%2F decoded to /v1/data// and gorilla/mux returned 301
+# before NotFoundHandler could fire. Both impls now return 400.
+go_slash_only=$(curl -s -o /dev/null -w '%{http_code}' -X PUT -H "X-TTL: 300" \
+  -d "x" "$GO1/v1/data/%2F")
+assert_status "go-node1 rejects slash-only key (PUT) with 400 (no 301)" "400" "$go_slash_only"
+
+ts_slash_only=$(curl -s -o /dev/null -w '%{http_code}' -X PUT -H "X-TTL: 300" \
+  -d "x" "$TS1/v1/data/%2F")
+assert_status "ts-node1 rejects slash-only key (PUT) with 400" "400" "$ts_slash_only"
 echo ""
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/test/live-wire-compat/run.sh
+++ b/test/live-wire-compat/run.sh
@@ -312,6 +312,28 @@ assert_contains "ts-node1 /v1/status includes uptime" "uptime" "$ts_status"
 assert_contains "ts-node1 /v1/status includes memory" "rss" "$ts_status"
 echo ""
 
+# ── 11. Slash-key rejection (#91) ────────────────────────────────────
+# Pre-fix: Go 404'd via gorilla/mux route mismatch on %2F-decoded paths,
+# while TS silently accepted and stored multi-segment keys. Both impls
+# now return 400 for any request whose decoded key contains '/'.
+
+bold "11. Slash-key rejection (#91)"
+
+go_put_status=$(curl -s -o /dev/null -w '%{http_code}' -X PUT -H "X-TTL: 300" \
+  -d "should-be-rejected" "$GO1/v1/data/foo%2Fbar")
+assert_status "go-node1 rejects PUT with encoded-slash key" "400" "$go_put_status"
+
+ts_put_status=$(curl -s -o /dev/null -w '%{http_code}' -X PUT -H "X-TTL: 300" \
+  -d "should-be-rejected" "$TS1/v1/data/foo%2Fbar")
+assert_status "ts-node1 rejects PUT with encoded-slash key" "400" "$ts_put_status"
+
+go_get_status=$(curl -s -o /dev/null -w '%{http_code}' "$GO1/v1/data/foo%2Fbar")
+assert_status "go-node1 rejects GET with encoded-slash key" "400" "$go_get_status"
+
+ts_get_status=$(curl -s -o /dev/null -w '%{http_code}' "$TS1/v1/data/foo%2Fbar")
+assert_status "ts-node1 rejects GET with encoded-slash key" "400" "$ts_get_status"
+echo ""
+
 # ═══════════════════════════════════════════════════════════════════════
 # RESULTS
 # ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Closes #91. Fixes a silent wire-compat divergence: pre-fix, TS accepted and stored keys containing `/` while Go 404'd the same request because gorilla/mux normalizes `%2F` to `/` before route matching, after which `/v1/data/{key}` fails to match the 3-segment path. Real-workload keys like `agent/task-1/state` would store on TS but 404 on Go — corrupted reads from a Go peer of data written via TS, with no error visible to the writer.

Both impls now return **400** with a useful message, codifying the convention already in `docs/patterns.md` ("keys are opaque, use `:` for hierarchy") as a server-enforced rule.

## Approach (option 2 from the issue)

Per the issue body and `docs/patterns.md` (which already says hierarchy delimiter is `:`, not `/`), this PR rejects slash-keys rather than enabling `UseEncodedPath()`. Option 1 would have required both impls to agree on encoding semantics for the captured group, which is fragile and contradicts the documented contract.

## What changed

**Go (`cmd/repram/main.go`):**
- Added a custom `NotFoundHandler` on the gorilla/mux router. Detects `/v1/data/`-prefixed paths reaching the 404 fallback (always a slash-containing key after gorilla decodes `%2F` to `/`) and returns 400 with `"key must not contain '/'"`. Other unmatched paths still 404.
- No `UseEncodedPath()` toggle needed — sidesteps the cross-impl encoding-coordination question entirely.

**TS (`repram-mcp/src/node/server.ts`):**
- After `decodeURIComponent` in the `/v1/data/(.+)` route match, check `key.includes('/')` and return 400 before dispatching to put/getHandler.

**Tests:**
- `cmd/repram/handlers_test.go` (+3): PUT 400, GET 400, and a guard that the NotFoundHandler doesn't over-reach (unknown non-`/v1/data/` paths still 404).
- `repram-mcp/src/node/server.test.ts` (+2): PUT 400, GET 400.
- `test/live-wire-compat/run.sh` (+1 section, +4 assertions): live integration covering PUT and GET against both Go and TS real HTTP. Closes the test gap the issue called out.

**Doc/convention updates:**
- `docs/patterns.md`: opening line now states keys are opaque single-segment strings and the server rejects `/`. The "use `:` as delimiter" line is reframed: convention for hierarchy, but `/` is rejected.
- `test/burnin/workload.js`: replaced the F11-bug-as-current-state comment with a reference to the documented contract.

## Suite results

- Go: all packages green (+3 new tests)
- TS: 359/359 (was 357, +2 new)
- Live wire-compat: not auto-run; +4 assertions ready for next `./run.sh`

## Test plan
- [ ] CI green
- [ ] Run `./test/live-wire-compat/run.sh` to confirm the new section 11 passes against a real cluster
- [ ] Spot-check that no real-world docs or examples reference slash-containing keys (I checked the burnin workload + patterns.md; would catch a stale example anywhere else)

## Closes
Closes #91

// ticktockbent