### PR TITLE
prep: update burn-in harness for 72-hour run with pprof

### DIFF
--- a/test/burnin/README.md
+++ b/test/burnin/README.md
@@ -204,15 +204,22 @@ If any of these fail, stop and fix before starting the 72h timer.
 mkdir -p burn-in-$(date +%Y-%m-%d)
 cd burn-in-$(date +%Y-%m-%d)
 for node_ip in 10.0.20.72 10.0.10.81 10.0.10.104; do
-    # Go nodes: standard pprof binary profiles
-    curl -s http://${node_ip}:6060/debug/pprof/heap > heap-${node_ip}.pprof
-    curl -s http://${node_ip}:6060/debug/pprof/goroutine > goroutine-${node_ip}.pprof
-    # TS node (10.0.10.104): heap snapshot + stats
-    # curl -s -X POST http://10.0.10.104:6060/debug/pprof/heap  # returns {"path":"..."}
-    # curl -s http://10.0.10.104:6060/debug/pprof/stats > stats-ts.json
     curl -s http://${node_ip}:18080/v1/status > status-${node_ip}.json
     curl -s http://${node_ip}:18080/v1/topology > topology-${node_ip}.json
 done
+
+# Go nodes: standard pprof binary profiles (go tool pprof compatible)
+for go_ip in 10.0.20.72 10.0.10.81; do
+    curl -s http://${go_ip}:6060/debug/pprof/heap > heap-${go_ip}.pprof
+    curl -s http://${go_ip}:6060/debug/pprof/goroutine > goroutine-${go_ip}.pprof
+done
+
+# TS node: V8 heap snapshot (writes file inside container) + JSON stats
+curl -s -X POST http://10.0.10.104:6060/debug/pprof/heap > heap-ts-response.json
+curl -s http://10.0.10.104:6060/debug/pprof/stats > stats-ts.json
+# The heap response contains {"path":"/tmp/repram-heap-<ts>.heapsnapshot"}.
+# Copy it out of the container:
+#   docker cp repram-node-c:$(jq -r .path heap-ts-response.json) ./heap-ts.heapsnapshot
 # Copy logs, dnsmasq logs, prometheus snapshot, cache files (root-list.json)
 
 # 2. Stop everything

--- a/test/burnin/README.md
+++ b/test/burnin/README.md
@@ -1,6 +1,6 @@
 # REPRAM 2.1 — Burn-in Test Harness
 
-Operator runbook for the 48-hour baseline test described in
+Operator runbook for the 72-hour burn-in test described in
 `docs/internal/REPRAM-2.1-Minimal-BurnIn.md`.
 
 ## What's here
@@ -12,7 +12,7 @@ Operator runbook for the 48-hour baseline test described in
 | `Dockerfile.ts-node` | Burn-in image for the TS node, with baked test pubkey. |
 | `build-images.sh` | Build both images from a pubkey file. |
 | `sign-loop.sh` | Re-sign + republish the omega TXT record every 25 min. |
-| `workload.js` | k6 workload generator (50 ops/sec, 48h). |
+| `workload.js` | k6 workload generator (50 ops/sec, 72h). |
 | `prometheus-scrape.yml` | Drop-in scrape job for the existing Prometheus stack. |
 | `grafana-dashboard.json` | 6-panel dashboard, importable to Grafana. |
 
@@ -56,16 +56,19 @@ appear in the signed list (`NODES` in `sign-loop.sh`).
 
 ```bash
 docker run -d --name repram-node-a \
-  -p 8080:8080 -p 9090:9090 \
+  -p 18080:18080 -p 6060:6060 \
   -v /var/lib/repram/cache:/data/cache \
   -e REPRAM_NETWORK=public \
   -e REPRAM_ENCLAVE=default \
   -e REPRAM_LOG_LEVEL=info \
   -e REPRAM_NODE_ID=node-a \
   -e REPRAM_ADDRESS=10.0.20.72 \
-  -e REPRAM_GOSSIP_PORT=9090 \
-  -e REPRAM_HTTP_PORT=8080 \
-  --dns 127.0.0.1 \
+  -e REPRAM_GOSSIP_PORT=18080 \
+  -e REPRAM_HTTP_PORT=18080 \
+  -e REPRAM_RATE_LIMIT=10000 \
+  -e REPRAM_PPROF_ENABLED=true \
+  -e REPRAM_PPROF_ADDR=0.0.0.0:6060 \
+  --dns 10.0.20.72 \
   ticktockbent/repram-node:experimental
 ```
 
