### PR TITLE
fix(security): F6 exempt peer endpoints from per-IP rate limit

### DIFF
--- a/internal/node/middleware.go
+++ b/internal/node/middleware.go
@@ -160,17 +160,36 @@ func NewSecurityMiddleware(rateLimit, burst int, maxRequestSize int64, trustProx
 	}
 }
 
+// peerEndpoints are inter-cluster paths that the per-IP rate limiter must
+// not apply to. Two reasons:
+//   1. When REPRAM_CLUSTER_SECRET is set, these endpoints are HMAC-gated
+//      already (verifyGossipSignature). Authenticated peer traffic at
+//      cluster volumes legitimately exceeds the client-tier per-IP rate.
+//   2. In open mode, the operator has explicitly accepted no-auth on the
+//      cluster plane — applying a client-tier rate limit there is
+//      inconsistent with that trust model.
+// Either way, applying the client rate limit here was the F6 burn-in
+// symptom: peer-to-peer gossip got 429'd and the cluster broke at modest
+// volumes (#86). Other security checks (size, scanner, headers) still
+// apply to peer endpoints.
+var peerEndpoints = map[string]bool{
+	"/v1/gossip/message": true,
+	"/v1/bootstrap":      true,
+}
+
 func (sm *SecurityMiddleware) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Apply security headers
 		sm.applySecurityHeaders(w)
-		
-		// Check rate limiting
+
+		// Check rate limiting (peer endpoints exempt — see peerEndpoints comment)
 		clientIP := sm.getClientIP(r)
-		if !sm.rateLimiter.Allow(clientIP) {
-			sm.metrics.rateLimitedRequests.Inc()
-			http.Error(w, "Rate limit exceeded", http.StatusTooManyRequests)
-			return
+		if !peerEndpoints[r.URL.Path] {
+			if !sm.rateLimiter.Allow(clientIP) {
+				sm.metrics.rateLimitedRequests.Inc()
+				http.Error(w, "Rate limit exceeded", http.StatusTooManyRequests)
+				return
+			}
 		}
 		
 		// Check request size

--- a/internal/node/middleware_test.go
+++ b/internal/node/middleware_test.go
@@ -236,3 +236,62 @@ func TestMaxRequestSizeMiddleware(t *testing.T) {
 		t.Fatalf("oversized request returned %d, want 413", rec.Code)
 	}
 }
+
+// TestPeerEndpointsBypassRateLimit locks in #86 (F6): /v1/gossip/message
+// and /v1/bootstrap must not be subject to the per-IP rate limiter,
+// otherwise authenticated peer traffic at cluster volumes triggers 429s
+// and the cluster breaks. HMAC verification (or open mode by operator
+// choice) handles authentication; the rate limit was the wrong layer.
+func TestPeerEndpointsBypassRateLimit(t *testing.T) {
+	// Tiny bucket so any rate-limit application is instantly visible.
+	sm := NewSecurityMiddleware(1, 1, 1024*1024, false)
+	defer sm.Close()
+
+	noopHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	wrapped := sm.Middleware(noopHandler)
+
+	for _, path := range []string{"/v1/gossip/message", "/v1/bootstrap"} {
+		// Hammer the endpoint past the burst — none should 429.
+		for i := 0; i < 50; i++ {
+			req := httptest.NewRequest("POST", path, nil)
+			req.RemoteAddr = "10.0.0.1:1234"
+			w := httptest.NewRecorder()
+			wrapped.ServeHTTP(w, req)
+			if w.Code == http.StatusTooManyRequests {
+				t.Fatalf("%s should bypass rate limit; got 429 on request %d", path, i)
+			}
+		}
+	}
+}
+
+// TestClientEndpointsStillRateLimited verifies the bypass is scoped
+// strictly to peer endpoints — client traffic still hits the limiter.
+func TestClientEndpointsStillRateLimited(t *testing.T) {
+	sm := NewSecurityMiddleware(1, 1, 1024*1024, false)
+	defer sm.Close()
+
+	noopHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	wrapped := sm.Middleware(noopHandler)
+
+	// First request: allowed (consumes the burst).
+	req1 := httptest.NewRequest("PUT", "/v1/data/foo", nil)
+	req1.RemoteAddr = "10.0.0.1:1234"
+	w1 := httptest.NewRecorder()
+	wrapped.ServeHTTP(w1, req1)
+	if w1.Code == http.StatusTooManyRequests {
+		t.Fatalf("first request should be allowed under burst=1, got 429")
+	}
+
+	// Second from same IP: rate limited.
+	req2 := httptest.NewRequest("PUT", "/v1/data/bar", nil)
+	req2.RemoteAddr = "10.0.0.1:1234"
+	w2 := httptest.NewRecorder()
+	wrapped.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusTooManyRequests {
+		t.Fatalf("client endpoint should be rate-limited; got %d", w2.Code)
+	}
+}

