### PR TITLE
fix(cluster): F5 isolation recovery — re-bootstrap when peer count hits 0

### DIFF
--- a/cmd/repram/main.go
+++ b/cmd/repram/main.go
@@ -164,6 +164,23 @@ func main() {
 			},
 		}, rootList)
 		go refresher.Run(ctx)
+
+		// Public network: re-bootstrap pulls from the refresher's current
+		// signed list, so a node that fully isolates picks up whatever
+		// roots are live now, not whatever it started with (#85, F5).
+		clusterNode.SetSeedProvider(func() []string {
+			list := refresher.Current()
+			if list == nil {
+				return nil
+			}
+			return list.Nodes
+		})
+	} else if len(bootstrapNodes) > 0 {
+		// Private / REPRAM_PEERS: re-bootstrap reuses the static seed list
+		// the operator provided. Capture by closure so the goroutine sees
+		// the same slice we started with (#85, F5).
+		seeds := append([]string(nil), bootstrapNodes...)
+		clusterNode.SetSeedProvider(func() []string { return seeds })
 	}
 
 	server := &HTTPServer{

--- a/internal/cluster/node.go
+++ b/internal/cluster/node.go
@@ -33,7 +33,20 @@ type ClusterNode struct {
 	// (see cmd/repram/main.go and future phase 4 refresh loop). When
 	// false, the HTTP server refuses bootstrap requests with 403.
 	isRoot atomic.Bool
+
+	// seedProvider returns the current bootstrap seed list. Used by the
+	// isolation-recovery loop to re-bootstrap when peer count drops to 0
+	// (#85, F5). Public deployments wire this to the omega refresher's
+	// current list; private deployments wire it to the static REPRAM_PEERS
+	// list. Nil disables recovery (used for tests and for cases where
+	// re-bootstrap doesn't make sense).
+	seedProvider func() []string
 }
+
+// IsolationRecoveryInterval is how often the recovery loop checks for
+// the zero-peer condition. Matches the gossip health-check cadence so
+// recovery starts within one tick of full eviction.
+const IsolationRecoveryInterval = 30 * time.Second
 
 type WriteOperation struct {
 	Key         string
@@ -98,7 +111,67 @@ func (cn *ClusterNode) Start(ctx context.Context, bootstrapAddresses []string) e
 		logging.Info("[%s] Starting as first node (no bootstrap addresses)", cn.localNode.ID)
 	}
 
+	go cn.runIsolationRecovery(ctx)
+
 	return nil
+}
+
+// SetSeedProvider wires a callback that returns the current bootstrap
+// seed list. The isolation-recovery loop calls it whenever peer count
+// drops to 0 to attempt re-bootstrap. Nil disables recovery (#85, F5).
+func (cn *ClusterNode) SetSeedProvider(p func() []string) {
+	cn.seedProvider = p
+}
+
+// runIsolationRecovery polls peer count on IsolationRecoveryInterval
+// and triggers re-bootstrap when the node is fully isolated (#85, F5).
+//
+// Why polling rather than event-driven from removePeer: multi-eviction
+// in a single pingPeers tick can fire several removals back-to-back, and
+// triggering from each would either spawn duplicate recoveries or
+// require single-flight machinery. Polling also catches isolation that
+// happens via paths other than ping eviction.
+func (cn *ClusterNode) runIsolationRecovery(ctx context.Context) {
+	ticker := time.NewTicker(IsolationRecoveryInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			cn.CheckIsolationAndRecover(ctx)
+		}
+	}
+}
+
+// CheckIsolationAndRecover runs one isolation-recovery cycle. Returns
+// true if a re-bootstrap was attempted AND it found at least one peer.
+// Public so tests can drive recovery deterministically without timers.
+func (cn *ClusterNode) CheckIsolationAndRecover(ctx context.Context) bool {
+	if len(cn.protocol.GetPeers()) > 0 {
+		return false
+	}
+	if cn.seedProvider == nil {
+		return false
+	}
+	seeds := cn.seedProvider()
+	if len(seeds) == 0 {
+		return false
+	}
+	logging.Warn("[%s] Isolated (0 peers) — re-bootstrapping against %d seeds",
+		cn.localNode.ID, len(seeds))
+	if err := cn.protocol.Bootstrap(ctx, seeds); err != nil {
+		logging.Warn("[%s] Re-bootstrap failed: %v", cn.localNode.ID, err)
+		return false
+	}
+	after := len(cn.protocol.GetPeers())
+	if after > 0 {
+		logging.Info("[%s] Re-bootstrap recovered %d peers", cn.localNode.ID, after)
+		return true
+	}
+	logging.Warn("[%s] Re-bootstrap completed but discovered no peers; will retry next cycle",
+		cn.localNode.ID)
+	return false
 }
 
 func (cn *ClusterNode) Stop() error {

--- a/internal/cluster/recovery_test.go
+++ b/internal/cluster/recovery_test.go
@@ -1,0 +1,142 @@
+package cluster
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestCheckIsolationAndRecover_HappyPath drives the recovery cycle
+// directly with a node that has 0 peers and a seedProvider pointing at
+// a live cluster. After one cycle the isolated node should have
+// rejoined (#85, F5).
+func TestCheckIsolationAndRecover_HappyPath(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Build a 2-node base cluster (A bootstrapping from B).
+	a := newTestNode(t, "node-a", "default", 2)
+	b := newTestNode(t, "node-b", "default", 2)
+	defer a.stop()
+	defer b.stop()
+
+	a.start(t, ctx, nil) // first node
+	b.start(t, ctx, []string{a.addr()})
+
+	if err := waitFor(ctx, 2*time.Second, func() bool {
+		return len(a.node.protocol.GetPeers()) == 1 && len(b.node.protocol.GetPeers()) == 1
+	}); err != nil {
+		t.Fatalf("base cluster failed to converge: %v", err)
+	}
+
+	// Spin up an isolated node C with a seedProvider pointing at A.
+	c := newTestNode(t, "node-c", "default", 2)
+	defer c.stop()
+	c.start(t, ctx, nil) // start as isolated first node
+	if got := len(c.node.protocol.GetPeers()); got != 0 {
+		t.Fatalf("setup error: expected isolated node-c to have 0 peers, got %d", got)
+	}
+
+	c.node.SetSeedProvider(func() []string { return []string{a.addr(), b.addr()} })
+
+	// Drive one recovery cycle directly.
+	if !c.node.CheckIsolationAndRecover(ctx) {
+		t.Fatal("CheckIsolationAndRecover returned false; expected re-bootstrap to recover peers")
+	}
+
+	got := len(c.node.protocol.GetPeers())
+	if got < 1 {
+		t.Fatalf("expected node-c to discover at least 1 peer after recovery, got %d", got)
+	}
+}
+
+// TestCheckIsolationAndRecover_NoOpWithPeers verifies the recovery
+// cycle does nothing when peers exist — the seed provider should not
+// be consulted (#85, F5).
+func TestCheckIsolationAndRecover_NoOpWithPeers(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	a := newTestNode(t, "node-a", "default", 2)
+	b := newTestNode(t, "node-b", "default", 2)
+	defer a.stop()
+	defer b.stop()
+
+	a.start(t, ctx, nil)
+	b.start(t, ctx, []string{a.addr()})
+
+	if err := waitFor(ctx, 2*time.Second, func() bool {
+		return len(b.node.protocol.GetPeers()) == 1
+	}); err != nil {
+		t.Fatalf("base cluster failed to converge: %v", err)
+	}
+
+	var calls int32
+	b.node.SetSeedProvider(func() []string {
+		atomic.AddInt32(&calls, 1)
+		return []string{a.addr()}
+	})
+
+	if b.node.CheckIsolationAndRecover(ctx) {
+		t.Fatal("recovery should be a no-op when peers exist")
+	}
+	if got := atomic.LoadInt32(&calls); got != 0 {
+		t.Fatalf("seedProvider called %d times; expected 0 — recovery should short-circuit on peer count", got)
+	}
+}
+
+// TestCheckIsolationAndRecover_NoSeedProvider verifies that recovery is
+// disabled when no seed provider is wired. The recovery cycle returns
+// false without attempting bootstrap.
+func TestCheckIsolationAndRecover_NoSeedProvider(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	a := newTestNode(t, "node-a", "default", 2)
+	defer a.stop()
+	a.start(t, ctx, nil)
+
+	// No SetSeedProvider call; provider is nil.
+	if a.node.CheckIsolationAndRecover(ctx) {
+		t.Fatal("recovery should return false when no seedProvider is set")
+	}
+}
+
+// TestCheckIsolationAndRecover_EmptySeeds verifies the recovery cycle
+// short-circuits when the seed provider returns an empty list. This
+// happens transiently in the public-network case if the omega refresher
+// hasn't loaded a list yet.
+func TestCheckIsolationAndRecover_EmptySeeds(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	a := newTestNode(t, "node-a", "default", 2)
+	defer a.stop()
+	a.start(t, ctx, nil)
+
+	a.node.SetSeedProvider(func() []string { return nil })
+	if a.node.CheckIsolationAndRecover(ctx) {
+		t.Fatal("recovery should return false when seedProvider returns empty")
+	}
+}
+
+// waitFor polls until predicate returns true or the timeout elapses.
+func waitFor(ctx context.Context, timeout time.Duration, predicate func() bool) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		if predicate() {
+			return nil
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !predicate() {
+		return context.DeadlineExceeded
+	}
+	return nil
+}

--- a/repram-mcp/src/index.ts
+++ b/repram-mcp/src/index.ts
@@ -98,6 +98,33 @@ async function bootstrap(server: HTTPServer, config: ServerConfig, logger: Logge
       rootList,
     );
     void refresher.run();
+
+    // Public network: re-bootstrap pulls from the refresher's current
+    // signed list, so a node that fully isolates picks up whatever
+    // roots are live now, not whatever it started with (#85, F5).
+    server.clusterNode.setRebootstrapFn(async () => {
+      const list = refresher.currentList;
+      if (list.nodes.length === 0) return [];
+      return await bootstrapFromPeers(
+        list.nodes,
+        server.clusterNode.localNode,
+        config.clusterSecret,
+        logger,
+      );
+    });
+  } else if (seedPeers.length > 0) {
+    // Private / REPRAM_PEERS: re-bootstrap reuses the static seed list.
+    // Capture by closure so the goroutine sees the same slice we started
+    // with (#85, F5).
+    const seedSnapshot = [...seedPeers];
+    server.clusterNode.setRebootstrapFn(async () => {
+      return await bootstrapFromPeers(
+        seedSnapshot,
+        server.clusterNode.localNode,
+        config.clusterSecret,
+        logger,
+      );
+    });
   }
 
   if (seedPeers.length === 0) return;