@@ -79,15 +82,18 @@ bind mount:
 
 ```powershell
 docker run -d --name repram-node-b `
-  -p 8080:8080 -p 9090:9090 `
+  -p 18080:18080 -p 6060:6060 `
   -v C:\repram-cache:/data/cache `
   -e REPRAM_NETWORK=public `
   -e REPRAM_ENCLAVE=default `
   -e REPRAM_LOG_LEVEL=info `
   -e REPRAM_NODE_ID=node-b `
   -e REPRAM_ADDRESS=10.0.10.81 `
-  -e REPRAM_GOSSIP_PORT=9090 `
-  -e REPRAM_HTTP_PORT=8080 `
+  -e REPRAM_GOSSIP_PORT=18080 `
+  -e REPRAM_HTTP_PORT=18080 `
+  -e REPRAM_RATE_LIMIT=10000 `
+  -e REPRAM_PPROF_ENABLED=true `
+  -e REPRAM_PPROF_ADDR=0.0.0.0:6060 `
   --dns 10.0.20.72 `
   ticktockbent/repram-node:experimental
 ```
@@ -96,17 +102,20 @@ docker run -d --name repram-node-b `
 
 ```powershell
 docker run -d --name repram-node-c `
-  -p 8080:8080 -p 9090:9090 `
+  -p 18080:18080 -p 6060:6060 `
   -v C:\repram-cache:/data/cache `
   -e REPRAM_NETWORK=public `
   -e REPRAM_ENCLAVE=default `
   -e REPRAM_LOG_LEVEL=info `
   -e REPRAM_NODE_ID=node-c `
   -e REPRAM_ADDRESS=10.0.10.104 `
-  -e REPRAM_GOSSIP_PORT=9090 `
-  -e REPRAM_HTTP_PORT=8080 `
+  -e REPRAM_GOSSIP_PORT=18080 `
+  -e REPRAM_HTTP_PORT=18080 `
+  -e REPRAM_RATE_LIMIT=10000 `
+  -e REPRAM_PPROF_ENABLED=true `
+  -e REPRAM_PPROF_ADDR=0.0.0.0:6060 `
   --dns 10.0.20.72 `
-  ticktockbent/repram-node:experimental-ts
+  ticktockbent/repram-node:experimental-ts --standalone
 ```
 
 The TS image already has `REPRAM_MODE=standalone` baked in.
@@ -132,8 +141,8 @@ DNSMASQ_HOSTS_FILE=/etc/dnsmasq.d/repram-burnin.conf \
 
 # 3. workload generator
 k6 run \
-  -e REPRAM_NODES=http://10.0.20.72:8080,http://10.0.10.81:8080,http://10.0.10.104:8080 \
-  -e BURNIN_DURATION=48h \
+  -e REPRAM_NODES=http://10.0.20.72:18080,http://10.0.10.81:18080,http://10.0.10.104:18080 \
+  -e BURNIN_DURATION=72h \
   test/burnin/workload.js
 ```
 
@@ -176,16 +185,17 @@ All six dashboard panels have full data on both Go and TS nodes:
 
 ## Pre-flight checks
 
-Before kicking off the 48h run:
+Before kicking off the 72h run:
 
 1. **dnsmasq reachable from each node:** `dig TXT _bootstrap.repram.io @<observer-ip>` returns the omega target; following with `dig TXT _omega.repram.io @<observer-ip>` returns the signed list.
 2. **All three nodes recognize themselves:** check the startup log for `Initial root status: bootstrap root` on node-a and `Initial root status: not a root` on node-b/c.