--- a/internal/node/middleware_test.go
+++ b/internal/node/middleware_test.go
@@ -266,6 +266,55 @@ func TestPeerEndpointsBypassRateLimit(t *testing.T) {
 	}
 }
 
+// TestPeerEndpointsSizeCheckStillApplies guards against a refactor that
+// accidentally widens the bypass to other security checks. The fix
+// should exempt peer endpoints from rate-limiting only — body-size,
+// scanner detection, and security headers must continue to fire (#86).
+func TestPeerEndpointsSizeCheckStillApplies(t *testing.T) {
+	sm := NewSecurityMiddleware(1000, 1000, 1024 /* 1 KiB */, false)
+	defer sm.Close()
+
+	noopHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	wrapped := sm.Middleware(noopHandler)
+
+	for _, path := range []string{"/v1/gossip/message", "/v1/bootstrap"} {
+		req := httptest.NewRequest("POST", path, nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		req.ContentLength = 4096 // 4 KiB > 1 KiB max
+		w := httptest.NewRecorder()
+		wrapped.ServeHTTP(w, req)
+		if w.Code != http.StatusRequestEntityTooLarge {
+			t.Fatalf("%s: expected 413 for oversized body, got %d", path, w.Code)
+		}
+	}
+}
+
+// TestPeerEndpointsScannerCheckStillApplies — same shape as the size
+// check guard. Scanner detection on peer endpoints catches a malicious
+// peer (or compromised secret) using a known scanner UA.
+func TestPeerEndpointsScannerCheckStillApplies(t *testing.T) {
+	sm := NewSecurityMiddleware(1000, 1000, 1024*1024, false)
+	defer sm.Close()
+
+	noopHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	wrapped := sm.Middleware(noopHandler)
+
+	for _, path := range []string{"/v1/gossip/message", "/v1/bootstrap"} {
+		req := httptest.NewRequest("POST", path, nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		req.Header.Set("User-Agent", "sqlmap/1.5")
+		w := httptest.NewRecorder()
+		wrapped.ServeHTTP(w, req)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("%s: expected 403 for scanner UA, got %d", path, w.Code)
+		}
+	}
+}
+
 // TestClientEndpointsStillRateLimited verifies the bypass is scoped
 // strictly to peer endpoints — client traffic still hits the limiter.
 func TestClientEndpointsStillRateLimited(t *testing.T) {

--- a/repram-mcp/src/node/middleware.test.ts
+++ b/repram-mcp/src/node/middleware.test.ts
@@ -333,4 +333,78 @@ describe("SecurityMiddleware", () => {
     expect(res._headers.get("x-content-type-options")).toBe("nosniff");
     mw.close();
   });
+
+  // #86 (F6): peer endpoints (gossip + bootstrap) bypass the per-IP rate
+  // limiter so authenticated peer traffic at cluster volumes doesn't get
+  // 429'd. HMAC verification (or operator-chosen open mode) is the auth
+  // layer; client-tier rate limiting was the wrong enforcement here.
+  it("bypasses rate limit on /v1/gossip/message", () => {
+    const mw = new SecurityMiddleware({
+      rateLimit: 1,
+      burst: 1,
+      maxRequestSize: 10_000,
+      trustProxy: false,
+    });
+
+    const req = mockRequest({
+      socket: { remoteAddress: "1.2.3.4" } as any,
+      url: "/v1/gossip/message",
+      method: "POST",
+    });
+
+    // Hammer past burst — every request should pass.
+    for (let i = 0; i < 50; i++) {
+      const res = mockResponse();
+      const ip = mw.check(req, res);
+      expect(ip, `request ${i}`).toBe("1.2.3.4");
+      expect(res.writtenHead).toBeNull();
+    }
+    mw.close();
+  });
+
+  it("bypasses rate limit on /v1/bootstrap", () => {
+    const mw = new SecurityMiddleware({
+      rateLimit: 1,
+      burst: 1,
+      maxRequestSize: 10_000,
+      trustProxy: false,
+    });
+
+    const req = mockRequest({
+      socket: { remoteAddress: "1.2.3.4" } as any,
+      url: "/v1/bootstrap",
+      method: "POST",
+    });
+
+    for (let i = 0; i < 50; i++) {
+      const res = mockResponse();
+      const ip = mw.check(req, res);
+      expect(ip, `request ${i}`).toBe("1.2.3.4");
+      expect(res.writtenHead).toBeNull();
+    }
+    mw.close();
+  });
+
+  it("still rate-limits client endpoints when peer-bypass is in effect", () => {
+    const mw = new SecurityMiddleware({
+      rateLimit: 1,
+      burst: 1,
+      maxRequestSize: 10_000,
+      trustProxy: false,
+    });
+
+    const clientReq = mockRequest({
+      socket: { remoteAddress: "1.2.3.4" } as any,
+      url: "/v1/data/foo",
+      method: "PUT",
+    });
+
+    // First client request passes; second is rate-limited.
+    const res1 = mockResponse();
+    expect(mw.check(clientReq, res1)).toBe("1.2.3.4");
+    const res2 = mockResponse();
+    expect(mw.check(clientReq, res2)).toBeNull();
+    expect(res2.writtenHead?.status).toBe(429);
+    mw.close();
+  });
 });