--- a/repram-mcp/src/index.ts
+++ b/repram-mcp/src/index.ts
@@ -113,9 +113,10 @@ async function bootstrap(server: HTTPServer, config: ServerConfig, logger: Logge
       );
     });
   } else if (seedPeers.length > 0) {
-    // Private / REPRAM_PEERS: re-bootstrap reuses the static seed list.
-    // Capture by closure so the goroutine sees the same slice we started
-    // with (#85, F5).
+    // Private / REPRAM_PEERS: re-bootstrap reuses the static seed list
+    // captured at startup. Operators who rotate seeds at runtime (e.g.,
+    // replacing a decommissioned seed) need to restart the node — there
+    // is no SIGHUP-style reload path today (#85, F5).
     const seedSnapshot = [...seedPeers];
     server.clusterNode.setRebootstrapFn(async () => {
       return await bootstrapFromPeers(

--- a/repram-mcp/src/node/cluster.test.ts
+++ b/repram-mcp/src/node/cluster.test.ts
@@ -1053,3 +1053,94 @@ describe("ClusterNode ACK reverse-routing", () => {
     tree.stop();
   });
 });
+
+// --- #85: isolation recovery ---
+
+describe("ClusterNode isolation recovery", () => {
+  it("re-bootstraps when peer count is 0 and a rebootstrapFn is wired", async () => {
+    const node = new ClusterNode(defaultOptions(), silentLogger());
+    node.setTransport(createMockTransport().transport);
+
+    // Spy on gossip.addPeer to confirm discovered peers are registered.
+    const addPeerSpy = vi.spyOn(node.gossip, "addPeer");
+
+    const discoveredPeer: NodeInfo = {
+      id: "rediscovered",
+      address: "10.0.0.9",
+      port: 9090,
+      httpPort: 8080,
+      enclave: "default",
+    };
+    let calls = 0;
+    node.setRebootstrapFn(async () => {
+      calls += 1;
+      return [discoveredPeer];
+    });
+
+    expect(node.gossip.getPeers().length).toBe(0);
+    const recovered = await node.checkIsolationAndRecover();
+
+    expect(recovered).toBe(true);
+    expect(calls).toBe(1);
+    expect(addPeerSpy).toHaveBeenCalledWith(discoveredPeer);
+    expect(node.gossip.getPeers().length).toBe(1);
+  });
+
+  it("is a no-op when peers exist", async () => {
+    const node = new ClusterNode(defaultOptions(), silentLogger());
+    node.setTransport(createMockTransport().transport);
+    node.gossip.addPeer({
+      id: "existing",
+      address: "10.0.0.2",
+      port: 9090,
+      httpPort: 8080,
+      enclave: "default",
+    });
+
+    let calls = 0;
+    node.setRebootstrapFn(async () => {
+      calls += 1;
+      return [];
+    });
+
+    const recovered = await node.checkIsolationAndRecover();
+    expect(recovered).toBe(false);
+    expect(calls).toBe(0);
+  });
+
+  it("returns false when no rebootstrapFn is wired", async () => {
+    const node = new ClusterNode(defaultOptions(), silentLogger());
+    node.setTransport(createMockTransport().transport);
+
+    const recovered = await node.checkIsolationAndRecover();
+    expect(recovered).toBe(false);
+  });
+
+  it("returns false when rebootstrapFn discovers no peers", async () => {
+    const node = new ClusterNode(defaultOptions(), silentLogger());
+    node.setTransport(createMockTransport().transport);
+
+    let calls = 0;
+    node.setRebootstrapFn(async () => {
+      calls += 1;
+      return [];
+    });
+
+    const recovered = await node.checkIsolationAndRecover();
+    expect(recovered).toBe(false);
+    expect(calls).toBe(1);
+  });
+
+  it("swallows rebootstrapFn errors and returns false", async () => {
+    const node = new ClusterNode(defaultOptions(), silentLogger());
+    node.setTransport(createMockTransport().transport);
+
+    node.setRebootstrapFn(async () => {
+      throw new Error("network unreachable");
+    });
+
+    // Should not throw.
+    const recovered = await node.checkIsolationAndRecover();
+    expect(recovered).toBe(false);
+  });
+});

--- a/repram-mcp/src/node/cluster.test.ts
+++ b/repram-mcp/src/node/cluster.test.ts
@@ -1144,3 +1144,73 @@ describe("ClusterNode isolation recovery", () => {
     expect(recovered).toBe(false);
   });
 });