-3. **Cluster is connected:** `curl http://10.0.20.72:8080/v1/topology` shows all three nodes.
+3. **Cluster is connected:** `curl http://10.0.20.72:18080/v1/topology` shows all three nodes.
 4. **All three nodes self-recognize as roots:** `Initial root status: bootstrap root` in each startup log (every address in the signed list is a root).
 5. **Cache files exist after the first refresh:** `ls /data/cache/root-list.json` (in container) or the bind-mount equivalent.
-6. **Workload generator can write:** `curl -X PUT http://10.0.20.72:8080/v1/data/test -d hi -H "X-TTL: 300"` returns 200.
+6. **Workload generator can write:** `curl -X PUT http://10.0.20.72:18080/v1/data/test -d hi -H "X-TTL: 300"` returns 201.
+7. **pprof responding:** `curl http://10.0.20.72:6060/debug/pprof/` returns the Go pprof index (Go nodes) or `curl -X POST http://10.0.10.104:6060/debug/pprof/heap` triggers a TS heap snapshot.
 
-If any of these fail, stop and fix before starting the 48h timer.
+If any of these fail, stop and fix before starting the 72h timer.
 
 ## Teardown
 
@@ -193,11 +203,15 @@ If any of these fail, stop and fix before starting the 48h timer.
 # 1. Capture artifacts (per the burn-in spec)
 mkdir -p burn-in-$(date +%Y-%m-%d)
 cd burn-in-$(date +%Y-%m-%d)
-for node in node-a node-b node-c; do
-    curl -s http://${node}-ip:8080/debug/pprof/heap > heap-${node}.pprof
-    curl -s http://${node}-ip:8080/debug/pprof/goroutine > goroutine-${node}.pprof
-    curl -s http://${node}-ip:8080/v1/status > status-${node}.json
-    curl -s http://${node}-ip:8080/v1/topology > topology-${node}.json
+for node_ip in 10.0.20.72 10.0.10.81 10.0.10.104; do
+    # Go nodes: standard pprof binary profiles
+    curl -s http://${node_ip}:6060/debug/pprof/heap > heap-${node_ip}.pprof
+    curl -s http://${node_ip}:6060/debug/pprof/goroutine > goroutine-${node_ip}.pprof
+    # TS node (10.0.10.104): heap snapshot + stats
+    # curl -s -X POST http://10.0.10.104:6060/debug/pprof/heap  # returns {"path":"..."}
+    # curl -s http://10.0.10.104:6060/debug/pprof/stats > stats-ts.json
+    curl -s http://${node_ip}:18080/v1/status > status-${node_ip}.json
+    curl -s http://${node_ip}:18080/v1/topology > topology-${node_ip}.json
 done
 # Copy logs, dnsmasq logs, prometheus snapshot, cache files (root-list.json)
 

--- a/test/burnin/commands.md
+++ b/test/burnin/commands.md
@@ -219,7 +219,7 @@ observer's dnsmasq via the host's LAN IP.
 
 ```bash
 docker run -d --name repram-node-a \
-  -p 18080:18080 \
+  -p 18080:18080 -p 6060:6060 \
   -v /var/lib/repram/cache:/data/cache \
   -e REPRAM_NETWORK=public \
   -e REPRAM_ENCLAVE=default \
@@ -229,6 +229,8 @@ docker run -d --name repram-node-a \
   -e REPRAM_GOSSIP_PORT=18080 \
   -e REPRAM_HTTP_PORT=18080 \
   -e REPRAM_RATE_LIMIT=10000 \
+  -e REPRAM_PPROF_ENABLED=true \
+  -e REPRAM_PPROF_ADDR=0.0.0.0:6060 \
   --dns 10.0.20.72 \
   ticktockbent/repram-node:experimental
 ```
@@ -280,7 +282,7 @@ docker rm repram-smoke 2>$null
 if (-Not (Test-Path C:\repram-cache)) { New-Item -ItemType Directory -Path C:\repram-cache | Out-Null }
 
 docker run -d --name repram-node-b `
-  -p 18080:18080 `
+  -p 18080:18080 -p 6060:6060 `
   -v C:\repram-cache:/data/cache `
   -e REPRAM_NETWORK=public `
   -e REPRAM_ENCLAVE=default `
