### PR TITLE
fix(tree): F108 reattach transient nodes after ungraceful disconnect

### DIFF
--- a/repram-mcp/src/index.ts
+++ b/repram-mcp/src/index.ts
@@ -112,6 +112,11 @@ async function bootstrap(server: HTTPServer, config: ServerConfig, logger: Logge
         logger,
       );
     });
+
+    // Same source for the WS reattach loop: when a transient loses its
+    // parent ungracefully and exhausts cached alternatives, fresh roots
+    // come from the omega refresher's current list (#108).
+    server.treeManager.setSeedProvider(() => refresher.currentList.nodes);
   } else if (seedPeers.length > 0) {
     // Private / REPRAM_PEERS: re-bootstrap reuses the static seed list
     // captured at startup. Operators who rotate seeds at runtime (e.g.,
@@ -126,6 +131,9 @@ async function bootstrap(server: HTTPServer, config: ServerConfig, logger: Logge
         logger,
       );
     });
+
+    // Same snapshot for the WS reattach loop (#108).
+    server.treeManager.setSeedProvider(() => seedSnapshot);
   }
 
   if (seedPeers.length === 0) return;

--- a/repram-mcp/src/node/tree.test.ts
+++ b/repram-mcp/src/node/tree.test.ts
@@ -5,6 +5,7 @@ import {
   TreeManager,
   DEFAULT_MAX_CHILDREN,
   type InboundCapability,
+  type AlternativeParent,
 } from "./tree.js";
 import {
   WebSocketConnection,
@@ -560,6 +561,208 @@ describe("TreeManager", () => {
       substrateTree.stop();
       transientTree.stop();
       await pair.cleanup();
+    });
+  });
+
+  // #108: ungraceful WebSocket disconnect should trigger reattach via the
+  // cached topology + seed list, not strand the transient until restart.
+  describe("ungraceful disconnect reattach (#108)", () => {
+    it("captures welcome.topology as cached alternatives, excluding self", async () => {
+      const pair = await createPair();
+
+      const substrateNode = makeNodeInfo("substrate-1");
+      const substrateGossip = new GossipProtocol(substrateNode, 3, silentLogger());
+      // Substrate knows about a couple of other peers — these end up in the
+      // welcome topology and should be cached as reattach alternatives.
+      substrateGossip.addPeer(makeNodeInfo("peer-a", { httpPort: 8001 }));
+      substrateGossip.addPeer(makeNodeInfo("peer-b", { httpPort: 8002 }));
+      const substrateTree = makeTreeManager(substrateNode, substrateGossip);
+
+      pair.serverConn.on("attachment", (msg: AttachmentMessage) => {
+        if (msg.type === "hello") {
+          substrateTree.handleHello(pair.serverConn, msg.payload as HelloPayload);
+        }
+      });
+
+      const transientNode = makeNodeInfo("transient-1", { address: "10.0.0.1" });
+      const transientGossip = new GossipProtocol(transientNode, 3, silentLogger());
+      const transientTree = makeTreeManager(transientNode, transientGossip, { inbound: "false" });
+
+      const welcome = await transientTree.attach(pair.clientConn);
+      expect(welcome).not.toBeNull();
+
+      // Inspect cached alternatives. Should include substrate-1, peer-a,
+      // peer-b — but NOT transient-1 (self).
+      const cached = (transientTree as unknown as { lastKnownAlternatives: AlternativeParent[] })
+        .lastKnownAlternatives;
+      const ids = cached.map((a) => a.id).sort();
+      expect(ids).toEqual(["peer-a", "peer-b", "substrate-1"]);
+
+      substrateTree.stop();
+      transientTree.stop();
+      await pair.cleanup();
+    });
+
+    it("parseSeedAddress handles host:port and rejects malformed input", () => {
+      const tree = makeTreeManager(makeNodeInfo("t-1"), new GossipProtocol(makeNodeInfo("t-1"), 3, silentLogger()));
+      const parse = (s: string) =>
+        (tree as unknown as { parseSeedAddress: (s: string) => AlternativeParent | null })
+          .parseSeedAddress(s);
+
+      expect(parse("10.0.0.5:8080")).toEqual({
+        id: "seed-10.0.0.5:8080",
+        address: "10.0.0.5",
+        http_port: 8080,
+      });
+      // IPv6-style is split on lastIndexOf(":") so it works for [::1]:8080-style only;
+      // bare "::1:8080" would parse address="::1" port=8080. Acceptable for now.
+      expect(parse("host.example:443")).toEqual({
+        id: "seed-host.example:443",
+        address: "host.example",
+        http_port: 443,
+      });
+      // Malformed
+      expect(parse("no-colon")).toBeNull();
+      expect(parse(":8080")).toBeNull();
+      expect(parse("host:")).toBeNull();
+      expect(parse("host:notaport")).toBeNull();
+      expect(parse("host:0")).toBeNull();
+      expect(parse("host:99999")).toBeNull();
+
+      tree.stop();
+    });
+
+    it("close handler on a stale connection does not clobber the active parent", async () => {
+      const pairA = await createPair();
+      const pairB = await createPair();
+
+      const substrateA = makeNodeInfo("substrate-a");
+      const substrateAGossip = new GossipProtocol(substrateA, 3, silentLogger());
+      const substrateATree = makeTreeManager(substrateA, substrateAGossip);
+      pairA.serverConn.on("attachment", (msg: AttachmentMessage) => {
+        if (msg.type === "hello") {
+          substrateATree.handleHello(pairA.serverConn, msg.payload as HelloPayload);
+        }
+      });
+
+      const substrateB = makeNodeInfo("substrate-b");
+      const substrateBGossip = new GossipProtocol(substrateB, 3, silentLogger());
+      const substrateBTree = makeTreeManager(substrateB, substrateBGossip);
+      pairB.serverConn.on("attachment", (msg: AttachmentMessage) => {
+        if (msg.type === "hello") {
+          substrateBTree.handleHello(pairB.serverConn, msg.payload as HelloPayload);
+        }
+      });
+
+      const transient = makeNodeInfo("transient-1", { address: "10.0.0.1" });
+      const transientGossip = new GossipProtocol(transient, 3, silentLogger());
+      const transientTree = makeTreeManager(transient, transientGossip, { inbound: "false" });
+
+      // Attach to A.
+      const welcomeA = await transientTree.attach(pairA.clientConn);
+      expect(welcomeA).not.toBeNull();
+      expect(transientTree.parent).toBe(pairA.clientConn);
+
+      // Now attach to B (simulating a successful reattach to a new parent).
+      const welcomeB = await transientTree.attach(pairB.clientConn);
+      expect(welcomeB).not.toBeNull();
+      expect(transientTree.parent).toBe(pairB.clientConn);
+
+      // Close the OLD pairA connection. Its close handler must not
+      // clobber the current parent (B) — the identity check guards this.
+      pairA.clientConn.close();
+      // Give the close event a chance to fire.
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(transientTree.parent).toBe(pairB.clientConn);
+
+      substrateATree.stop();
+      substrateBTree.stop();
+      transientTree.stop();
+      await pairA.cleanup();
+      await pairB.cleanup();
+    });
+
+    it("ungraceful close on the active parent triggers the reattach loop", async () => {
+      const pair = await createPair();
+
+      const substrateNode = makeNodeInfo("substrate-1");
+      const substrateGossip = new GossipProtocol(substrateNode, 3, silentLogger());
+      const substrateTree = makeTreeManager(substrateNode, substrateGossip);
+      pair.serverConn.on("attachment", (msg: AttachmentMessage) => {
+        if (msg.type === "hello") {
+          substrateTree.handleHello(pair.serverConn, msg.payload as HelloPayload);
+        }
+      });
+
+      const transient = makeNodeInfo("transient-1", { address: "10.0.0.1" });
+      const transientGossip = new GossipProtocol(transient, 3, silentLogger());
+      const transientTree = makeTreeManager(transient, transientGossip, { inbound: "false" });
+
+      // Wire a seedProvider that records calls. The reattach loop walks
+      // cached topology first; substrate-1 is the only entry there and
+      // its address is the test pair's port — when we close pair.clientConn
+      // the substrate is still listening, so reattach to it would actually
+      // succeed. To force fall-through to the seed layer, replace cached
+      // alternatives with an unreachable address after attach.
+      let seedCalls = 0;
+      transientTree.setSeedProvider(() => {
+        seedCalls++;
+        return []; // empty seed list — loop will sleep then retry
+      });
+
+      const welcome = await transientTree.attach(pair.clientConn);
+      expect(welcome).not.toBeNull();
+
+      // Force cached alternatives to a single unreachable entry so the
+      // cached layer fails fast (5s timeout) and the loop falls through
+      // to the seed provider.
+      (transientTree as unknown as { lastKnownAlternatives: AlternativeParent[] })
+        .lastKnownAlternatives = [
+        { id: "ghost", address: "127.0.0.1", http_port: 1, enclave: "default" },
+      ];
+
+      // Close ungracefully — no goodbye sent.
+      pair.clientConn.close();
+
+      // Poll briefly for the seed provider to be hit. The cached entry
+      // (port 1) refuses TCP fast (sub-second), then the loop reaches
+      // the seed layer.
+      const deadline = Date.now() + 8_000;
+      while (seedCalls === 0 && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      expect(seedCalls).toBeGreaterThan(0);
+
+      // stop() must wake the reattach loop's backoff sleep.
+      substrateTree.stop();
+      transientTree.stop();
+      await pair.cleanup();
+    }, 15_000);
+
+    it("stop() sets stopping flag and resolves pending sleeps promptly", async () => {
+      const tree = makeTreeManager(makeNodeInfo("t-1"), new GossipProtocol(makeNodeInfo("t-1"), 3, silentLogger()));
+      const internal = tree as unknown as {
+        stopping: boolean;
+        sleep: (ms: number) => Promise<void>;
+      };
+
+      expect(internal.stopping).toBe(false);
+      // Start a long sleep that would normally block the reattach loop
+      // for 60s. stop() should wake it within milliseconds via the
+      // stopSignal race.
+      const sleepPromise = internal.sleep(60_000);
+
+      tree.stop();
+      expect(internal.stopping).toBe(true);
+
+      // Race the sleep resolution against a short timeout to confirm
+      // it actually unblocks (and isn't relying on the 60s timer firing).
+      const result = await Promise.race([
+        sleepPromise.then(() => "resolved"),
+        new Promise<string>((resolve) => setTimeout(() => resolve("hung"), 100)),
+      ]);
+      expect(result).toBe("resolved");
     });
   });
 });

