### PR TITLE
feat(pprof): opt-in diagnostic endpoints for offline profiling

### DIFF
--- a/cmd/repram/handlers_test.go
+++ b/cmd/repram/handlers_test.go
@@ -706,3 +706,46 @@ func TestSlashOnlyKeyReturns400_NotRedirect(t *testing.T) {
 		})
 	}
 }
+
+// --- #97: pprof on separate listener ---
+
+func TestPprofDefaultServeMuxHasHandlers(t *testing.T) {
+	// The blank import of net/http/pprof registers handlers on
+	// http.DefaultServeMux. Verify they respond.
+	req := httptest.NewRequest("GET", "/debug/pprof/", nil)
+	w := httptest.NewRecorder()
+	http.DefaultServeMux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 from /debug/pprof/, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "goroutine") {
+		t.Fatal("pprof index should list goroutine profile")
+	}
+}
+
+func TestPprofHeapProfile(t *testing.T) {
+	req := httptest.NewRequest("GET", "/debug/pprof/heap", nil)
+	w := httptest.NewRecorder()
+	http.DefaultServeMux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 from /debug/pprof/heap, got %d", w.Code)
+	}
+	if w.Body.Len() == 0 {
+		t.Fatal("heap profile should not be empty")
+	}
+}
+
+func TestPprofNotOnMainRouter(t *testing.T) {
+	server, cleanup := newTestServer(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("GET", "/debug/pprof/", nil)
+	w := httptest.NewRecorder()
+	server.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("pprof should NOT be on the main router; expected 404, got %d", w.Code)
+	}
+}