@@ -290,6 +292,8 @@ docker run -d --name repram-node-b `
   -e REPRAM_GOSSIP_PORT=18080 `
   -e REPRAM_HTTP_PORT=18080 `
   -e REPRAM_RATE_LIMIT=10000 `
+  -e REPRAM_PPROF_ENABLED=true `
+  -e REPRAM_PPROF_ADDR=0.0.0.0:6060 `
   --dns 10.0.20.72 `
   ticktockbent/repram-node:experimental
 
@@ -306,7 +310,7 @@ docker rm repram-smoke 2>$null
 if (-Not (Test-Path C:\repram-cache)) { New-Item -ItemType Directory -Path C:\repram-cache | Out-Null }
 
 docker run -d --name repram-node-c `
-  -p 18080:18080 `
+  -p 18080:18080 -p 6060:6060 `
   -v C:\repram-cache:/data/cache `
   -e REPRAM_NETWORK=public `
   -e REPRAM_ENCLAVE=default `
@@ -316,6 +320,8 @@ docker run -d --name repram-node-c `
   -e REPRAM_GOSSIP_PORT=18080 `
   -e REPRAM_HTTP_PORT=18080 `
   -e REPRAM_RATE_LIMIT=10000 `
+  -e REPRAM_PPROF_ENABLED=true `
+  -e REPRAM_PPROF_ADDR=0.0.0.0:6060 `
   --dns 10.0.20.72 `
   ticktockbent/repram-node:experimental-ts --standalone
 
@@ -479,11 +485,11 @@ account for ~5 minutes after a handful of failures. If you trip it,
 
 ---
 
-## Task 32 — Launch the long-runners (start the 48h timer)
+## Task 32 — Launch the long-runners (start the 72h timer)
 
 ### 32a. Passwordless sudo for sign-loop
 
-sign-loop.sh runs every 25 min for 48h. It needs to write to
+sign-loop.sh runs every 25 min for 72h. It needs to write to
 `/etc/dnsmasq.d/repram-burnin.conf` and restart dnsmasq each cycle —
 prompting for sudo every cycle defeats the unattended-loop point.
 
@@ -506,7 +512,7 @@ echo "exit=$?"
 **Option A — Docker (recommended; consistent with everything else):**
 
 ```bash
-# Smoke test it first (10s, 5 ops/sec) before committing to 48h
+# Smoke test it first (10s, 5 ops/sec) before committing to 72h
 docker run --rm -i --network host \
   -v /home/ticktockbent/projects/infrastructure/repram/test/burnin:/work \
   -e REPRAM_NODES=http://10.0.20.72:18080,http://10.0.10.81:18080,http://10.0.10.104:18080 \
@@ -546,9 +552,9 @@ Look at the summary at the end:
 - No `setup() ran error` or fetch failures
 - ~500 requests in 10s × 50 RPS
 
-If anything's red, fix before launching the 48h.
+If anything's red, fix before launching the 72h.
 
-### 32d. Long-running tmux session (launch the 48h timer)
+### 32d. Long-running tmux session (launch the 72h timer)
 
 Three panes — each independent.
 
@@ -564,7 +570,7 @@ DNSMASQ_HOSTS_FILE=/etc/dnsmasq.d/repram-burnin.conf \
 docker run --rm -i --network host \
   -v /home/ticktockbent/projects/infrastructure/repram/test/burnin:/work \
   -e REPRAM_NODES=http://10.0.20.72:18080,http://10.0.10.81:18080,http://10.0.10.104:18080 \
-  -e BURNIN_DURATION=48h \
+  -e BURNIN_DURATION=72h \
   -e K6_PROMETHEUS_RW_SERVER_URL=http://localhost:9090/api/v1/write \
   grafana/k6 run --out experimental-prometheus-rw /work/workload.js \
   | tee -a $HOME/.repram-burnin/k6.log
@@ -572,7 +578,7 @@ docker run --rm -i --network host \
 # Pane 3: dashboard watcher — keep eyes on it during initial 30 min
 echo "Open: http://localhost:3000/d/repram-burnin-2-1/"
 echo "Start time:  $(date -Is)"
-echo "Expected end: $(date -Is -d '+48 hours')"
+echo "Expected end: $(date -Is -d '+72 hours')"
 ```
 
 For Prometheus remote-write to accept k6's pushes, Prometheus needs

