### PR TITLE
docs: update test counts and add pprof env vars

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,8 +61,8 @@ Both languages:
 - Write tests for new functionality
 - Ensure all tests pass:
   ```bash
-  make test                             # Go (83 tests)
-  cd repram-mcp && npm test             # TypeScript (248 tests)
+  make test                             # Go (155 tests)
+  cd repram-mcp && npm test             # TypeScript (381 tests)
   ```
 - Include both unit and integration tests where appropriate
 

--- a/README.md
+++ b/README.md
@@ -197,20 +197,22 @@ REPRAM accepts requests from any origin. This is intentional — REPRAM is permi
 | `REPRAM_TRUST_PROXY` | `false` | Trust `X-Forwarded-For` and `X-Real-IP` headers for client IP detection. Set to `true` when running behind a reverse proxy (nginx, Cloudflare, etc.). |
 | `REPRAM_LOG_LEVEL` | `info` | Log verbosity: `debug`, `info`, `warn`, `error` |
 | `REPRAM_MAX_STORAGE_MB` | `0` | Max data storage in MB (0 = unlimited). Rejects writes with 507 when full. Tracks payload bytes only — actual memory usage is higher due to per-entry overhead (~80 bytes + key length per entry). For workloads with many small values, set conservatively. |
+| `REPRAM_PPROF_ENABLED` | `false` | Enable pprof/profiling diagnostic endpoints. Go: separate listener on `REPRAM_PPROF_ADDR`. TS: heap snapshot and stats endpoints. Do not expose in untrusted environments. |
+| `REPRAM_PPROF_ADDR` | `127.0.0.1:6060` | Address for the pprof listener (only used when `REPRAM_PPROF_ENABLED=true`). Loopback-only by default — set to `0.0.0.0:6060` to allow external access. |
 
 ## Building from Source
 
 ```bash
 # Go node
 make build          # Build Go binary to bin/repram
-make test           # Run Go tests (83 tests)
+make test           # Run Go tests (155 tests)
 make docker-build   # Build Docker image (ticktockbent/repram-node:latest)
 
 # TypeScript node / MCP server
 cd repram-mcp
 npm install
 npm run build       # Compile TypeScript
-npm test            # Run tests (248 tests)
+npm test            # Run tests (381 tests)
 ```
 
 ## Documentation

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -74,7 +74,7 @@ REPRAM is `pipe`, not `grep`. It doesn't know or care what flows through it — 
 * **Storage**: In-memory with TTL-based expiration and configurable capacity limits
 * **Discovery**: DNS SRV/A records for public network, static peer list for private
 * **Agent Interface**: Model Context Protocol (MCP) over stdio, with in-process calls for embedded mode
-* **Testing**: 83 Go tests + 248 TypeScript tests (331 total)
+* **Testing**: 155 Go tests + 381 TypeScript tests (536 total)
 
 ## Resilience Through Ephemerality
 

--- a/repram-mcp/README.md
+++ b/repram-mcp/README.md
@@ -89,6 +89,8 @@ All settings via `REPRAM_*` environment variables. Defaults differ between embed
 | `REPRAM_LOG_LEVEL` | `warn` | `info` | Log level (debug/info/warn/error) |
 | `REPRAM_URL` | _(not set)_ | n/a | External node URL (MCP mode only; skips embedded node) |
 | `REPRAM_PEERS` | _(not set)_ | _(not set)_ | Comma-separated peer addresses for bootstrap |
+| `REPRAM_PPROF_ENABLED` | `false` | `false` | Enable pprof diagnostic endpoints (heap snapshot, stats) |
+| `REPRAM_PPROF_ADDR` | `127.0.0.1:6060` | `127.0.0.1:6060` | Address for the pprof listener |
 
 ## HTTP API (v1)
 
@@ -113,7 +115,7 @@ The TypeScript node uses the same JSON wire format and HMAC-SHA256 signing as th
 ```bash
 npm install
 npm run build
-npm test          # 248 tests
+npm test          # 381 tests
 ```
 
 ## License


### PR DESCRIPTION
## Summary
- **Test counts**: 83 Go → 155, 248 TS → 381 (536 total) across README.md, repram-mcp/README.md, CONTRIBUTING.md, docs/project-overview.md
- **New env vars**: Added `REPRAM_PPROF_ENABLED` and `REPRAM_PPROF_ADDR` to config tables in README.md and repram-mcp/README.md
- **CLAUDE.md** (local, gitignored): Fixed docker-compose port range 8081-8083 → 8091-8093

## Test plan
- [x] Documentation-only changes, no code modified

// ticktockbent