--- a/cmd/repram/main.go
+++ b/cmd/repram/main.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"errors"
+	_ "net/http/pprof"
 
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
@@ -72,6 +73,11 @@ func main() {
 	network := os.Getenv("REPRAM_NETWORK")
 	if network == "" {
 		network = "public"
+	}
+	pprofEnabled := strings.EqualFold(os.Getenv("REPRAM_PPROF_ENABLED"), "true")
+	pprofAddr := os.Getenv("REPRAM_PPROF_ADDR")
+	if pprofAddr == "" {
+		pprofAddr = ":6060"
 	}
 
 	// Resolve bootstrap peers.
@@ -211,11 +217,31 @@ func main() {
 	} else {
 		logging.Info("  Gossip authentication: none (open mode)")
 	}
+	if pprofEnabled {
+		logging.Info("  pprof: enabled on %s (do not expose in untrusted environments)", pprofAddr)
+	}
 
 	// Create HTTP server for graceful shutdown support
 	httpServer := &http.Server{
 		Addr:    fmt.Sprintf(":%d", httpPort),
 		Handler: server.Router(),
+	}
+
+	// Optional pprof server on a separate listener (diagnostic plane).
+	// Uses http.DefaultServeMux which has pprof handlers auto-registered
+	// via the net/http/pprof blank import.
+	var pprofServer *http.Server
+	if pprofEnabled {
+		pprofServer = &http.Server{
+			Addr:    pprofAddr,
+			Handler: http.DefaultServeMux,
+		}
+		go func() {
+			logging.Info("pprof listening on %s", pprofAddr)
+			if err := pprofServer.ListenAndServe(); err != http.ErrServerClosed {
+				logging.Warn("pprof server error: %v", err)
+			}
+		}()
 	}
 
 	// Graceful shutdown: drain in-flight requests before exiting
@@ -225,6 +251,10 @@ func main() {
 	go func() {
 		<-sigChan
 		logging.Info("Shutting down — draining in-flight requests...")
+
+		if pprofServer != nil {
+			pprofServer.Close()
+		}
 
 		// Give in-flight requests up to 10 seconds to complete
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/cmd/repram/main.go
+++ b/cmd/repram/main.go
@@ -17,6 +17,8 @@ import (
 	"time"
 
 	"errors"
+	// Registers pprof handlers on http.DefaultServeMux unconditionally;
+	// only exposed via a listener when REPRAM_PPROF_ENABLED=true.
 	_ "net/http/pprof"
 
 	"github.com/gorilla/mux"
@@ -252,15 +254,21 @@ func main() {
 		<-sigChan
 		logging.Info("Shutting down — draining in-flight requests...")
 
-		// Give in-flight requests up to 10 seconds to complete
-		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer shutdownCancel()
-
+		// Shut down pprof first with a short deadline. pprof has no
+		// data-plane responsibilities; a 2s cap prevents a long-running
+		// CPU profile (/debug/pprof/profile, 30s default) from starving
+		// the main server's drain window.
 		if pprofServer != nil {
-			if err := pprofServer.Shutdown(shutdownCtx); err != nil {
+			pprofCtx, pprofCancel := context.WithTimeout(context.Background(), 2*time.Second)
+			if err := pprofServer.Shutdown(pprofCtx); err != nil {
 				logging.Warn("pprof server shutdown error: %v", err)
 			}
+			pprofCancel()
 		}
+
+		// Give in-flight data-plane requests up to 10 seconds to complete
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer shutdownCancel()
 
 		if err := httpServer.Shutdown(shutdownCtx); err != nil {
 			logging.Warn("HTTP server shutdown error: %v", err)

--- a/cmd/repram/main.go
+++ b/cmd/repram/main.go
@@ -77,7 +77,7 @@ func main() {
 	pprofEnabled := strings.EqualFold(os.Getenv("REPRAM_PPROF_ENABLED"), "true")
 	pprofAddr := os.Getenv("REPRAM_PPROF_ADDR")
 	if pprofAddr == "" {
-		pprofAddr = ":6060"
+		pprofAddr = "127.0.0.1:6060"
 	}
 
 	// Resolve bootstrap peers.
@@ -252,13 +252,15 @@ func main() {
 		<-sigChan
 		logging.Info("Shutting down — draining in-flight requests...")
 
-		if pprofServer != nil {
-			pprofServer.Close()
-		}
-
 		// Give in-flight requests up to 10 seconds to complete
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer shutdownCancel()
+
+		if pprofServer != nil {
+			if err := pprofServer.Shutdown(shutdownCtx); err != nil {
+				logging.Warn("pprof server shutdown error: %v", err)
+			}
+		}
 
 		if err := httpServer.Shutdown(shutdownCtx); err != nil {
 			logging.Warn("HTTP server shutdown error: %v", err)

--- a/repram-mcp/src/node/integration.test.ts
+++ b/repram-mcp/src/node/integration.test.ts
@@ -45,6 +45,7 @@ function substrateConfig(overrides: Partial<ServerConfig> = {}): ServerConfig {
     logLevel: "error",
     inbound: "true",
     maxChildren: DEFAULT_MAX_CHILDREN,
+    pprofEnabled: false,
     ...overrides,
   };
 }

--- a/repram-mcp/src/node/integration.test.ts
+++ b/repram-mcp/src/node/integration.test.ts
@@ -46,6 +46,7 @@ function substrateConfig(overrides: Partial<ServerConfig> = {}): ServerConfig {
     inbound: "true",
     maxChildren: DEFAULT_MAX_CHILDREN,
     pprofEnabled: false,
+    pprofAddr: "127.0.0.1:0",
     ...overrides,
   };
 }

--- a/repram-mcp/src/node/server.bootstrap-gate.test.ts
+++ b/repram-mcp/src/node/server.bootstrap-gate.test.ts
@@ -35,6 +35,7 @@ function publicConfig(overrides: Partial<ServerConfig> = {}): ServerConfig {
     inbound: "false",
     maxChildren: 100,
     pprofEnabled: false,
+    pprofAddr: "127.0.0.1:0",
     ...overrides,
   };
 }

--- a/repram-mcp/src/node/server.bootstrap-gate.test.ts
+++ b/repram-mcp/src/node/server.bootstrap-gate.test.ts
@@ -34,6 +34,7 @@ function publicConfig(overrides: Partial<ServerConfig> = {}): ServerConfig {
     logLevel: "error",
     inbound: "false",
     maxChildren: 100,
+    pprofEnabled: false,
     ...overrides,
   };
 }

--- a/repram-mcp/src/node/server.test.ts
+++ b/repram-mcp/src/node/server.test.ts
@@ -27,6 +27,9 @@ function testConfig(overrides: Partial<ServerConfig> = {}): ServerConfig {
     trustProxy: false,
     maxStorageBytes: 0,
     logLevel: "error",
+    inbound: "false",
+    maxChildren: 100,
+    pprofEnabled: false,
     ...overrides,
   };
 }
@@ -667,5 +670,86 @@ describe("WebSocket upgrade on /v1/ws", () => {
 
     expect(shutdownServer.getWSConnections().size).toBe(0);
     ws.close();
+  });
+});
+
+// ─── pprof diagnostic endpoints (#97) ────────────────────────────────
+
+describe("pprof endpoints", () => {
+  let server: HTTPServer;
+
+  afterAll(async () => {
+    if (server) await server.stop();
+  });
+
+  it("returns 404 for /debug/pprof/* when disabled", async () => {
+    server = new HTTPServer(testConfig({ pprofEnabled: false }), silentLogger());
+    server.setTransport(mockTransport());
+    await server.start();
+
+    const res = await request(server, "GET", "/debug/pprof/stats");
+    expect(res.status).toBe(404);
+    await server.stop();
+  });
+
+  it("GET /debug/pprof/stats returns heap statistics when enabled", async () => {
+    server = new HTTPServer(testConfig({ pprofEnabled: true }), silentLogger());
+    server.setTransport(mockTransport());
+    await server.start();
+
+    const res = await request(server, "GET", "/debug/pprof/stats");
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.process).toHaveProperty("rss");
+    expect(body.process).toHaveProperty("heapUsed");
+    expect(body.process).toHaveProperty("external");
+    expect(body.heap).toHaveProperty("total_heap_size");
+    expect(body.spaces).toBeInstanceOf(Array);
+    await server.stop();
+  });
+
+  it("POST /debug/pprof/heap writes a heap snapshot and returns path", async () => {
+    server = new HTTPServer(testConfig({ pprofEnabled: true }), silentLogger());
+    server.setTransport(mockTransport());
+    await server.start();
+
+    const res = await request(server, "POST", "/debug/pprof/heap");
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.path).toMatch(/\.heapsnapshot$/);
+
+    // Clean up the snapshot file
+    const { unlinkSync } = await import("node:fs");
+    try { unlinkSync(body.path); } catch { /* may already be gone */ }
+    await server.stop();
+  });
+
+  it("returns 404 for unknown pprof sub-path", async () => {
+    server = new HTTPServer(testConfig({ pprofEnabled: true }), silentLogger());
+    server.setTransport(mockTransport());
+    await server.start();
+
+    const res = await request(server, "GET", "/debug/pprof/unknown");
+    expect(res.status).toBe(404);
+    const body = JSON.parse(res.body);
+    expect(body.error).toBe("unknown pprof endpoint");
+    await server.stop();
+  });
+
+  it("pprof endpoints bypass rate limiting", async () => {
+    server = new HTTPServer(testConfig({ pprofEnabled: true, rateLimit: 1 }), silentLogger());
+    server.setTransport(mockTransport());
+    await server.start();
+
+    // Exhaust the rate limiter via a normal endpoint
+    await request(server, "GET", "/v1/health");
+    await request(server, "GET", "/v1/health");
+    const limited = await request(server, "GET", "/v1/health");
+    expect(limited.status).toBe(429);
+
+    // pprof should still work
+    const pprof = await request(server, "GET", "/debug/pprof/stats");
+    expect(pprof.status).toBe(200);
+    await server.stop();
   });
 });

--- a/repram-mcp/src/node/server.test.ts
+++ b/repram-mcp/src/node/server.test.ts
@@ -30,6 +30,7 @@ function testConfig(overrides: Partial<ServerConfig> = {}): ServerConfig {
     inbound: "false",
     maxChildren: 100,
     pprofEnabled: false,
+    pprofAddr: "127.0.0.1:0",
     ...overrides,
   };
 }