+
+// --- #85: review-driven follow-ups (PR #107) ---
+
+describe("ClusterNode isolation recovery — single-flight + timer", () => {
+  // #107 review (suggestion 1): the setInterval tick can fire while a
+  // previous async re-bootstrap is still in flight. Without single-flight
+  // guard that produces duplicate addPeer calls. This test verifies
+  // overlapping calls return false and don't double-invoke the seed fn.
+  it("guards against overlapping recovery cycles (single-flight)", async () => {
+    const node = new ClusterNode(defaultOptions(), silentLogger());
+    node.setTransport(createMockTransport().transport);
+
+    let pending: ((peers: NodeInfo[]) => void) | null = null;
+    let calls = 0;
+    node.setRebootstrapFn(
+      () =>
+        new Promise<NodeInfo[]>((resolve) => {
+          calls += 1;
+          pending = resolve;
+        }),
+    );
+
+    const first = node.checkIsolationAndRecover();
+    // Yield so the first call has time to set this.recovering = true.
+    await Promise.resolve();
+    const second = await node.checkIsolationAndRecover();
+    expect(second).toBe(false);
+    expect(calls).toBe(1); // second call short-circuited
+
+    // Resolve the first call's pending promise; it should complete cleanly.
+    pending!([]);
+    await first;
+    expect(calls).toBe(1);
+  });
+
+  // #107 review (suggestion 3): exercise the timer-driven path via
+  // vitest fake timers. Verifies setInterval actually invokes recovery
+  // and stop() clears the timer.
+  it("invokes recovery on the setInterval tick and stops on .stop()", async () => {
+    vi.useFakeTimers();
+    const node = new ClusterNode(defaultOptions(), silentLogger());
+    node.setTransport(createMockTransport().transport);
+
+    let calls = 0;
+    node.setRebootstrapFn(async () => {
+      calls += 1;
+      return [];
+    });
+
+    node.start();
+
+    // No tick yet — start() shouldn't invoke recovery synchronously.
+    expect(calls).toBe(0);
+
+    // Advance one full interval; recovery should fire once.
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(calls).toBe(1);
+
+    // Another interval, fire again.
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(calls).toBe(2);
+
+    // stop() should clear the interval — further ticks no-op.
+    node.stop();
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(calls).toBe(2);
+
+    vi.useRealTimers();
+  });
+});

