### PR TITLE
chore(deps): drop uuid in favor of node:crypto.randomUUID

### DIFF
--- a/repram-mcp/package-lock.json
+++ b/repram-mcp/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "prom-client": "^15.1.3",
-        "uuid": "^14.0.0",
         "ws": "^8.19.0",
         "zod": "^3.25 || ^4.0"
       },
@@ -20,7 +19,6 @@
       },
       "devDependencies": {
         "@types/node": "^20.11.0",
-        "@types/uuid": "^10.0.0",
         "@types/ws": "^8.18.1",
         "typescript": "^5.3.0",
         "vitest": "^4.0.18"
@@ -930,13 +928,6 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -2467,19 +2458,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/repram-mcp/package.json
+++ b/repram-mcp/package.json
@@ -32,13 +32,11 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
     "prom-client": "^15.1.3",
-    "uuid": "^14.0.0",
     "ws": "^8.19.0",
     "zod": "^3.25 || ^4.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",
-    "@types/uuid": "^10.0.0",
     "@types/ws": "^8.18.1",
     "typescript": "^5.3.0",
     "vitest": "^4.0.18"

--- a/repram-mcp/src/tools.ts
+++ b/repram-mcp/src/tools.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from "uuid";
+import { randomUUID } from "node:crypto";
 import type { RepramClientInterface } from "./client.js";
 
 export interface ToolDefinition {
@@ -99,7 +99,7 @@ export async function handleToolCall(
     case "repram_store": {
       const data = args.data as string;
       const ttlSeconds = (args.ttl_seconds as number) ?? 3600;
-      const key = (args.key as string) ?? uuidv4();
+      const key = (args.key as string) ?? randomUUID();
 
       const result = await client.store(key, data, ttlSeconds);
 


### PR DESCRIPTION
## Summary

Removes the `uuid` dependency entirely. The dependabot bump from `^11` to `^14` (#74) made uuid ESM-only, which has been breaking `tsc` in the docker build (`module: Node16`, CommonJS imports). The break has been pre-existing since #74 merged:

- I noted it during PR #98 verification (chore/burnin-2-1-artifacts)
- It blocked the live wire-compat run for PR #104 (#91 fix)
- It would block any future docker-based testing

## What changed

- `repram-mcp/src/tools.ts`: replace `import { v4 as uuidv4 } from "uuid"` with `import { randomUUID } from "node:crypto"`. One usage site at line 102 (`repram_store` default key generation).
- `repram-mcp/package.json`: drop `uuid` and `@types/uuid`.
- `repram-mcp/package-lock.json`: regenerated.

`randomUUID()` has been in Node since 14.17 and our `engines.node` is `>=18`. Output is identical RFC 4122 v4 UUIDs — no behavior change in `repram_store`.

## Verification

```
$ npm run build       # tsc — was failing pre-fix, now succeeds
$ npm test            # 357/357 passing
```

## Test plan
- [ ] CI green (build + test)
- [ ] Confirm docker build succeeds (the original blocker)
- [ ] Spot-check that `repram_store` returns valid UUIDs when no key is provided

// ticktockbent