--- a/test/burnin/prometheus-scrape.yml
+++ b/test/burnin/prometheus-scrape.yml
@@ -14,8 +14,8 @@ scrape_configs:
     scrape_interval: 15s
     static_configs:
       - targets:
-          - 10.0.20.72:8080
-          - 10.0.10.81:8080
+          - 10.0.20.72:18080
+          - 10.0.10.81:18080
         labels:
           cluster: burnin
           impl: go
@@ -28,7 +28,7 @@ scrape_configs:
     scrape_interval: 15s
     static_configs:
       - targets:
-          - 10.0.10.104:8080
+          - 10.0.10.104:18080
         labels:
           cluster: burnin
           impl: ts

--- a/test/burnin/snapshot.sh
+++ b/test/burnin/snapshot.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Capture a single-line burn-in snapshot per cycle. Run by cron every 30
-# minutes during the 48h test. Output is appended to the log file
+# minutes during the burn-in test. Output is appended to the log file
 # specified in $SNAPSHOT_LOG (default: ~/.repram-burnin/snapshots.log).
 #
 # Each cycle emits one section per node and a header so the file can be

--- a/test/burnin/workload.js
+++ b/test/burnin/workload.js
@@ -32,11 +32,11 @@ const AGENT_COUNT = 100;
 const GRAVEYARD_TTL_SEC = 300;
 const GRAVEYARD_WARMUP_SEC = 360;
 
-// Long-lived reference set: 24h TTL covers most of a 48h run. After hour 24
-// these natural-expire and GET-existing will start returning 404 from the
-// ref-set arm. That's expected — the ref set is a retention probe for the
-// first refresh cycles, not a 48h invariant.
-const REF_TTL_SEC = 24 * 3600;
+// Long-lived reference set: 72h TTL covers the full run. After expiry,
+// GET-existing will start returning 404 from the ref-set arm. The ref set
+// is a retention probe, not an invariant — if the run exceeds REF_TTL,
+// that's expected behavior.
+const REF_TTL_SEC = 72 * 3600;
 
 export const options = {
     setupTimeout: '15m',
@@ -45,7 +45,7 @@ export const options = {
             executor: 'constant-arrival-rate',
             rate: 50,
             timeUnit: '1s',
-            duration: __ENV.BURNIN_DURATION || '48h',
+            duration: __ENV.BURNIN_DURATION || '72h',
             preAllocatedVUs: 30,
             maxVUs: 60,
         },


### PR DESCRIPTION
## Summary
Prepares the burn-in test infrastructure for a 72-hour run, incorporating fixes from #97 (pprof) and #94 (memory).

**Critical fixes (would break the run):**
- `workload.js`: REF_TTL_SEC 24h → 72h — reference keys would have expired at T+24h on a 72h run
- `prometheus-scrape.yml`: target ports 8080 → 18080 (matching the F1/F2 workaround from the previous run)
- `commands.md`: date calculation `+48 hours` → `+72 hours`

**pprof enablement:**
- All three node startup commands now include `REPRAM_PPROF_ENABLED=true`, `REPRAM_PPROF_ADDR=0.0.0.0:6060`, and `-p 6060:6060`
- Teardown section updated with correct pprof URLs (`:6060` separate listener, not `:8080`)
- Pre-flight checklist includes pprof verification step

**Duration + port fixes:**
- All `48h` references → `72h` across commands.md, README.md, workload.js
- README per-host runbook synced with commands.md (was stale — still had :8080/:9090 ports, missing rate limit and pprof)

## Test plan
- [x] No code changes — burn-in harness docs/scripts only
- [x] All 155 Go + 381 TS tests pass (unchanged)

// ticktockbent