### PR TITLE
fix(transport): drain fetch response bodies to release sockets

### DIFF
--- a/repram-mcp/src/client.ts
+++ b/repram-mcp/src/client.ts
@@ -96,6 +96,7 @@ export class RepramClient implements RepramClientInterface {
       body: data,
     });
 
+    await response.text();
     return {
       status: response.status,
       statusText: response.statusText,
@@ -105,6 +106,8 @@ export class RepramClient implements RepramClientInterface {
   async retrieve(key: string): Promise<RetrieveResult | null> {
     const response = await fetch(`${this.baseUrl}/v1/data/${encodeURIComponent(key)}`);
 
+    const data = await response.text();
+
     if (response.status === 404) {
       return null;
     }
@@ -112,8 +115,6 @@ export class RepramClient implements RepramClientInterface {
     if (!response.ok) {
       throw new Error(`REPRAM retrieve failed: ${response.status} ${response.statusText}`);
     }
-
-    const data = await response.text();
     const createdAt = response.headers.get("X-Created-At") ?? "";
     const remainingTtlSeconds = parseInt(response.headers.get("X-Remaining-TTL") ?? "0", 10);
     const originalTtlSeconds = parseInt(response.headers.get("X-Original-TTL") ?? "0", 10);

--- a/repram-mcp/src/node/bootstrap.test.ts
+++ b/repram-mcp/src/node/bootstrap.test.ts
@@ -270,7 +270,7 @@ describe("bootstrapFromPeers", () => {
 
 describe("notifyPeerAboutNewNode", () => {
   it("sends bootstrap request to peer", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve("") });
     vi.stubGlobal("fetch", fetchMock);
 
     const logger = silentLogger();
@@ -294,7 +294,7 @@ describe("notifyPeerAboutNewNode", () => {
     const fetchMock = vi.fn()
       .mockRejectedValueOnce(new Error("fail1"))
       .mockRejectedValueOnce(new Error("fail2"))
-      .mockResolvedValueOnce({ ok: true });
+      .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve("") });
     vi.stubGlobal("fetch", fetchMock);
 
     const logger = silentLogger();

--- a/repram-mcp/src/node/bootstrap.ts
+++ b/repram-mcp/src/node/bootstrap.ts
@@ -214,7 +214,6 @@ export async function notifyPeerAboutNewNode(
   maxRetries: number = 3,
 ): Promise<void> {
   const jsonBody = JSON.stringify(request);
-  const bodyBuffer = Buffer.from(jsonBody);
 
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     try {
@@ -223,7 +222,7 @@ export async function notifyPeerAboutNewNode(
         "Content-Type": "application/json",
       };
       if (clusterSecret) {
-        headers["X-Repram-Signature"] = signBody(clusterSecret, bodyBuffer);
+        headers["X-Repram-Signature"] = signBody(clusterSecret, Buffer.from(jsonBody));
       }
 
       const controller = new AbortController();
@@ -237,11 +236,12 @@ export async function notifyPeerAboutNewNode(
           signal: controller.signal,
         });
 
-        await response.text();
+        const responseText = await response.text();
         if (response.ok) {
           logger.debug(`Notified ${peerAddr} about new node (attempt ${attempt + 1})`);
           return;
         }
+        logger.warn(`Notify ${peerAddr} returned ${response.status}: ${responseText.slice(0, 200)}`);
       } finally {
         clearTimeout(timeout);
       }

--- a/repram-mcp/src/node/bootstrap.ts
+++ b/repram-mcp/src/node/bootstrap.ts
@@ -237,6 +237,7 @@ export async function notifyPeerAboutNewNode(
           signal: controller.signal,
         });
 
+        await response.text();
         if (response.ok) {
           logger.debug(`Notified ${peerAddr} about new node (attempt ${attempt + 1})`);
           return;

--- a/repram-mcp/src/node/transport.test.ts
+++ b/repram-mcp/src/node/transport.test.ts
@@ -186,7 +186,7 @@ describe("round-trip serialization", () => {
 
 describe("HTTPTransport.send", () => {
   it("sends POST with JSON body", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, text: () => Promise.resolve("") });
     vi.stubGlobal("fetch", fetchMock);
 
     const logger = new Logger("error");
@@ -207,7 +207,7 @@ describe("HTTPTransport.send", () => {
   });
 
   it("includes HMAC signature when secret is set", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, text: () => Promise.resolve("") });
     vi.stubGlobal("fetch", fetchMock);
 
     const logger = new Logger("error");
@@ -221,7 +221,7 @@ describe("HTTPTransport.send", () => {
   });
 
   it("omits HMAC signature when secret is empty", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, text: () => Promise.resolve("") });
     vi.stubGlobal("fetch", fetchMock);
 
     const logger = new Logger("error");

--- a/repram-mcp/src/node/transport.ts
+++ b/repram-mcp/src/node/transport.ts
@@ -25,7 +25,6 @@ export class HTTPTransport {
   async send(target: NodeInfo, msg: Message): Promise<void> {
     const wireMsg = messageToWire(msg);
     const jsonBody = JSON.stringify(wireMsg);
-    const bodyBuffer = Buffer.from(jsonBody);
 
     const url = `http://${target.address}:${target.httpPort}/v1/gossip/message`;
 
@@ -34,7 +33,7 @@ export class HTTPTransport {
     };
 
     if (this.clusterSecret) {
-      headers["X-Repram-Signature"] = signBody(this.clusterSecret, bodyBuffer);
+      headers["X-Repram-Signature"] = signBody(this.clusterSecret, Buffer.from(jsonBody));
     }
 
     const controller = new AbortController();
@@ -48,10 +47,13 @@ export class HTTPTransport {
         signal: controller.signal,
       });
 
+      // Drain the response body so undici can return the socket to its
+      // pool. Without this, each request pins a new socket and its
+      // internal buffers accumulate as external memory (#94).
+      await response.text();
+
       if (!response.ok) {
         this.logger.warn(`Message rejected by ${target.id} with status ${response.status}`);
-      } else {
-        this.logger.debug(`Sent ${msg.type} message to ${target.id} at ${url}`);
       }
     } catch (err) {
       if (err instanceof Error && err.name === "AbortError") {

--- a/repram-mcp/src/node/transport.ts
+++ b/repram-mcp/src/node/transport.ts
@@ -50,10 +50,12 @@ export class HTTPTransport {
       // Drain the response body so undici can return the socket to its
       // pool. Without this, each request pins a new socket and its
       // internal buffers accumulate as external memory (#94).
-      await response.text();
+      const responseText = await response.text();
 
       if (!response.ok) {
-        this.logger.warn(`Message rejected by ${target.id} with status ${response.status}`);
+        this.logger.warn(`Message rejected by ${target.id} with status ${response.status}: ${responseText.slice(0, 200)}`);
+      } else {
+        this.logger.debug(`Sent ${msg.type} message to ${target.id} at ${url}`);
       }
     } catch (err) {
       if (err instanceof Error && err.name === "AbortError") {


### PR DESCRIPTION
## Summary
- **Root cause**: `HTTPTransport.send()` called `fetch()` but never consumed the response body. In Node.js's undici-based fetch, unconsumed bodies keep the underlying socket locked — it can't be returned to the connection pool. Under sustained gossip traffic (40+ messages/sec in a 3-node cluster), this creates a new socket per request, each with internal buffers (~64KB) that accumulate as external memory until GC collects the stale Response objects.
- **Fix**: `await response.text()` after every `fetch()` to drain the body and return the socket to the pool. Applied to both `transport.ts` (hot gossip path) and `bootstrap.ts` (peer notification).
- **Side fix**: Removed a gratuitous `Buffer.from(jsonBody)` allocation that was created unconditionally but only used for HMAC signing — now inlined to the branch that needs it.

## Investigation summary

Ruled out the four suspects from the issue:
1. **MemoryStore.set() retains request-body Buffers** — already copies via `Buffer.from(data)` (storage.ts:48)
2. **seenMessages stores full objects** — stores only `Map<string, number>` (gossip.ts:89)
3. **MCP deps loaded in standalone mode** — already lazy-loaded via dynamic `import()` (index.ts:254)
4. **HTTP keep-alive socket pools** — correct direction but the real issue was socket *non-reuse* from unconsumed bodies, not pool size

## Test plan
- [x] All 381 TS tests pass (updated fetch mocks in transport.test.ts and bootstrap.test.ts to include `text()` method)
- [x] All 86 Go tests pass (no changes to Go code)
- [ ] Full validation requires next burn-in run — external memory under sustained load should drop from ~590MB to ~working-set size

Closes #94

// ticktockbent