--- a/repram-mcp/src/node/tree.ts
+++ b/repram-mcp/src/node/tree.ts
@@ -30,6 +30,37 @@ import type { GossipProtocol } from "./gossip.js";
 /** Default maximum number of transient node attachments. */
 export const DEFAULT_MAX_CHILDREN = 100;
 
+/** Initial backoff before retrying a failed reattach cycle. */
+export const REATTACH_BACKOFF_INITIAL_MS = 5_000;
+
+/** Cap on exponential backoff between full reattach cycles. */
+export const REATTACH_BACKOFF_MAX_MS = 60_000;
+
+/**
+ * Per-attempt connect timeout for cached-topology alternatives. Shorter
+ * than seed-list timeout because cached entries are speculative — they
+ * may have left the substrate since the cache was taken (#108).
+ */
+export const CACHED_ALT_CONNECT_TIMEOUT_MS = 5_000;
+
+/** Per-attempt connect timeout for fresh seed-list alternatives. */
+export const SEED_CONNECT_TIMEOUT_MS = 10_000;
+
+/**
+ * Total deadline for the cached-topology layer of a single reattach cycle.
+ * Without this cap, a stale cache with N entries could waste
+ * N × CACHED_ALT_CONNECT_TIMEOUT_MS before falling through to fresh seeds.
+ */
+export const CACHED_LAYER_DEADLINE_MS = 30_000;
+
+/** Alternative-parent shape used for reattach (matches goodbye payload). */
+export interface AlternativeParent {
+  id: string;
+  address: string;
+  http_port: number;
+  enclave?: string;
+}
+
 // --- Types ---
 
 export type NodeRole = "substrate" | "transient";