--- a/repram-mcp/src/node/cluster.ts
+++ b/repram-mcp/src/node/cluster.ts
@@ -21,6 +21,13 @@ import type { Message, NodeInfo } from "./types.js";
 import type { TreeManager } from "./tree.js";
 import type { WebSocketConnection } from "./ws-transport.js";
 
+/**
+ * How often the isolation-recovery loop checks peer count. Matches the
+ * gossip health-check cadence so recovery starts within one tick of full
+ * eviction (#85, F5).
+ */
+export const ISOLATION_RECOVERY_INTERVAL_MS = 30_000;
+
 /** Quorum reached — all replicas confirmed. */
 export const WRITE_STATUS_CREATED = 201;
 
@@ -66,6 +73,13 @@ export class ClusterNode {
   // currently-trusted omega signed root list. Gates the bootstrap handler.
   // See docs/REPRAM-2.1-Spec.md.
   private _isRoot = false;
+
+  // rebootstrapFn returns a promise of newly-discovered peers. Called by
+  // the isolation-recovery loop when peer count drops to 0 (#85, F5).
+  // Wired in index.ts: closures over the omega refresher's current list
+  // for public networks, or the static REPRAM_PEERS list for private.
+  private rebootstrapFn: (() => Promise<NodeInfo[]>) | null = null;
+  private isolationTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(options: ClusterNodeOptions, logger: Logger) {
     const enclave = options.enclave || "default";
@@ -116,10 +130,20 @@ export class ClusterNode {
 
   start(): void {
     this.gossip.start();
+    this.isolationTimer = setInterval(
+      () => void this.checkIsolationAndRecover(),
+      ISOLATION_RECOVERY_INTERVAL_MS,
+    );
+    // Don't keep the event loop alive just for the recovery timer.
+    this.isolationTimer.unref();
     this.logger.info(`[${this.localNode.id}] Cluster node started`);
   }
 
   stop(): void {
+    if (this.isolationTimer) {
+      clearInterval(this.isolationTimer);
+      this.isolationTimer = null;
+    }
     // Resolve all pending writes as 202 (timeout)
     for (const [messageId, op] of this.pendingWrites) {
       clearTimeout(op.timer);
@@ -129,6 +153,47 @@ export class ClusterNode {
 
     this.gossip.stop();
     this.store.close();
+  }
+
+  /** Wire the re-bootstrap callback used by the isolation-recovery loop.
+   *  Set to null to disable recovery (#85, F5). */
+  setRebootstrapFn(fn: (() => Promise<NodeInfo[]>) | null): void {
+    this.rebootstrapFn = fn;
+  }
+
+  /** One isolation-recovery cycle. Public so tests can drive recovery
+   *  deterministically without timers. Returns true when re-bootstrap
+   *  attempted AND found at least one peer (#85, F5). */
+  async checkIsolationAndRecover(): Promise<boolean> {
+    if (this.gossip.getPeers().length > 0) return false;
+    if (!this.rebootstrapFn) return false;
+
+    this.logger.warn(
+      `[${this.localNode.id}] Isolated (0 peers) — re-bootstrapping`,
+    );
+    let discovered: NodeInfo[];
+    try {
+      discovered = await this.rebootstrapFn();
+    } catch (err) {
+      this.logger.warn(
+        `[${this.localNode.id}] Re-bootstrap failed: ${(err as Error).message}`,
+      );
+      return false;
+    }
+    for (const peer of discovered) {
+      this.gossip.addPeer(peer);
+    }
+    const after = this.gossip.getPeers().length;
+    if (after > 0) {
+      this.logger.info(
+        `[${this.localNode.id}] Re-bootstrap recovered ${after} peers`,
+      );
+      return true;
+    }
+    this.logger.warn(
+      `[${this.localNode.id}] Re-bootstrap completed but discovered no peers; will retry next cycle`,
+    );
+    return false;
   }
 
   // --- Read operations ---

--- a/repram-mcp/src/node/cluster.ts
+++ b/repram-mcp/src/node/cluster.ts
@@ -80,6 +80,11 @@ export class ClusterNode {
   // for public networks, or the static REPRAM_PEERS list for private.
   private rebootstrapFn: (() => Promise<NodeInfo[]>) | null = null;
   private isolationTimer: ReturnType<typeof setInterval> | null = null;
+  // Single-flight guard for checkIsolationAndRecover. The async re-bootstrap
+  // call can take longer than the ISOLATION_RECOVERY_INTERVAL_MS tick on
+  // slow networks; without this flag a second tick would spawn a second
+  // concurrent recovery and produce duplicate addPeer calls.
+  private recovering = false;
 
   constructor(options: ClusterNodeOptions, logger: Logger) {
     const enclave = options.enclave || "default";
@@ -163,37 +168,45 @@ export class ClusterNode {
 
   /** One isolation-recovery cycle. Public so tests can drive recovery
    *  deterministically without timers. Returns true when re-bootstrap
-   *  attempted AND found at least one peer (#85, F5). */
+   *  attempted AND found at least one peer (#85, F5). Single-flight:
+   *  overlapping calls (e.g., from a slow re-bootstrap that outlasts a
+   *  timer tick) return false without launching a duplicate. */
   async checkIsolationAndRecover(): Promise<boolean> {
+    if (this.recovering) return false;
     if (this.gossip.getPeers().length > 0) return false;
     if (!this.rebootstrapFn) return false;
 
-    this.logger.warn(
-      `[${this.localNode.id}] Isolated (0 peers) — re-bootstrapping`,
-    );
-    let discovered: NodeInfo[];
+    this.recovering = true;
     try {
-      discovered = await this.rebootstrapFn();
-    } catch (err) {
       this.logger.warn(
-        `[${this.localNode.id}] Re-bootstrap failed: ${(err as Error).message}`,
+        `[${this.localNode.id}] Isolated (0 peers) — re-bootstrapping`,
+      );
+      let discovered: NodeInfo[];
+      try {
+        discovered = await this.rebootstrapFn();
+      } catch (err) {
+        this.logger.warn(
+          `[${this.localNode.id}] Re-bootstrap failed: ${(err as Error).message}`,
+        );
+        return false;
+      }
+      for (const peer of discovered) {
+        this.gossip.addPeer(peer);
+      }
+      const after = this.gossip.getPeers().length;
+      if (after > 0) {
+        this.logger.info(
+          `[${this.localNode.id}] Re-bootstrap recovered ${after} peers`,
+        );
+        return true;
+      }
+      this.logger.warn(
+        `[${this.localNode.id}] Re-bootstrap completed but discovered no peers; will retry next cycle`,
       );
       return false;
+    } finally {
+      this.recovering = false;
     }
-    for (const peer of discovered) {
-      this.gossip.addPeer(peer);
-    }
-    const after = this.gossip.getPeers().length;
-    if (after > 0) {
-      this.logger.info(
-        `[${this.localNode.id}] Re-bootstrap recovered ${after} peers`,
-      );
-      return true;
-    }
-    this.logger.warn(
-      `[${this.localNode.id}] Re-bootstrap completed but discovered no peers; will retry next cycle`,
-    );
-    return false;
   }
 
   // --- Read operations ---


### PR DESCRIPTION
## Summary

Closes #85. A node that loses every peer had no in-band path back to the cluster — topology sync exchanges peer lists with *known* peers, so an empty peer set means there's no one to ask. The burn-in repro was stopping node-b/c briefly; node-a evicted both, then never rejoined until manual restart.

## Relationship to #87

The F7 fix in #87 already covered the *non-zero-peer* slice of this issue: pre-#87 self leaked into the peer map, so `len(p.peers)` overstated by 1 and `performTopologySync`'s threshold check was always satisfied even when the node was missing real peers — sync was permanently skipped. Post-#87 that path works.

What's left is the **zero-real-peer case**: even with honest counts, topology sync has no peer to broadcast to once the local set is empty. This PR adds the recovery path for that case.

## Design (Go + TS, mirrored)

- `ClusterNode` runs an isolation-recovery loop on a 30s ticker (matches the gossip health-check cadence — recovery starts within one tick of full eviction).
- Each tick: if peer count is 0 and a seedProvider (Go) or rebootstrapFn (TS) is wired, re-bootstrap.
- **Polling rather than event-driven** from `removePeer`: multi-eviction in a single `pingPeers` tick can fire several removals back-to-back. Triggering from each would either spawn duplicate recoveries or require single-flight machinery. Polling is simpler and correct.
- **Public network**: re-bootstrap pulls from the omega refresher's current signed list. An isolated node picks up whatever roots are live *now*, not whatever it started with.
- **Private / REPRAM_PEERS**: re-bootstrap reuses the static seed list the operator provided (captured by closure at startup).
- The recovery method is extracted as `CheckIsolationAndRecover` (Go) / `checkIsolationAndRecover` (TS) so tests can drive recovery deterministically without timers.

## What changed

| File | Change |
|------|--------|
| `internal/cluster/node.go` | `seedProvider` field, `SetSeedProvider`, `runIsolationRecovery` goroutine, `CheckIsolationAndRecover` method, `IsolationRecoveryInterval` constant |
| `cmd/repram/main.go` | Wire seedProvider — public closes over `refresher.Current().Nodes`, private snapshots `bootstrapNodes` |
| `repram-mcp/src/node/cluster.ts` | `rebootstrapFn` field, `setRebootstrapFn`, isolation timer in `start()`, `checkIsolationAndRecover`, `ISOLATION_RECOVERY_INTERVAL_MS` constant |
| `repram-mcp/src/index.ts` | Wire rebootstrapFn — public closes over `refresher.currentList.nodes`, private snapshots `seedPeers` |

## Tests

- `internal/cluster/recovery_test.go` (+4): happy-path recovery, no-op when peers exist, no-op without seedProvider, no-op on empty seeds.
- `repram-mcp/src/node/cluster.test.ts` (+5): same coverage plus an error-swallowing test for a re-bootstrap that throws.

Suite results: Go all packages green; TS 369/369 (was 364, +5 new).

## Out of scope (follow-ups)

- **WebSocket reattachment**: transient nodes that isolate need their WS attachment to recover too. That's handled separately by TreeManager's goodbye/redirect logic. This PR is HTTP gossip recovery only.
- **Threshold tuning**: current trigger is hard-coded zero. The issue body floats "configurable threshold" — deferrable until someone needs it.
- **Backoff under sustained outage**: the 30s polling interval doubles as the de-facto retry backoff. If the cluster is fully down, re-bootstrap fails every 30s indefinitely. No exponential backoff added — keeps the design simpler. Easy to add later if seeds become rate-limited under sustained-outage scenarios.

## Test plan
- [ ] CI green
- [ ] Live wire-compat (`./test/live-wire-compat/run.sh`) passes — adds confidence that the timer-driven path doesn't interfere with normal operation
- [ ] Manual repro of the burn-in scenario: spin up 3-node cluster, stop 2 nodes, verify the third recovers when the cluster comes back

## Closes
Closes #85

// ticktockbent