--- a/repram-mcp/src/node/middleware.test.ts
+++ b/repram-mcp/src/node/middleware.test.ts
@@ -385,6 +385,53 @@ describe("SecurityMiddleware", () => {
     mw.close();
   });
 
+  // #86 review: guard against a refactor that widens the bypass to
+  // other security checks. Body-size and scanner detection must still
+  // fire on peer endpoints.
+  it("still enforces body size on peer endpoints", () => {
+    const mw = new SecurityMiddleware({
+      rateLimit: 1000,
+      burst: 1000,
+      maxRequestSize: 1024,
+      trustProxy: false,
+    });
+
+    for (const path of ["/v1/gossip/message", "/v1/bootstrap"]) {
+      const req = mockRequest({
+        socket: { remoteAddress: "1.2.3.4" } as any,
+        url: path,
+        method: "POST",
+        headers: { "content-length": "4096" },
+      });
+      const res = mockResponse();
+      expect(mw.check(req, res), path).toBeNull();
+      expect(res.writtenHead?.status, path).toBe(413);
+    }
+    mw.close();
+  });
+
+  it("still enforces scanner detection on peer endpoints", () => {
+    const mw = new SecurityMiddleware({
+      rateLimit: 1000,
+      burst: 1000,
+      maxRequestSize: 1024 * 1024,
+      trustProxy: false,
+    });
+
+    for (const path of ["/v1/gossip/message", "/v1/bootstrap"]) {
+      const req = mockRequest({
+        socket: { remoteAddress: "1.2.3.4" } as any,
+        url: path,
+        method: "POST",
+        headers: { "user-agent": "sqlmap/1.5" },
+      });
+      const res = mockResponse();
+      expect(mw.check(req, res), path).toBeNull();
+      expect(res.writtenHead?.status, path).toBe(403);
+    }
+    mw.close();
+  });
+
   it("still rate-limits client endpoints when peer-bypass is in effect", () => {
     const mw = new SecurityMiddleware({
       rateLimit: 1,

--- a/repram-mcp/src/node/middleware.ts
+++ b/repram-mcp/src/node/middleware.ts
@@ -154,6 +154,16 @@ export function applyCorsHeaders(
 
 // ─── Composed SecurityMiddleware ─────────────────────────────────────
 
+/**
+ * Inter-cluster endpoints exempt from the per-IP rate limiter. Mirrors
+ * the Go `peerEndpoints` map (`internal/node/middleware.go`). When a
+ * third peer endpoint is added, update both sides.
+ */
+const PEER_ENDPOINTS: ReadonlySet<string> = new Set([
+  "/v1/gossip/message",
+  "/v1/bootstrap",
+]);
+
 export interface SecurityMiddlewareOptions {
   rateLimit: number;
   burst: number;
@@ -194,9 +204,7 @@ export class SecurityMiddleware {
     const clientIP = getClientIP(req, this.trustProxy);
 
     const path = (req.url ?? "").split("?")[0];
-    const isPeerEndpoint = path === "/v1/gossip/message" || path === "/v1/bootstrap";
-
-    if (!isPeerEndpoint && !this.rateLimiter.allow(clientIP)) {
+    if (!PEER_ENDPOINTS.has(path) && !this.rateLimiter.allow(clientIP)) {
       res.writeHead(429, { "Content-Type": "text/plain" });
       res.end("Rate limit exceeded");
       return null;

--- a/repram-mcp/src/node/middleware.ts
+++ b/repram-mcp/src/node/middleware.ts
@@ -175,13 +175,28 @@ export class SecurityMiddleware {
   /**
    * Run all security checks. Returns the client IP if allowed,
    * or null if the request was rejected (response already sent).
+   *
+   * The per-IP rate limiter is bypassed on inter-cluster endpoints
+   * (`/v1/gossip/message`, `/v1/bootstrap`):
+   *   1. With REPRAM_CLUSTER_SECRET set, those endpoints are HMAC-gated;
+   *      authenticated peer traffic at cluster volumes legitimately
+   *      exceeds the client-tier per-IP rate.
+   *   2. In open mode the operator has explicitly accepted no-auth on
+   *      the cluster plane — applying client-tier rate limiting there
+   *      is inconsistent with that trust model.
+   * Either way, applying the client rate limit broke gossip at modest
+   * volumes (F6 burn-in symptom, #86). Other checks (size, scanner,
+   * headers) still apply.
    */
   check(req: IncomingMessage, res: ServerResponse): string | null {
     applySecurityHeaders(res);
 
     const clientIP = getClientIP(req, this.trustProxy);
 
-    if (!this.rateLimiter.allow(clientIP)) {
+    const path = (req.url ?? "").split("?")[0];
+    const isPeerEndpoint = path === "/v1/gossip/message" || path === "/v1/bootstrap";
+
+    if (!isPeerEndpoint && !this.rateLimiter.allow(clientIP)) {
       res.writeHead(429, { "Content-Type": "text/plain" });
       res.end("Rate limit exceeded");
       return null;


### PR DESCRIPTION
## Summary

Closes #86. The per-IP rate limiter was applied to all routes, including the inter-cluster endpoints `/v1/gossip/message` and `/v1/bootstrap`. Above ~6 ops/sec/peer the default 100 req/min limit 429'd legitimate peer traffic and broke the cluster — the burn-in symptom that forced the `REPRAM_RATE_LIMIT=10000` workaround.

## Threat model (resolved during PR design)

The interesting question on this PR was whether removing rate-limiting on peer endpoints opens a DoS vector. Walked through it explicitly:

- **HMAC verification is already in place** on both endpoints when `REPRAM_CLUSTER_SECRET` is set (`verifyGossipSignature` in Go, `verifySignature` in TS). The rate limiter was running *before* auth and 429'ing valid peer traffic before HMAC could decide.
- **Open mode** (`REPRAM_CLUSTER_SECRET` empty): operators have explicitly accepted no-auth on the cluster plane. Applying a client-tier rate limit there is inconsistent with that trust model — if you chose open mode you accepted possible hostile actors.

So peer endpoints bypass rate-limiting in both modes. HMAC handles secret-set; operator-chosen trust handles open-mode.

## What changed

- `internal/node/middleware.go`: added `peerEndpoints` map. `Middleware` skips the rate-limit branch for `/v1/gossip/message` and `/v1/bootstrap`. Other checks (size, scanner, headers) still apply.
- `repram-mcp/src/node/middleware.ts`: same change in `check()`.

## Tests

- `internal/node/middleware_test.go` (+2): gossip + bootstrap stay open at burst=1 over 50 requests; client endpoints still 429.
- `repram-mcp/src/node/middleware.test.ts` (+3): same coverage on TS.

## Suite results
- Go: all packages green
- TS: 362/362 (was 359, +3 new)

## Test plan
- [ ] CI green
- [ ] Re-run live wire-compat (`./test/live-wire-compat/run.sh`) — the 50 ops/sec gossip rate it generates would have been borderline pre-fix
- [ ] Spot-check that scanner-detection and oversized-request rejection still fire on peer endpoints (covered by existing tests, but worth confirming)

## Closes
Closes #86

// ticktockbent