@@ -83,6 +114,35 @@ export class TreeManager {
   /** Whether a reattachment attempt is currently in progress. */
   private reattaching = false;
 
+  /**
+   * Snapshot of the substrate's topology captured from welcome at attach
+   * time. Used as the cached-alternatives layer for ungraceful-disconnect
+   * reattach (#108). Stale by definition — entries may have left the
+   * cluster since attach — so per-attempt and total-layer timeouts are
+   * shorter than the seed-list layer. Refreshing this during attach is
+   * out of scope and tracked by #67/#68.
+   */
+  private lastKnownAlternatives: AlternativeParent[] = [];
+
+  /**
+   * Returns the current bootstrap seed list (host:http-port). Used as
+   * the freshest reattach fallback when cached alternatives are exhausted.
+   * Wired in index.ts; mirrors the seedProvider pattern in ClusterNode (#85).
+   */
+  private seedProvider: (() => string[]) | null = null;
+
+  /** Set in stop(); causes the reattach loop and any sleeps to exit. */
+  private stopping = false;
+
+  /**
+   * Resolves when stop() is called. The reattach loop's backoff sleep
+   * races against this so a shutdown wakes it within milliseconds rather
+   * than waiting up to a full backoff interval. setTimeout naturally fires
+   * if shutdown doesn't intervene.
+   */
+  private stopSignal: Promise<void>;
+  private resolveStopSignal!: () => void;
+
   constructor(
     localNode: NodeInfo,
     gossip: GossipProtocol,
@@ -93,6 +153,9 @@ export class TreeManager {
     this.gossip = gossip;
     this.logger = logger;
     this.options = options;
+    this.stopSignal = new Promise<void>((resolve) => {
+      this.resolveStopSignal = resolve;
+    });
 
     // Resolve role from config: true = substrate, false = transient
     if (options.inbound === "true") {
@@ -132,6 +195,16 @@ export class TreeManager {
    */
   setReattachCallback(cb: (conn: WebSocketConnection) => void): void {
     this.onReattachCallback = cb;
+  }
+
+  /**
+   * Wire the seed-list provider used as the freshest reattach fallback.
+   * For public-network deployments this typically closes over the omega
+   * refresher's currentList; for private it snapshots REPRAM_PEERS.
+   * Null disables the seed-list layer (#108).
+   */
+  setSeedProvider(fn: (() => string[]) | null): void {
+    this.seedProvider = fn;
   }
 
   // --- Server-side: handle incoming attachments ---
@@ -312,29 +385,50 @@ export class TreeManager {
 
     conn.remoteNodeId = welcome.your_position.parent_id;
 
-    // Handle parent disconnection
-    conn.on("close", () => {
-      this.logger.warn(
-        `Substrate attachment to ${conn.remoteNodeId ?? "unknown"} lost`,
-      );
-      this.parentConnection = null;
-    });
+    // Snapshot the substrate's topology as cached reattach alternatives.
+    // Excludes self. Stale by definition; deadline + per-attempt-timeout
+    // bound the cost of trying ghosts before falling through to seeds (#108).
+    this.lastKnownAlternatives = [];
+    for (const sync of welcome.topology) {
+      const info = sync.node_info;
+      if (!info || info.id === this.localNode.id) continue;
+      this.lastKnownAlternatives.push({
+        id: info.id,
+        address: info.address,
+        http_port: info.http_port,
+        enclave: info.enclave,
+      });
+    }
 
-    // Handle goodbye from parent (graceful shutdown → proactive migration)
+    // Handle goodbye from parent (graceful shutdown → proactive migration).
+    // Identity-aware: only fires reattach if this conn is still our parent
+    // (a stale handler from a previous attach must not clobber a successful
+    // reattach to a new parent).
     conn.on("attachment", (msg: AttachmentMessage) => {
       if (msg.type === "goodbye") {
+        if (this.parentConnection !== conn) return;
         const payload = msg.payload as GoodbyePayload;
         this.logger.info(
           `Substrate node sent goodbye: ${payload.reason} ` +
             `(${payload.alternative_parents.length} alternatives)`,
         );
         this.parentConnection = null;
-
-        // Proactive migration — try alternatives before falling back to bootstrap
-        if (payload.alternative_parents.length > 0) {
-          this.reattachToAlternative(payload.alternative_parents);
-        }
+        void this.triggerReattach(payload.alternative_parents);
       }
+    });
+
+    // Handle parent disconnection (graceful close after goodbye, or
+    // ungraceful TCP drop / crash / NAT rebind). Identity-aware as above.
+    // For ungraceful disconnects there are no fresh goodbye-supplied
+    // alternatives, so triggerReattach falls through to cached topology
+    // and then the seed list (#108).
+    conn.on("close", () => {
+      if (this.parentConnection !== conn) return;
+      this.logger.warn(
+        `Substrate attachment to ${conn.remoteNodeId ?? "unknown"} lost`,
+      );
+      this.parentConnection = null;
+      void this.triggerReattach(undefined);
     });
 
     this.logger.info(
@@ -349,57 +443,160 @@ export class TreeManager {
   // --- Reattachment ---
 
   /**
-   * Attempt to reattach to an alternative substrate node after receiving
-   * a goodbye from the current parent. Tries each alternative in order,
-   * falls back to logged warning if all fail.
+   * Entry point for reattach. Single-flight via the `reattaching` flag —
+   * concurrent calls (e.g., goodbye handler and close handler firing
+   * back-to-back) collapse to one running loop. Pass goodbye-supplied
+   * alternatives if available; pass undefined for ungraceful disconnect
+   * (the loop will use cached topology and the seed list).
    *
-   * This is fire-and-forget — the transient node continues operating
-   * with local storage while reattachment is in progress.
+   * Fire-and-forget — the transient node continues serving local reads
+   * while reattach is in progress (#108).
    */
-  private async reattachToAlternative(
-    alternatives: GoodbyePayload["alternative_parents"],
+  private async triggerReattach(
+    suppliedAlternatives: AlternativeParent[] | undefined,
   ): Promise<void> {
-    if (this.reattaching) return; // prevent concurrent reattachment
+    if (this.reattaching || this.stopping) return;
     this.reattaching = true;
-
     try {
-      for (const alt of alternatives) {
-        try {
-          this.logger.info(
-            `Attempting reattachment to ${alt.id} (${alt.address}:${alt.http_port})`,
-          );
+      await this.reattachLoop(suppliedAlternatives);
+    } finally {
+      this.reattaching = false;
+    }
+  }
 
-          const conn = await connectToSubstrate(
-            alt.address,
-            alt.http_port,
-            this.options.clusterSecret,
-            this.logger,
-            10_000,
-          );
+  /**
+   * Full reattach loop with three layers, exponential backoff, and
+   * stop-aware sleeps. Runs until success or stop() (#108):
+   *
+   *   1. Goodbye payload alternatives (if any) — freshest, single-shot.
+   *   2. Cached `welcome.topology` from attach time — local, fast,
+   *      possibly stale. Bounded by per-attempt timeout AND total layer
+   *      deadline so a fully-stale cache can't waste minutes before
+   *      falling through.
+   *   3. Seed list from seedProvider — slowest but guaranteed-fresh.
+   *
+   * Between full cycles, sleeps with exponential backoff capped at
+   * REATTACH_BACKOFF_MAX_MS. Backoff resets implicitly on success
+   * (the loop returns).
+   */
+  private async reattachLoop(
+    suppliedAlternatives: AlternativeParent[] | undefined,
+  ): Promise<void> {
+    let backoffMs = REATTACH_BACKOFF_INITIAL_MS;
 
-          const welcome = await this.attach(conn);
-          if (welcome) {
-            this.logger.info(`Reattached to ${alt.id} — gossip resumed`);
+    while (!this.stopping) {
+      // Layer 1: supplied alternatives (goodbye payload). Used once on
+      // the first iteration if present; subsequent iterations skip this
+      // layer because the goodbye payload is no fresher than the cached
+      // topology by then.
+      if (suppliedAlternatives && suppliedAlternatives.length > 0) {
+        if (await this.tryAlternatives(suppliedAlternatives, SEED_CONNECT_TIMEOUT_MS, undefined)) {
+          return;
+        }
+        suppliedAlternatives = undefined;
+      }
 
-            // Notify server to set up message routing on new connection
-            this.onReattachCallback?.(conn);
-            conn.startHeartbeat();
-            return;
-          }
+      // Layer 2: cached welcome topology. Per-attempt 5s, layer total 30s.
+      if (this.lastKnownAlternatives.length > 0) {
+        const deadline = Date.now() + CACHED_LAYER_DEADLINE_MS;
+        if (await this.tryAlternatives(this.lastKnownAlternatives, CACHED_ALT_CONNECT_TIMEOUT_MS, deadline)) {
+          return;
+        }
+      }
 
-          conn.close();
-        } catch (err) {
-          this.logger.warn(`Reattachment to ${alt.id} failed: ${err}`);
+      // Layer 3: seed list. Per-attempt 10s; small N (typically 2-5).
+      const seeds = this.seedProvider?.() ?? [];
+      const seedAlts: AlternativeParent[] = [];
+      for (const seed of seeds) {
+        const parsed = this.parseSeedAddress(seed);
+        if (parsed !== null) seedAlts.push(parsed);
+      }
+      if (seedAlts.length > 0) {
+        if (await this.tryAlternatives(seedAlts, SEED_CONNECT_TIMEOUT_MS, undefined)) {
+          return;
         }
       }
 
       this.logger.warn(
-        "All alternative substrate nodes failed — operating in degraded mode " +
-          "(local store only until heartbeat-based reattachment or restart)",
+        `All reattach paths failed — sleeping ${backoffMs}ms before retry ` +
+          "(local store still serves reads; quorum writes degraded until reattach)",
       );
-    } finally {
-      this.reattaching = false;
+      await this.sleep(backoffMs);
+      backoffMs = Math.min(backoffMs * 2, REATTACH_BACKOFF_MAX_MS);
     }
+  }
+
+  /**
+   * Walk a list of alternative substrates, attempting WebSocket attach
+   * to each. Returns true on the first success. Honors stopping flag and
+   * an optional layer deadline for the cached-topology case.
+   */
+  private async tryAlternatives(
+    alts: AlternativeParent[],
+    perAttemptTimeoutMs: number,
+    deadlineMs: number | undefined,
+  ): Promise<boolean> {
+    for (const alt of alts) {
+      if (this.stopping) return false;
+      if (deadlineMs !== undefined && Date.now() >= deadlineMs) {
+        this.logger.warn(
+          "Cached-alternatives layer hit deadline; falling through to seed list",
+        );
+        return false;
+      }
+
+      this.logger.info(
+        `Attempting reattachment to ${alt.id} (${alt.address}:${alt.http_port})`,
+      );
+      try {
+        const conn = await connectToSubstrate(
+          alt.address,
+          alt.http_port,
+          this.options.clusterSecret,
+          this.logger,
+          perAttemptTimeoutMs,
+        );
+        const welcome = await this.attach(conn);
+        if (welcome) {
+          this.logger.info(`Reattached to ${alt.id} — gossip resumed`);
+          this.onReattachCallback?.(conn);
+          conn.startHeartbeat();
+          return true;
+        }
+        if (!conn.isClosed) conn.close();
+      } catch (err) {
+        this.logger.warn(`Reattachment to ${alt.id} failed: ${err}`);
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Parse a seed string of the form "host:http-port" into an
+   * AlternativeParent. Returns null on malformed input. The id is a
+   * synthetic label since seeds carry no node identity until attach.
+   */
+  private parseSeedAddress(seed: string): AlternativeParent | null {
+    const idx = seed.lastIndexOf(":");
+    if (idx <= 0 || idx === seed.length - 1) return null;
+    const address = seed.slice(0, idx);
+    const portStr = seed.slice(idx + 1);
+    const http_port = parseInt(portStr, 10);
+    if (isNaN(http_port) || http_port <= 0 || http_port > 65535) return null;
+    return { id: `seed-${seed}`, address, http_port };
+  }
+
+  /**
+   * Sleep for ms or until stop() is called, whichever comes first. Races
+   * a setTimeout against stopSignal so a shutdown wakes the reattach
+   * loop within milliseconds rather than at end-of-backoff.
+   */
+  private sleep(ms: number): Promise<void> {
+    if (this.stopping) return Promise.resolve();
+    return Promise.race([
+      new Promise<void>((resolve) => setTimeout(resolve, ms)),
+      this.stopSignal,
+    ]);
   }
 
   // --- Relay: ACK routing ---
@@ -504,9 +701,19 @@ export class TreeManager {
   }
 
   /**
-   * Clean shutdown: send goodbyes, clear state.
+   * Clean shutdown: send goodbyes, clear state, cancel any in-flight
+   * reattach loop and pending backoff sleeps.
    */
   stop(): void {
+    // Set stopping first so any close handlers that fire during teardown
+    // (when we close the parent below) short-circuit at triggerReattach.
+    this.stopping = true;
+
+    // Wake any sleeping backoff in the reattach loop so it observes
+    // stopping and exits promptly. setTimeout still fires later but its
+    // resolved promise is now harmless — the loop is gone.
+    this.resolveStopSignal();
+
     this.sendGoodbyeToChildren();
 
     // Clean up ACK route timers

--- a/repram-mcp/src/node/tree.ts
+++ b/repram-mcp/src/node/tree.ts
@@ -418,7 +418,14 @@ export class TreeManager {
     });
 
     // Handle parent disconnection (graceful close after goodbye, or
-    // ungraceful TCP drop / crash / NAT rebind). Identity-aware as above.
+    // ungraceful TCP drop / crash / NAT rebind). The `!== conn` guard
+    // catches two cases:
+    //   1. Stale handler: this conn was replaced by a successful reattach
+    //      to a new parent — parentConnection now points at the new conn.
+    //   2. Post-goodbye close: the goodbye handler already nulled
+    //      parentConnection, so `null !== conn` short-circuits triggering
+    //      a duplicate reattach (the single-flight flag would block it
+    //      anyway, but this avoids the spurious entry).
     // For ungraceful disconnects there are no fresh goodbye-supplied
     // alternatives, so triggerReattach falls through to cached topology
     // and then the seed list (#108).
@@ -558,6 +565,20 @@ export class TreeManager {
         );
         const welcome = await this.attach(conn);
         if (welcome) {
+          // Race guard: the conn could have dropped between welcome
+          // receipt and now. If its close handler already fired, it
+          // tried to triggerReattach but was blocked by the single-flight
+          // `reattaching` flag (we hold it). Returning true here would
+          // mark the cycle a success and exit the outer loop, leaving
+          // the node parentless with no further retry. Detect via
+          // identity + isClosed and treat as a per-alternative failure
+          // so the outer loop continues.
+          if (this.parentConnection !== conn || conn.isClosed) {
+            this.logger.warn(
+              `Reattachment to ${alt.id} dropped before activation; trying next`,
+            );
+            continue;
+          }
           this.logger.info(`Reattached to ${alt.id} — gossip resumed`);
           this.onReattachCallback?.(conn);
           conn.startHeartbeat();


### PR DESCRIPTION
## Summary

Closes #108. Pre-fix, a transient TS node lost its substrate parent permanently if the WebSocket closed ungracefully (TCP drop, crash, NAT rebind). Only the graceful goodbye path triggered reattachment; the ungraceful close handler nulled `parentConnection`, logged a warning referencing nonexistent "heartbeat-based reattachment," and left the node operating degraded until restart. On residential networks where ungraceful disconnects are routine (parent restarts that don't go through clean shutdown, NAT rebinds), this made the transient role unreliable.

## Design (walked through pre-implementation)

**Unified close handler.** Both graceful (goodbye-then-close) and ungraceful paths flow through `triggerReattach`. Graceful supplies the goodbye-payload alternatives; ungraceful supplies undefined and the loop falls back to cached topology then the seed list.

**Three-layer alternatives lookup**, attempted once per cycle:

| # | Source | Per-attempt timeout | Total layer cap | Notes |
|---|--------|---------------------|------------------|-------|
| 1 | Goodbye-payload alternatives | 10s | n/a | First iteration only if present |
| 2 | Cached `welcome.topology` from attach time | 5s | 30s | Stale by definition; fast-fail on TCP refused, cap on blackhole |
| 3 | Seed list (`setSeedProvider`) | 10s | n/a | Public: omega refresher's currentList; private: REPRAM_PEERS snapshot |

The cached-layer per-attempt timeout is shorter than the seed layer because cached entries are speculative — a substrate that left the cluster fails fast on TCP refused. The 30s total cap bounds the worst case (blackhole holes in a fully-stale cache) so the loop reaches fresh seeds without minutes of waste.

**Exponential backoff** between full cycles: 5s → 10s → 30s → 60s, capped. Retries forever (until success or `stop()`) — same philosophy as #85's isolation recovery. The transient stays alive and keeps trying; operators detect "stuck retrying" via metrics rather than detect-and-restart.

**Concurrency.** Single-flight via the existing `reattaching` flag. `stop()`-aware:
- `stopping` flag short-circuits `triggerReattach`
- `stopSignal` Promise races against backoff sleep so shutdown wakes the loop within milliseconds rather than at end-of-backoff
- Identity-aware close/goodbye handlers (`if (this.parentConnection !== conn) return`) don't clobber a new parent when a stale connection's events fire after a successful reattach

## Tests (+5)

- `captures welcome.topology as cached alternatives, excluding self`
- `parseSeedAddress handles host:port and rejects malformed input`
- `close handler on a stale connection does not clobber the active parent` (identity check)
- `ungraceful close on the active parent triggers the reattach loop` (verified via observable seedProvider call)
- `stop() sets stopping flag and resolves pending sleeps promptly` (races stopSignal against a 60s sleep)

**Suite results:** TS 376/376 (was 371, +5). Go unchanged.

## Out of scope (acknowledged)

- **Refreshing `lastKnownAlternatives` during attach.** The cached topology is captured at attach time and never refreshed. Overlaps with #67/#68 (Phase 3 attachment migration) which is the place to address dynamic topology awareness. Deferred deliberately.
- **Parallel cached-layer attempts via `Promise.race`.** Sequential walk with fail-fast timeout + 30s layer cap is sufficient. Adding parallel attempts would require abort-signal support in `connectToSubstrate`. Filed mentally as future optimization if cache-staleness becomes a real operational issue.
- **Metrics.** Reattach counts and time-to-recover would help operators detect stuck transients. Separate concern; could land alongside #16 (public dashboard).

## Test plan
- [ ] CI green
- [ ] Manual: spin up a substrate + transient locally; SIGKILL the substrate; verify the transient logs reattach attempts and recovers when the substrate restarts
- [ ] Verify the existing graceful-goodbye path still works (covered by existing `reattachment on goodbye` test)

## Closes
Closes #108

// ticktockbent