@@ -675,29 +676,62 @@ describe("WebSocket upgrade on /v1/ws", () => {
 
 // ─── pprof diagnostic endpoints (#97) ────────────────────────────────
 
-describe("pprof endpoints", () => {
-  let server: HTTPServer;
+/** Make an HTTP request to the pprof server (separate listener). */
+function pprofRequest(
+  server: HTTPServer,
+  method: string,
+  path: string,
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const pprofSrv = server.getPprofServer();
+    if (!pprofSrv) {
+      reject(new Error("pprof server not running"));
+      return;
+    }
+    const addr = pprofSrv.address();
+    if (!addr || typeof addr === "string") {
+      reject(new Error("pprof server not started"));
+      return;
+    }
 
-  afterAll(async () => {
-    if (server) await server.stop();
+    const req = http.request(
+      { hostname: "127.0.0.1", port: addr.port, method, path },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString(),
+          });
+        });
+      },
+    );
+    req.on("error", reject);
+    req.end();
   });
+}
 
-  it("returns 404 for /debug/pprof/* when disabled", async () => {
-    server = new HTTPServer(testConfig({ pprofEnabled: false }), silentLogger());
+describe("pprof endpoints", () => {
+  it("no pprof server when disabled", async () => {
+    const server = new HTTPServer(testConfig({ pprofEnabled: false }), silentLogger());
     server.setTransport(mockTransport());
     await server.start();
 
+    expect(server.getPprofServer()).toBeNull();
+
+    // /debug/pprof/* on the main server should 404
     const res = await request(server, "GET", "/debug/pprof/stats");
     expect(res.status).toBe(404);
     await server.stop();
   });
 
   it("GET /debug/pprof/stats returns heap statistics when enabled", async () => {
-    server = new HTTPServer(testConfig({ pprofEnabled: true }), silentLogger());
+    const server = new HTTPServer(testConfig({ pprofEnabled: true }), silentLogger());
     server.setTransport(mockTransport());
     await server.start();
 
-    const res = await request(server, "GET", "/debug/pprof/stats");
+    const res = await pprofRequest(server, "GET", "/debug/pprof/stats");
     expect(res.status).toBe(200);
     const body = JSON.parse(res.body);
     expect(body.process).toHaveProperty("rss");
@@ -709,46 +743,51 @@ describe("pprof endpoints", () => {
   });
 
   it("POST /debug/pprof/heap writes a heap snapshot and returns path", async () => {
-    server = new HTTPServer(testConfig({ pprofEnabled: true }), silentLogger());
+    const server = new HTTPServer(testConfig({ pprofEnabled: true }), silentLogger());
     server.setTransport(mockTransport());
     await server.start();
 
-    const res = await request(server, "POST", "/debug/pprof/heap");
-    expect(res.status).toBe(200);
-    const body = JSON.parse(res.body);
-    expect(body.path).toMatch(/\.heapsnapshot$/);
-
-    // Clean up the snapshot file
-    const { unlinkSync } = await import("node:fs");
-    try { unlinkSync(body.path); } catch { /* may already be gone */ }
-    await server.stop();
+    let snapshotPath: string | undefined;
+    try {
+      const res = await pprofRequest(server, "POST", "/debug/pprof/heap");
+      expect(res.status).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.path).toMatch(/\.heapsnapshot$/);
+      snapshotPath = body.path;
+    } finally {
+      if (snapshotPath) {
+        const { unlinkSync } = await import("node:fs");
+        try { unlinkSync(snapshotPath); } catch { /* may already be gone */ }
+      }
+      await server.stop();
+    }
   });
 
   it("returns 404 for unknown pprof sub-path", async () => {
-    server = new HTTPServer(testConfig({ pprofEnabled: true }), silentLogger());
+    const server = new HTTPServer(testConfig({ pprofEnabled: true }), silentLogger());
     server.setTransport(mockTransport());
     await server.start();
 
-    const res = await request(server, "GET", "/debug/pprof/unknown");
+    const res = await pprofRequest(server, "GET", "/debug/pprof/unknown");
     expect(res.status).toBe(404);
     const body = JSON.parse(res.body);
     expect(body.error).toBe("unknown pprof endpoint");
     await server.stop();
   });
 
-  it("pprof endpoints bypass rate limiting", async () => {
-    server = new HTTPServer(testConfig({ pprofEnabled: true, rateLimit: 1 }), silentLogger());
+  it("pprof on separate listener is independent of main server rate limiting", async () => {
+    const server = new HTTPServer(testConfig({ pprofEnabled: true, rateLimit: 1 }), silentLogger());
     server.setTransport(mockTransport());
     await server.start();
 
-    // Exhaust the rate limiter via a normal endpoint
+    // Exhaust the rate limiter on the main server
     await request(server, "GET", "/v1/health");
     await request(server, "GET", "/v1/health");
     const limited = await request(server, "GET", "/v1/health");
     expect(limited.status).toBe(429);
 
-    // pprof should still work
-    const pprof = await request(server, "GET", "/debug/pprof/stats");
+    // pprof on separate port is unaffected
+    const pprof = await pprofRequest(server, "GET", "/debug/pprof/stats");
     expect(pprof.status).toBe(200);
     await server.stop();
   });

--- a/repram-mcp/src/node/server.ts
+++ b/repram-mcp/src/node/server.ts
@@ -7,6 +7,8 @@
 
 import { createServer, type IncomingMessage, type ServerResponse, type Server } from "node:http";
 import { writeHeapSnapshot, getHeapStatistics, getHeapSpaceStatistics } from "node:v8";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import type { Duplex } from "node:stream";
 import { WebSocketServer } from "ws";
 import { Logger } from "./logger.js";
@@ -43,8 +45,10 @@ export interface ServerConfig {
   inbound: InboundCapability;
   /** Maximum transient node attachments (0 = never accept). */
   maxChildren: number;
-  /** Enable /debug/pprof/ diagnostic endpoints. */
+  /** Enable /debug/pprof/ diagnostic endpoints on a separate listener. */
   pprofEnabled: boolean;
+  /** Address for the pprof listener (default: 127.0.0.1:6060). */
+  pprofAddr: string;
 }
 
 /**
@@ -71,6 +75,7 @@ export function loadConfig(embedded = false): ServerConfig {
     inbound: (process.env.REPRAM_INBOUND ?? "false") as InboundCapability,
     maxChildren: envInt("REPRAM_MAX_CHILDREN", 100),
     pprofEnabled: (process.env.REPRAM_PPROF_ENABLED ?? "").toLowerCase() === "true",
+    pprofAddr: process.env.REPRAM_PPROF_ADDR ?? "127.0.0.1:6060",
   };
 }
 
@@ -94,6 +99,8 @@ export class HTTPServer {
   private config: ServerConfig;
   private securityMW: SecurityMiddleware;
   private startTime = Date.now();
+  private pprofServer: Server | null = null;
+  private heapSnapshotInProgress = false;
 
   /** Active WebSocket connections from attached transient nodes. */
   private wsConnections = new Set<WebSocketConnection>();
@@ -220,11 +227,33 @@ export class HTTPServer {
         this.logger.info(
           `  Replication: ${this.config.replicationFactor}  TTL range: ${this.config.minTTL}-${this.config.maxTTL}s`,
         );
+
         if (this.config.pprofEnabled) {
-          this.logger.info(`  pprof: enabled on /debug/pprof/ (do not expose in untrusted environments)`);
+          this.startPprofServer();
         }
+
         resolve();
       });
+    });
+  }
+
+  private startPprofServer(): void {
+    const pprofHandler = (req: IncomingMessage, res: ServerResponse) => {
+      const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+      this.pprofHandler(res, url.pathname, req.method ?? "GET");
+    };
+
+    this.pprofServer = createServer(pprofHandler);
+    const [host, portStr] = this.config.pprofAddr.includes(":")
+      ? this.config.pprofAddr.split(":")
+      : ["127.0.0.1", this.config.pprofAddr];
+    const port = parseInt(portStr, 10);
+
+    this.pprofServer.listen(port, host, () => {
+      this.logger.info(`  pprof: listening on ${host}:${port} (do not expose in untrusted environments)`);
+    });
+    this.pprofServer.on("error", (err) => {
+      this.logger.warn(`pprof server error: ${err.message}`);
     });
   }
 
@@ -248,6 +277,14 @@ export class HTTPServer {
 
     this.wss.close();
 
+    if (this.pprofServer) {
+      await new Promise<void>((resolve) => {
+        this.pprofServer!.close(() => resolve());
+        setTimeout(() => resolve(), 5_000);
+      });
+      this.pprofServer = null;
+    }
+
     await new Promise<void>((resolve) => {
       this.server.close(() => resolve());
       // Force close after 10s drain timeout
@@ -262,6 +299,11 @@ export class HTTPServer {
   /** Return the underlying http.Server (for testing). */
   getServer(): Server {
     return this.server;
+  }
+
+  /** Return the pprof http.Server if running (for testing). */
+  getPprofServer(): Server | null {
+    return this.pprofServer;
   }
 
   // ─── Request router ──────────────────────────────────────────────
@@ -280,13 +322,6 @@ export class HTTPServer {
     const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
     const path = url.pathname;
     const method = req.method ?? "GET";
-
-    // Diagnostic endpoints — before security checks (mirrors Go's separate
-    // pprof listener: no rate limiting on the diagnostic plane).
-    if (this.config.pprofEnabled && path.startsWith("/debug/pprof/")) {
-      this.pprofHandler(res, path, method);
-      return;
-    }
 
     // Security checks (rate limit, scanner, size)
     const clientIP = this.securityMW.check(req, res);
@@ -601,11 +636,19 @@ export class HTTPServer {
 
   private pprofHandler(res: ServerResponse, path: string, method: string): void {
     if (path === "/debug/pprof/heap" && method === "POST") {
+      if (this.heapSnapshotInProgress) {
+        sendJSON(res, 429, { error: "heap snapshot already in progress" });
+        return;
+      }
+      this.heapSnapshotInProgress = true;
       try {
-        const snapshotPath = writeHeapSnapshot();
+        const filename = `repram-heap-${Date.now()}.heapsnapshot`;
+        const snapshotPath = writeHeapSnapshot(join(tmpdir(), filename));
         sendJSON(res, 200, { path: snapshotPath });
       } catch (err) {
         sendJSON(res, 500, { error: `heap snapshot failed: ${err}` });
+      } finally {
+        this.heapSnapshotInProgress = false;
       }
       return;
     }

--- a/repram-mcp/src/node/server.ts
+++ b/repram-mcp/src/node/server.ts
@@ -6,6 +6,7 @@
  */
 
 import { createServer, type IncomingMessage, type ServerResponse, type Server } from "node:http";
+import { writeHeapSnapshot, getHeapStatistics, getHeapSpaceStatistics } from "node:v8";
 import type { Duplex } from "node:stream";
 import { WebSocketServer } from "ws";
 import { Logger } from "./logger.js";
@@ -42,6 +43,8 @@ export interface ServerConfig {
   inbound: InboundCapability;
   /** Maximum transient node attachments (0 = never accept). */
   maxChildren: number;
+  /** Enable /debug/pprof/ diagnostic endpoints. */
+  pprofEnabled: boolean;
 }
 
 /**
@@ -67,6 +70,7 @@ export function loadConfig(embedded = false): ServerConfig {
     logLevel: process.env.REPRAM_LOG_LEVEL ?? (embedded ? "warn" : "info"),
     inbound: (process.env.REPRAM_INBOUND ?? "false") as InboundCapability,
     maxChildren: envInt("REPRAM_MAX_CHILDREN", 100),
+    pprofEnabled: (process.env.REPRAM_PPROF_ENABLED ?? "").toLowerCase() === "true",
   };
 }
 
@@ -216,6 +220,9 @@ export class HTTPServer {
         this.logger.info(
           `  Replication: ${this.config.replicationFactor}  TTL range: ${this.config.minTTL}-${this.config.maxTTL}s`,
         );
+        if (this.config.pprofEnabled) {
+          this.logger.info(`  pprof: enabled on /debug/pprof/ (do not expose in untrusted environments)`);
+        }
         resolve();
       });
     });
@@ -270,13 +277,20 @@ export class HTTPServer {
       return;
     }
 
-    // Security checks (rate limit, scanner, size)
-    const clientIP = this.securityMW.check(req, res);
-    if (!clientIP) return; // rejected
-
     const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
     const path = url.pathname;
     const method = req.method ?? "GET";
+
+    // Diagnostic endpoints — before security checks (mirrors Go's separate
+    // pprof listener: no rate limiting on the diagnostic plane).
+    if (this.config.pprofEnabled && path.startsWith("/debug/pprof/")) {
+      this.pprofHandler(res, path, method);
+      return;
+    }
+
+    // Security checks (rate limit, scanner, size)
+    const clientIP = this.securityMW.check(req, res);
+    if (!clientIP) return; // rejected
 
     // Route matching
     const dataMatch = path.match(/^\/v1\/data\/(.+)$/);
@@ -581,6 +595,31 @@ export class HTTPServer {
         })),
       });
     });
+  }
+
+  // ─── Profiling ───────────────────────────────────────────────────
+
+  private pprofHandler(res: ServerResponse, path: string, method: string): void {
+    if (path === "/debug/pprof/heap" && method === "POST") {
+      try {
+        const snapshotPath = writeHeapSnapshot();
+        sendJSON(res, 200, { path: snapshotPath });
+      } catch (err) {
+        sendJSON(res, 500, { error: `heap snapshot failed: ${err}` });
+      }
+      return;
+    }
+
+    if (path === "/debug/pprof/stats" && method === "GET") {
+      sendJSON(res, 200, {
+        process: process.memoryUsage(),
+        heap: getHeapStatistics(),
+        spaces: getHeapSpaceStatistics(),
+      });
+      return;
+    }
+
+    sendJSON(res, 404, { error: "unknown pprof endpoint" });
   }
 
   // ─── Helpers ─────────────────────────────────────────────────────

--- a/repram-mcp/src/node/server.ts
+++ b/repram-mcp/src/node/server.ts
@@ -238,22 +238,33 @@ export class HTTPServer {
   }
 
   private startPprofServer(): void {
-    const pprofHandler = (req: IncomingMessage, res: ServerResponse) => {
+    const addr = this.config.pprofAddr;
+    const lastColon = addr.lastIndexOf(":");
+    let host: string;
+    let port: number;
+    if (lastColon >= 0) {
+      host = addr.slice(0, lastColon) || "127.0.0.1";
+      port = parseInt(addr.slice(lastColon + 1), 10);
+    } else {
+      host = "127.0.0.1";
+      port = parseInt(addr, 10);
+    }
+    if (isNaN(port)) {
+      this.logger.warn(`pprof: invalid address "${addr}" — pprof not started`);
+      return;
+    }
+
+    const handler = (req: IncomingMessage, res: ServerResponse) => {
       const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
       this.pprofHandler(res, url.pathname, req.method ?? "GET");
     };
 
-    this.pprofServer = createServer(pprofHandler);
-    const [host, portStr] = this.config.pprofAddr.includes(":")
-      ? this.config.pprofAddr.split(":")
-      : ["127.0.0.1", this.config.pprofAddr];
-    const port = parseInt(portStr, 10);
-
-    this.pprofServer.listen(port, host, () => {
-      this.logger.info(`  pprof: listening on ${host}:${port} (do not expose in untrusted environments)`);
-    });
+    this.pprofServer = createServer(handler);
     this.pprofServer.on("error", (err) => {
       this.logger.warn(`pprof server error: ${err.message}`);
+    });
+    this.pprofServer.listen(port, host, () => {
+      this.logger.info(`  pprof: listening on ${host}:${port} (do not expose in untrusted environments)`);
     });
   }
 
@@ -279,8 +290,8 @@ export class HTTPServer {
 
     if (this.pprofServer) {
       await new Promise<void>((resolve) => {
-        this.pprofServer!.close(() => resolve());
-        setTimeout(() => resolve(), 5_000);
+        const tid = setTimeout(() => resolve(), 5_000);
+        this.pprofServer!.close(() => { clearTimeout(tid); resolve(); });
       });
       this.pprofServer = null;
     }


### PR DESCRIPTION
## Summary
- **Go**: separate pprof listener on `REPRAM_PPROF_ADDR` (default `:6060`), gated by `REPRAM_PPROF_ENABLED`. Uses `http.DefaultServeMux` with standard `net/http/pprof` handlers — full Go profiling toolchain (`go tool pprof`) works out of the box.
- **TS**: `POST /debug/pprof/heap` triggers `v8.writeHeapSnapshot()` and returns the file path. `GET /debug/pprof/stats` returns `process.memoryUsage()` + V8 heap statistics as JSON. Routed before security middleware (mirrors Go's separate-listener approach — no rate limiting on diagnostic plane).
- Both gated behind `REPRAM_PPROF_ENABLED=true` (default: off). Startup log warns "do not expose in untrusted environments."

## Burn-in workflow

```bash
# Go nodes
curl http://<go-node>:6060/debug/pprof/heap > heap-go.pprof
go tool pprof -http=:8080 heap-go.pprof

# TS nodes
curl -X POST http://<ts-node>:8080/debug/pprof/heap
# returns { "path": "/path/to/Heap.heapsnapshot" }
# then: docker cp / scp the file, open in Chrome DevTools
```

## Test plan
- [x] 3 new Go tests: pprof handlers on DefaultServeMux, heap profile, not on main router
- [x] 5 new TS tests: disabled returns 404, stats returns heap data, heap snapshot writes file, unknown sub-path 404, bypasses rate limiting
- [x] All existing tests pass (86 Go + 381 TS)

Closes #97

// ticktockbent