### PR TITLE
fix(ts): replace undici/fetch with http.request, parallelize broadcasts

### DIFF
--- a/repram-mcp/src/node/bootstrap.test.ts
+++ b/repram-mcp/src/node/bootstrap.test.ts
@@ -1,10 +1,22 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { bootstrapFromPeers, notifyPeerAboutNewNode } from "./bootstrap.js";
 import { Logger } from "./logger.js";
 import type { NodeInfo } from "./types.js";
 
+const mockHttpPost = vi.fn();
+
+vi.mock("./transport.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./transport.js")>();
+  return {
+    ...actual,
+    httpPost: mockHttpPost,
+  };
+});
+
+const { bootstrapFromPeers, notifyPeerAboutNewNode } = await import("./bootstrap.js");
+
 afterEach(() => {
   vi.restoreAllMocks();
+  mockHttpPost.mockReset();
 });
 
 function silentLogger(): Logger {
@@ -22,6 +34,10 @@ function makeLocalNode(overrides: Partial<NodeInfo> = {}): NodeInfo {
   };
 }
 
+function mockSuccessResponse(peers: unknown[]) {
+  return { statusCode: 200, body: JSON.stringify({ success: true, peers }) };
+}
+
 // Note: the omega-based signed-root-list discovery path
 // (resolveOmegaBootstrap) is exercised under src/node/trust/ — see
 // resolver.test.ts, cache.test.ts, and refresher.test.ts. The legacy
@@ -31,17 +47,10 @@ function makeLocalNode(overrides: Partial<NodeInfo> = {}): NodeInfo {
 
 describe("bootstrapFromPeers", () => {
   it("returns discovered peers on success", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        success: true,
-        peers: [
-          { id: "peer-1", address: "10.0.0.1", port: 9090, http_port: 8080, enclave: "default" },
-          { id: "peer-2", address: "10.0.0.2", port: 9090, http_port: 8080 },
-        ],
-      }),
-    });
-    vi.stubGlobal("fetch", fetchMock);
+    mockHttpPost.mockResolvedValue(mockSuccessResponse([
+      { id: "peer-1", address: "10.0.0.1", port: 9090, http_port: 8080, enclave: "default" },
+      { id: "peer-2", address: "10.0.0.2", port: 9090, http_port: 8080 },
+    ]));
 
     const logger = silentLogger();
     vi.spyOn(logger, "info").mockImplementation(() => {});
@@ -59,16 +68,10 @@ describe("bootstrapFromPeers", () => {
   });
 
   it("filters out self from discovered peers", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        success: true,
-        peers: [
-          { id: "test-node", address: "localhost", port: 9090, http_port: 8080 },
-          { id: "other-node", address: "10.0.0.2", port: 9090, http_port: 8080 },
-        ],
-      }),
-    }));
+    mockHttpPost.mockResolvedValue(mockSuccessResponse([
+      { id: "test-node", address: "localhost", port: 9090, http_port: 8080 },
+      { id: "other-node", address: "10.0.0.2", port: 9090, http_port: 8080 },
+    ]));
 
     const logger = silentLogger();
     vi.spyOn(logger, "info").mockImplementation(() => {});
@@ -85,16 +88,11 @@ describe("bootstrapFromPeers", () => {
   });
 
   it("continues to next seed on failure", async () => {
-    const fetchMock = vi.fn()
+    mockHttpPost
       .mockRejectedValueOnce(new Error("connection refused"))
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          success: true,
-          peers: [{ id: "peer-1", address: "10.0.0.3", port: 9090, http_port: 8080 }],
-        }),
-      });
-    vi.stubGlobal("fetch", fetchMock);
+      .mockResolvedValueOnce(mockSuccessResponse([
+        { id: "peer-1", address: "10.0.0.3", port: 9090, http_port: 8080 },
+      ]));
 
     const logger = silentLogger();
     vi.spyOn(logger, "info").mockImplementation(() => {});
@@ -108,21 +106,16 @@ describe("bootstrapFromPeers", () => {
     );
 
     expect(peers).toHaveLength(1);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(mockHttpPost).toHaveBeenCalledTimes(2);
   });
 
   // #82 (F3): the old loop returned after the first successful seed,
   // leaving later seeds unaware of the joiner until topology sync. The
   // fixed loop contacts every seed.
   it("contacts every seed even after the first succeeds", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        success: true,
-        peers: [{ id: "shared", address: "10.0.0.9", port: 9090, http_port: 8080 }],
-      }),
-    });
-    vi.stubGlobal("fetch", fetchMock);
+    mockHttpPost.mockResolvedValue(mockSuccessResponse([
+      { id: "shared", address: "10.0.0.9", port: 9090, http_port: 8080 },
+    ]));
 
     const logger = silentLogger();
     vi.spyOn(logger, "info").mockImplementation(() => {});
@@ -134,8 +127,8 @@ describe("bootstrapFromPeers", () => {
       logger,
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    const urls = fetchMock.mock.calls.map((c) => c[0]);
+    expect(mockHttpPost).toHaveBeenCalledTimes(3);
+    const urls = mockHttpPost.mock.calls.map((c) => c[0]);
     expect(urls).toContain("http://seed-a:8080/v1/bootstrap");
     expect(urls).toContain("http://seed-b:8080/v1/bootstrap");
     expect(urls).toContain("http://seed-c:8080/v1/bootstrap");
@@ -146,14 +139,9 @@ describe("bootstrapFromPeers", () => {
   // must skip it — otherwise the node POSTs a bootstrap to itself and
   // pollutes its peer map with self.
   it("skips self in the seed list", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        success: true,
-        peers: [{ id: "other", address: "10.0.0.2", port: 9090, http_port: 8080 }],
-      }),
-    });
-    vi.stubGlobal("fetch", fetchMock);
+    mockHttpPost.mockResolvedValue(mockSuccessResponse([
+      { id: "other", address: "10.0.0.2", port: 9090, http_port: 8080 },
+    ]));
 
     const logger = silentLogger();
     vi.spyOn(logger, "info").mockImplementation(() => {});
@@ -167,8 +155,8 @@ describe("bootstrapFromPeers", () => {
       logger,
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock.mock.calls[0][0]).toBe("http://real-seed:8080/v1/bootstrap");
+    expect(mockHttpPost).toHaveBeenCalledTimes(1);
+    expect(mockHttpPost.mock.calls[0][0]).toBe("http://real-seed:8080/v1/bootstrap");
   });
 
   // #82 (F4): when multiple seeds report the same peer, the caller
@@ -176,14 +164,9 @@ describe("bootstrapFromPeers", () => {
   // the response — that's how a single-seed bootstrap learns about the
   // seed at all — so dedup runs on the caller side.)
   it("dedupes peers reported by multiple seeds", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        success: true,
-        peers: [{ id: "shared", address: "10.0.0.9", port: 9090, http_port: 8080 }],
-      }),
-    });
-    vi.stubGlobal("fetch", fetchMock);
+    mockHttpPost.mockResolvedValue(mockSuccessResponse([
+      { id: "shared", address: "10.0.0.9", port: 9090, http_port: 8080 },
+    ]));
 
     const logger = silentLogger();
     vi.spyOn(logger, "info").mockImplementation(() => {});
@@ -200,7 +183,7 @@ describe("bootstrapFromPeers", () => {
   });
 
   it("returns empty array when all seeds fail", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("refused")));
+    mockHttpPost.mockRejectedValue(new Error("refused"));
 
     const logger = silentLogger();
     vi.spyOn(logger, "info").mockImplementation(() => {});
@@ -216,12 +199,8 @@ describe("bootstrapFromPeers", () => {
     expect(peers).toEqual([]);
   });
 
-  it("includes HMAC signature when secret is set", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ success: true, peers: [] }),
-    });
-    vi.stubGlobal("fetch", fetchMock);
+  it("includes HMAC signature in headers", async () => {
+    mockHttpPost.mockResolvedValue(mockSuccessResponse([]));
 
     const logger = silentLogger();
     vi.spyOn(logger, "info").mockImplementation(() => {});
@@ -233,17 +212,13 @@ describe("bootstrapFromPeers", () => {
       logger,
     );
 
-    const [, opts] = fetchMock.mock.calls[0];
-    expect(opts.headers["X-Repram-Signature"]).toBeDefined();
-    expect(opts.headers["X-Repram-Signature"]).toMatch(/^[0-9a-f]{64}$/);
+    const headers = mockHttpPost.mock.calls[0][2];
+    expect(headers["X-Repram-Signature"]).toBeDefined();
+    expect(headers["X-Repram-Signature"]).toMatch(/^[0-9a-f]{64}$/);
   });
 
   it("sends correct bootstrap request body", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ success: true, peers: [] }),
-    });
-    vi.stubGlobal("fetch", fetchMock);
+    mockHttpPost.mockResolvedValue(mockSuccessResponse([]));
 
     const logger = silentLogger();
     vi.spyOn(logger, "info").mockImplementation(() => {});
@@ -255,9 +230,9 @@ describe("bootstrapFromPeers", () => {
       logger,
     );
 
-    const [url, opts] = fetchMock.mock.calls[0];
+    const [url, bodyStr] = mockHttpPost.mock.calls[0];
     expect(url).toBe("http://10.0.0.1:8080/v1/bootstrap");
-    const body = JSON.parse(opts.body);
+    const body = JSON.parse(bodyStr);
     expect(body.node_id).toBe("my-node");
     expect(body.address).toBe("192.168.1.1");
     expect(body.gossip_port).toBe(9091);
@@ -270,8 +245,7 @@ describe("bootstrapFromPeers", () => {
 
 describe("notifyPeerAboutNewNode", () => {
   it("sends bootstrap request to peer", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve("") });
-    vi.stubGlobal("fetch", fetchMock);
+    mockHttpPost.mockResolvedValue({ statusCode: 200, body: "" });
 
     const logger = silentLogger();
     vi.spyOn(logger, "debug").mockImplementation(() => {});
@@ -283,19 +257,18 @@ describe("notifyPeerAboutNewNode", () => {
       logger,
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url] = fetchMock.mock.calls[0];
+    expect(mockHttpPost).toHaveBeenCalledTimes(1);
+    const [url] = mockHttpPost.mock.calls[0];
     expect(url).toBe("http://10.0.0.2:8080/v1/bootstrap");
   });
 
   it("retries on failure with backoff", async () => {
     vi.useFakeTimers();
 
-    const fetchMock = vi.fn()
+    mockHttpPost
       .mockRejectedValueOnce(new Error("fail1"))
       .mockRejectedValueOnce(new Error("fail2"))
-      .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve("") });
-    vi.stubGlobal("fetch", fetchMock);
+      .mockResolvedValueOnce({ statusCode: 200, body: "" });
 
     const logger = silentLogger();
     vi.spyOn(logger, "warn").mockImplementation(() => {});
@@ -317,7 +290,7 @@ describe("notifyPeerAboutNewNode", () => {
 
     await notifyPromise;
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(mockHttpPost).toHaveBeenCalledTimes(3);
     expect(logger.warn).toHaveBeenCalledTimes(2); // 2 retries
 
     vi.useRealTimers();
@@ -326,7 +299,7 @@ describe("notifyPeerAboutNewNode", () => {
   it("logs error after all retries exhausted", async () => {
     vi.useFakeTimers();
 
-    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("permanent failure")));
+    mockHttpPost.mockRejectedValue(new Error("permanent failure"));
 
     const logger = silentLogger();
     vi.spyOn(logger, "warn").mockImplementation(() => {});

--- a/repram-mcp/src/node/bootstrap.ts
+++ b/repram-mcp/src/node/bootstrap.ts
@@ -7,6 +7,7 @@
  */
 
 import { signBody } from "./auth.js";
+import { httpPost } from "./transport.js";
 import type { Logger } from "./logger.js";
 import type { NodeInfo } from "./types.js";
 import { fetchSigned } from "./trust/resolver.js";
@@ -154,10 +155,9 @@ async function sendBootstrapRequest(
   seedAddr: string,
   request: BootstrapRequest,
   clusterSecret: string,
-  logger: Logger,
+  _logger: Logger,
 ): Promise<NodeInfo[]> {
   const jsonBody = JSON.stringify(request);
-  const bodyBuffer = Buffer.from(jsonBody);
 
   const url = `http://${seedAddr}/v1/bootstrap`;
   const headers: Record<string, string> = {
@@ -165,33 +165,21 @@ async function sendBootstrapRequest(
   };
 
   if (clusterSecret) {
-    headers["X-Repram-Signature"] = signBody(clusterSecret, bodyBuffer);
+    headers["X-Repram-Signature"] = signBody(clusterSecret, Buffer.from(jsonBody));
   }
 
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 5_000);
+  const result = await httpPost(url, jsonBody, headers);
 
-  try {
-    const response = await fetch(url, {
-      method: "POST",
-      headers,
-      body: jsonBody,
-      signal: controller.signal,
-    });
-
-    if (!response.ok) {
-      throw new Error(`bootstrap rejected with status ${response.status}`);
-    }
-
-    const body = (await response.json()) as BootstrapResponse;
-    if (!body.success) {
-      throw new Error("bootstrap failed");
-    }
-
-    return (body.peers ?? []).map(wirePeerToNodeInfo);
-  } finally {
-    clearTimeout(timeout);
+  if (result.statusCode < 200 || result.statusCode >= 300) {
+    throw new Error(`bootstrap rejected with status ${result.statusCode}`);
   }
+
+  const body = JSON.parse(result.body) as BootstrapResponse;
+  if (!body.success) {
+    throw new Error("bootstrap failed");
+  }
+
+  return (body.peers ?? []).map(wirePeerToNodeInfo);
 }
 
 function wirePeerToNodeInfo(peer: WireBootstrapPeer): NodeInfo {
@@ -225,26 +213,13 @@ export async function notifyPeerAboutNewNode(
         headers["X-Repram-Signature"] = signBody(clusterSecret, Buffer.from(jsonBody));
       }
 
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 5_000);
+      const result = await httpPost(url, jsonBody, headers);
 
-      try {
-        const response = await fetch(url, {
-          method: "POST",
-          headers,
-          body: jsonBody,
-          signal: controller.signal,
-        });
-
-        const responseText = await response.text();
-        if (response.ok) {
-          logger.debug(`Notified ${peerAddr} about new node (attempt ${attempt + 1})`);
-          return;
-        }
-        logger.warn(`Notify ${peerAddr} returned ${response.status}: ${responseText.slice(0, 200)}`);
-      } finally {
-        clearTimeout(timeout);
+      if (result.statusCode >= 200 && result.statusCode < 300) {
+        logger.debug(`Notified ${peerAddr} about new node (attempt ${attempt + 1})`);
+        return;
       }
+      logger.warn(`Notify ${peerAddr} returned ${result.statusCode}: ${result.body.slice(0, 200)}`);
     } catch (err) {
       if (attempt === maxRetries - 1) {
         logger.error(`Failed to notify ${peerAddr} after ${maxRetries} attempts: ${err}`);

--- a/repram-mcp/src/node/gossip.ts
+++ b/repram-mcp/src/node/gossip.ts
@@ -407,15 +407,7 @@ export class GossipProtocol {
       this.logger.debug(
         `[${this.localNode.id}] Broadcasting ${msg.type} to ${peers.length} enclave peers (${this.localNode.enclave})`,
       );
-      for (const peer of peers) {
-        try {
-          await this.transport.send(peer, msg);
-        } catch (err) {
-          this.logger.warn(
-            `[${this.localNode.id}] Failed to send to enclave peer ${peer.id}: ${err}`,
-          );
-        }
-      }
+      await this.sendToAll(peers, msg);
     } else {
       // Large enclave: √N probabilistic fanout
       const count = fanoutSize(peers.length);
@@ -423,15 +415,7 @@ export class GossipProtocol {
       this.logger.debug(
         `[${this.localNode.id}] Fanout ${msg.type} to ${targets.length}/${peers.length} enclave peers (${this.localNode.enclave})`,
       );
-      for (const peer of targets) {
-        try {
-          await this.transport.send(peer, msg);
-        } catch (err) {
-          this.logger.warn(
-            `[${this.localNode.id}] Failed to send to enclave peer ${peer.id}: ${err}`,
-          );
-        }
-      }
+      await this.sendToAll(targets, msg);
     }
   }
 
@@ -451,15 +435,7 @@ export class GossipProtocol {
     this.logger.debug(
       `[${this.localNode.id}] Forwarding ${msg.type} (key: ${msg.key}) to ${targets.length} enclave peers`,
     );
-    for (const peer of targets) {
-      try {
-        await this.transport!.send(peer, msg);
-      } catch (err) {
-        this.logger.warn(
-          `[${this.localNode.id}] Failed to forward to enclave peer ${peer.id}: ${err}`,
-        );
-      }
-    }
+    await this.sendToAll(targets, msg);
   }
 
   /** Send a message to a specific node. */
@@ -476,12 +452,18 @@ export class GossipProtocol {
     this.logger.debug(
       `[${this.localNode.id}] Broadcasting ${msg.type} to ${peers.length} peers`,
     );
-    for (const peer of peers) {
-      try {
-        await this.transport.send(peer, msg);
-      } catch (err) {
+    await this.sendToAll(peers, msg);
+  }
+
+  /** Send a message to multiple peers in parallel. */
+  private async sendToAll(peers: NodeInfo[], msg: Message): Promise<void> {
+    const results = await Promise.allSettled(
+      peers.map((peer) => this.transport!.send(peer, msg)),
+    );
+    for (let i = 0; i < results.length; i++) {
+      if (results[i].status === "rejected") {
         this.logger.warn(
-          `[${this.localNode.id}] Failed to send to peer ${peer.id}: ${err}`,
+          `[${this.localNode.id}] Failed to send to peer ${peers[i].id}: ${(results[i] as PromiseRejectedResult).reason}`,
         );
       }
     }

--- a/repram-mcp/src/node/gossip.ts
+++ b/repram-mcp/src/node/gossip.ts
@@ -238,7 +238,9 @@ export class GossipProtocol {
       nodeInfo: this.localNode, // include identity and enclave membership
     };
 
-    this.transport?.send(peer, pong);
+    this.transport?.send(peer, pong).catch((err) => {
+      this.logger.warn(`[${this.localNode.id}] Failed to send PONG to ${peer.id}: ${err}`);
+    });
   }
 
   private handlePong(msg: Message): void {

--- a/repram-mcp/src/node/transport.test.ts
+++ b/repram-mcp/src/node/transport.test.ts
@@ -1,10 +1,21 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { HTTPTransport, messageToWire, wireToMessage } from "./transport.js";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
 import { Logger } from "./logger.js";
 import type { Message, NodeInfo, WireMessage } from "./types.js";
 
+const mockRequest = vi.fn();
+
+vi.mock("node:http", () => ({
+  request: mockRequest,
+  Agent: vi.fn(),
+}));
+
+// Import after mock so the module picks up the mocked http
+const { HTTPTransport, messageToWire, wireToMessage } = await import("./transport.js");
+
 afterEach(() => {
   vi.restoreAllMocks();
+  mockRequest.mockReset();
 });
 
 function makeNodeInfo(overrides: Partial<NodeInfo> = {}): NodeInfo {
@@ -30,6 +41,36 @@ function makeMessage(overrides: Partial<Message> = {}): Message {
     messageId: "1740484800000000000-0",
     ...overrides,
   };
+}
+
+/**
+ * Sets up mockRequest to simulate a successful or failing HTTP response.
+ * Returns the fake request object for assertions.
+ */
+function setupMockRequest(statusCode: number, responseBody = "") {
+  const req = new EventEmitter() as EventEmitter & {
+    end: ReturnType<typeof vi.fn>;
+    setTimeout: ReturnType<typeof vi.fn>;
+    destroy: ReturnType<typeof vi.fn>;
+  };
+  req.end = vi.fn();
+  req.setTimeout = vi.fn();
+  req.destroy = vi.fn();
+
+  mockRequest.mockImplementation((_opts: unknown, callback: (res: unknown) => void) => {
+    process.nextTick(() => {
+      const res = new EventEmitter() as EventEmitter & { statusCode: number };
+      res.statusCode = statusCode;
+      callback(res);
+      process.nextTick(() => {
+        if (responseBody) res.emit("data", Buffer.from(responseBody));
+        res.emit("end");
+      });
+    });
+    return req;
+  });
+
+  return req;
 }
 
 // --- Serialization ---
@@ -186,8 +227,7 @@ describe("round-trip serialization", () => {
 
 describe("HTTPTransport.send", () => {
   it("sends POST with JSON body", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, text: () => Promise.resolve("") });
-    vi.stubGlobal("fetch", fetchMock);
+    const req = setupMockRequest(200);
 
     const logger = new Logger("error");
     const transport = new HTTPTransport(makeNodeInfo(), "", logger);
@@ -195,53 +235,66 @@ describe("HTTPTransport.send", () => {
 
     await transport.send(target, makeMessage());
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, opts] = fetchMock.mock.calls[0];
-    expect(url).toBe("http://10.0.0.2:8081/v1/gossip/message");
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+    const opts = mockRequest.mock.calls[0][0];
+    expect(opts.hostname).toBe("10.0.0.2");
+    expect(opts.port).toBe(8081);
+    expect(opts.path).toBe("/v1/gossip/message");
     expect(opts.method).toBe("POST");
     expect(opts.headers["Content-Type"]).toBe("application/json");
 
-    const body = JSON.parse(opts.body);
+    const body = JSON.parse(req.end.mock.calls[0][0]);
     expect(body.type).toBe("PUT");
     expect(body.message_id).toBeDefined();
   });
 
   it("includes HMAC signature when secret is set", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, text: () => Promise.resolve("") });
-    vi.stubGlobal("fetch", fetchMock);
+    setupMockRequest(200);
 
     const logger = new Logger("error");
     const transport = new HTTPTransport(makeNodeInfo(), "my-secret", logger);
 
     await transport.send(makeNodeInfo({ id: "target" }), makeMessage());
 
-    const [, opts] = fetchMock.mock.calls[0];
+    const opts = mockRequest.mock.calls[0][0];
     expect(opts.headers["X-Repram-Signature"]).toBeDefined();
     expect(opts.headers["X-Repram-Signature"]).toMatch(/^[0-9a-f]{64}$/);
   });
 
   it("omits HMAC signature when secret is empty", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, text: () => Promise.resolve("") });
-    vi.stubGlobal("fetch", fetchMock);
+    setupMockRequest(200);
 
     const logger = new Logger("error");
     const transport = new HTTPTransport(makeNodeInfo(), "", logger);
 
     await transport.send(makeNodeInfo({ id: "target" }), makeMessage());
 
-    const [, opts] = fetchMock.mock.calls[0];
+    const opts = mockRequest.mock.calls[0][0];
     expect(opts.headers["X-Repram-Signature"]).toBeUndefined();
   });
 
-  it("handles fetch failure gracefully (no throw)", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("connection refused")));
+  it("handles request error gracefully (no throw)", async () => {
+    const req = new EventEmitter() as EventEmitter & {
+      end: ReturnType<typeof vi.fn>;
+      setTimeout: ReturnType<typeof vi.fn>;
+      destroy: ReturnType<typeof vi.fn>;
+    };
+    req.end = vi.fn();
+    req.setTimeout = vi.fn();
+    req.destroy = vi.fn();
+
+    mockRequest.mockImplementation(() => {
+      process.nextTick(() => req.emit("error", new Error("connection refused")));
+      return req;
+    });
 
     const logger = new Logger("error");
     vi.spyOn(logger, "warn").mockImplementation(() => {});
     const transport = new HTTPTransport(makeNodeInfo(), "", logger);
 
-    // Should not throw
-    await transport.send(makeNodeInfo({ id: "target" }), makeMessage());
+    await expect(
+      transport.send(makeNodeInfo({ id: "target" }), makeMessage()),
+    ).rejects.toThrow("connection refused");
     expect(logger.warn).toHaveBeenCalled();
   });
 });

--- a/repram-mcp/src/node/transport.test.ts
+++ b/repram-mcp/src/node/transport.test.ts
@@ -11,7 +11,7 @@ vi.mock("node:http", () => ({
 }));
 
 // Import after mock so the module picks up the mocked http
-const { HTTPTransport, messageToWire, wireToMessage } = await import("./transport.js");
+const { HTTPTransport, messageToWire, wireToMessage, httpPost } = await import("./transport.js");
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -273,7 +273,7 @@ describe("HTTPTransport.send", () => {
     expect(opts.headers["X-Repram-Signature"]).toBeUndefined();
   });
 
-  it("handles request error gracefully (no throw)", async () => {
+  it("rejects on request error", async () => {
     const req = new EventEmitter() as EventEmitter & {
       end: ReturnType<typeof vi.fn>;
       setTimeout: ReturnType<typeof vi.fn>;
@@ -338,5 +338,139 @@ describe("HTTPTransport.handleIncoming", () => {
       timestamp: 0,
       message_id: "x",
     });
+  });
+});
+
+// --- httpPost ---
+
+describe("httpPost", () => {
+  it("resolves with status code and body on success", async () => {
+    const req = new EventEmitter() as EventEmitter & {
+      end: ReturnType<typeof vi.fn>;
+      setTimeout: ReturnType<typeof vi.fn>;
+      destroy: ReturnType<typeof vi.fn>;
+    };
+    req.end = vi.fn();
+    req.setTimeout = vi.fn();
+    req.destroy = vi.fn();
+
+    mockRequest.mockImplementation((_opts: unknown, callback: (res: unknown) => void) => {
+      process.nextTick(() => {
+        const res = new EventEmitter() as EventEmitter & { statusCode: number };
+        res.statusCode = 200;
+        callback(res);
+        process.nextTick(() => {
+          res.emit("data", Buffer.from('{"ok":true}'));
+          res.emit("end");
+        });
+      });
+      return req;
+    });
+
+    const result = await httpPost("http://10.0.0.1:8080/v1/bootstrap", '{"test":1}', { "Content-Type": "application/json" });
+
+    expect(result.statusCode).toBe(200);
+    expect(result.body).toBe('{"ok":true}');
+  });
+
+  it("parses URL into hostname, port, and path", async () => {
+    const req = new EventEmitter() as EventEmitter & {
+      end: ReturnType<typeof vi.fn>;
+      setTimeout: ReturnType<typeof vi.fn>;
+      destroy: ReturnType<typeof vi.fn>;
+    };
+    req.end = vi.fn();
+    req.setTimeout = vi.fn();
+    req.destroy = vi.fn();
+
+    mockRequest.mockImplementation((_opts: unknown, callback: (res: unknown) => void) => {
+      process.nextTick(() => {
+        const res = new EventEmitter() as EventEmitter & { statusCode: number };
+        res.statusCode = 200;
+        callback(res);
+        process.nextTick(() => res.emit("end"));
+      });
+      return req;
+    });
+
+    await httpPost("http://myhost:9090/v1/some/path?q=1", "{}", {});
+
+    const opts = mockRequest.mock.calls[0][0];
+    expect(opts.hostname).toBe("myhost");
+    expect(String(opts.port)).toBe("9090");
+    expect(opts.path).toBe("/v1/some/path?q=1");
+    expect(opts.method).toBe("POST");
+  });
+
+  it("rejects on connection error", async () => {
+    const req = new EventEmitter() as EventEmitter & {
+      end: ReturnType<typeof vi.fn>;
+      setTimeout: ReturnType<typeof vi.fn>;
+      destroy: ReturnType<typeof vi.fn>;
+    };
+    req.end = vi.fn();
+    req.setTimeout = vi.fn();
+    req.destroy = vi.fn();
+
+    mockRequest.mockImplementation(() => {
+      process.nextTick(() => req.emit("error", new Error("ECONNREFUSED")));
+      return req;
+    });
+
+    await expect(httpPost("http://10.0.0.1:8080/v1/test", "{}", {})).rejects.toThrow("ECONNREFUSED");
+  });
+
+  it("rejects on timeout and destroys the request", async () => {
+    const req = new EventEmitter() as EventEmitter & {
+      end: ReturnType<typeof vi.fn>;
+      setTimeout: ReturnType<typeof vi.fn>;
+      destroy: ReturnType<typeof vi.fn>;
+    };
+    req.end = vi.fn();
+    req.destroy = vi.fn();
+
+    let timeoutCb: () => void;
+    req.setTimeout = vi.fn((_ms: number, cb: () => void) => { timeoutCb = cb; });
+
+    mockRequest.mockImplementation(() => req);
+
+    const promise = httpPost("http://10.0.0.1:8080/v1/test", "{}", {}, 100);
+
+    // Trigger the timeout callback
+    process.nextTick(() => timeoutCb());
+
+    await expect(promise).rejects.toThrow("timeout");
+    expect(req.destroy).toHaveBeenCalled();
+  });
+
+  it("settled guard prevents double-settlement on timeout after response start", async () => {
+    const req = new EventEmitter() as EventEmitter & {
+      end: ReturnType<typeof vi.fn>;
+      setTimeout: ReturnType<typeof vi.fn>;
+      destroy: ReturnType<typeof vi.fn>;
+    };
+    req.end = vi.fn();
+    req.destroy = vi.fn();
+
+    let timeoutCb: () => void;
+    req.setTimeout = vi.fn((_ms: number, cb: () => void) => { timeoutCb = cb; });
+
+    const res = new EventEmitter() as EventEmitter & { statusCode: number };
+    res.statusCode = 200;
+
+    mockRequest.mockImplementation((_opts: unknown, callback: (r: unknown) => void) => {
+      process.nextTick(() => {
+        callback(res);
+        // Response ends, then timeout fires — settled flag should prevent double-settlement
+        process.nextTick(() => {
+          res.emit("end");
+          process.nextTick(() => timeoutCb());
+        });
+      });
+      return req;
+    });
+
+    const result = await httpPost("http://10.0.0.1:8080/v1/test", "{}", {});
+    expect(result.statusCode).toBe(200);
   });
 });

--- a/repram-mcp/src/node/transport.ts
+++ b/repram-mcp/src/node/transport.ts
@@ -4,11 +4,18 @@
  * Port of internal/gossip/http_transport.go. Handles serialization
  * between internal Message objects and the JSON wire format (WireMessage),
  * including base64 encoding of binary data for Go compatibility.
+ *
+ * Uses node:http instead of fetch/undici to avoid connection pool
+ * contention, ArrayBuffer accumulation, and head-of-line blocking
+ * under sustained gossip load (#94, #116, #117).
  */
 
+import { request as httpRequest, Agent } from "node:http";
 import { signBody } from "./auth.js";
 import type { Logger } from "./logger.js";
 import type { Message, NodeInfo, WireMessage, WireNodeInfo } from "./types.js";
+
+const gossipAgent = new Agent({ keepAlive: true, maxSockets: 4 });
 
 export class HTTPTransport {
   private localNode: NodeInfo;
@@ -26,46 +33,53 @@ export class HTTPTransport {
     const wireMsg = messageToWire(msg);
     const jsonBody = JSON.stringify(wireMsg);
 
-    const url = `http://${target.address}:${target.httpPort}/v1/gossip/message`;
-
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
+      "Content-Length": String(Buffer.byteLength(jsonBody)),
     };
 
     if (this.clusterSecret) {
       headers["X-Repram-Signature"] = signBody(this.clusterSecret, Buffer.from(jsonBody));
     }
 
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 5_000);
+    return new Promise<void>((resolve, reject) => {
+      const req = httpRequest(
+        {
+          hostname: target.address,
+          port: target.httpPort,
+          path: "/v1/gossip/message",
+          method: "POST",
+          headers,
+          agent: gossipAgent,
+        },
+        (res) => {
+          let body = "";
+          res.on("data", (chunk: Buffer) => { body += chunk; });
+          res.on("end", () => {
+            if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+              this.logger.debug(`Sent ${msg.type} message to ${target.id}`);
+              resolve();
+            } else {
+              this.logger.warn(`Message rejected by ${target.id} with status ${res.statusCode}: ${body.slice(0, 200)}`);
+              resolve();
+            }
+          });
+        },
+      );
 
-    try {
-      const response = await fetch(url, {
-        method: "POST",
-        headers,
-        body: jsonBody,
-        signal: controller.signal,
+      req.on("error", (err) => {
+        this.logger.warn(`Failed to send message to ${target.id}: ${err}`);
+        reject(err);
       });
 
-      // Drain the response body so undici can return the socket to its
-      // pool. Without this, each request pins a new socket and its
-      // internal buffers accumulate as external memory (#94).
-      const responseText = await response.text();
-
-      if (!response.ok) {
-        this.logger.warn(`Message rejected by ${target.id} with status ${response.status}: ${responseText.slice(0, 200)}`);
-      } else {
-        this.logger.debug(`Sent ${msg.type} message to ${target.id} at ${url}`);
-      }
-    } catch (err) {
-      if (err instanceof Error && err.name === "AbortError") {
+      req.setTimeout(5_000, () => {
+        req.destroy();
         this.logger.warn(`Send to ${target.id} timed out`);
-      } else {
-        this.logger.warn(`Failed to send message to ${target.id}: ${err}`);
-      }
-    } finally {
-      clearTimeout(timeout);
-    }
+        reject(new Error("timeout"));
+      });
+
+      req.end(jsonBody);
+    });
   }
 
   setMessageHandler(handler: (msg: Message) => void): void {
@@ -138,4 +152,46 @@ function wireToNodeInfo(wire: WireNodeInfo): NodeInfo {
     httpPort: wire.http_port,
     enclave: wire.enclave ?? "default",
   };
+}
+
+// --- Shared HTTP helper ---
+
+export interface HttpPostResult {
+  statusCode: number;
+  body: string;
+}
+
+export function httpPost(
+  url: string,
+  body: string,
+  headers: Record<string, string>,
+  timeoutMs = 5_000,
+): Promise<HttpPostResult> {
+  const parsed = new URL(url);
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port || 80,
+        path: parsed.pathname + parsed.search,
+        method: "POST",
+        headers: { ...headers, "Content-Length": String(Buffer.byteLength(body)) },
+        agent: gossipAgent,
+      },
+      (res) => {
+        let responseBody = "";
+        res.on("data", (chunk: Buffer) => { responseBody += chunk; });
+        res.on("end", () => {
+          resolve({ statusCode: res.statusCode ?? 0, body: responseBody });
+        });
+      },
+    );
+
+    req.on("error", reject);
+    req.setTimeout(timeoutMs, () => {
+      req.destroy();
+      reject(new Error("timeout"));
+    });
+    req.end(body);
+  });
 }

--- a/repram-mcp/src/node/transport.ts
+++ b/repram-mcp/src/node/transport.ts
@@ -16,6 +16,7 @@ import type { Logger } from "./logger.js";
 import type { Message, NodeInfo, WireMessage, WireNodeInfo } from "./types.js";
 
 const gossipAgent = new Agent({ keepAlive: true, maxSockets: 4 });
+const bootstrapAgent = new Agent({ keepAlive: true, maxSockets: 2 });
 
 export class HTTPTransport {
   private localNode: NodeInfo;
@@ -43,6 +44,7 @@ export class HTTPTransport {
     }
 
     return new Promise<void>((resolve, reject) => {
+      let settled = false;
       const req = httpRequest(
         {
           hostname: target.address,
@@ -56,24 +58,29 @@ export class HTTPTransport {
           let body = "";
           res.on("data", (chunk: Buffer) => { body += chunk; });
           res.on("end", () => {
+            if (settled) return;
+            settled = true;
             if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
               this.logger.debug(`Sent ${msg.type} message to ${target.id}`);
-              resolve();
             } else {
               this.logger.warn(`Message rejected by ${target.id} with status ${res.statusCode}: ${body.slice(0, 200)}`);
-              resolve();
             }
+            resolve();
           });
         },
       );
 
       req.on("error", (err) => {
+        if (settled) return;
+        settled = true;
         this.logger.warn(`Failed to send message to ${target.id}: ${err}`);
         reject(err);
       });
 
       req.setTimeout(5_000, () => {
         req.destroy();
+        if (settled) return;
+        settled = true;
         this.logger.warn(`Send to ${target.id} timed out`);
         reject(new Error("timeout"));
       });
@@ -176,21 +183,22 @@ export function httpPost(
         path: parsed.pathname + parsed.search,
         method: "POST",
         headers: { ...headers, "Content-Length": String(Buffer.byteLength(body)) },
-        agent: gossipAgent,
+        agent: bootstrapAgent,
       },
       (res) => {
         let responseBody = "";
         res.on("data", (chunk: Buffer) => { responseBody += chunk; });
         res.on("end", () => {
-          resolve({ statusCode: res.statusCode ?? 0, body: responseBody });
+          if (!settled) { settled = true; resolve({ statusCode: res.statusCode ?? 0, body: responseBody }); }
         });
       },
     );
 
-    req.on("error", reject);
+    let settled = false;
+    req.on("error", (err) => { if (!settled) { settled = true; reject(err); } });
     req.setTimeout(timeoutMs, () => {
       req.destroy();
-      reject(new Error("timeout"));
+      if (!settled) { settled = true; reject(new Error("timeout")); }
     });
     req.end(body);
   });

--- a/repram-mcp/src/node/transport.ts
+++ b/repram-mcp/src/node/transport.ts
@@ -176,6 +176,7 @@ export function httpPost(
 ): Promise<HttpPostResult> {
   const parsed = new URL(url);
   return new Promise((resolve, reject) => {
+    let settled = false;
     const req = httpRequest(
       {
         hostname: parsed.hostname,
@@ -194,7 +195,6 @@ export function httpPost(
       },
     );
 
-    let settled = false;
     req.on("error", (err) => { if (!settled) { settled = true; reject(err); } });
     req.setTimeout(timeoutMs, () => {
       req.destroy();


### PR DESCRIPTION
## Summary

- **Replaces `fetch()`/undici with `node:http.request`** in the TS gossip transport (`transport.ts`) and bootstrap layer (`bootstrap.ts`). Uses a shared `http.Agent` with `keepAlive: true, maxSockets: 4` — explicit pool control, no ArrayBuffer accumulation, no head-of-line blocking.
- **Parallelizes all broadcast loops** in `gossip.ts` (`broadcastToEnclave`, `forwardToEnclave`, `broadcast`) via `Promise.allSettled` through a new `sendToAll` helper. Peers are contacted concurrently instead of sequentially.
- **Updates tests** to mock `http.request` (transport) and `httpPost` (bootstrap) instead of global `fetch`.

Addresses three compounding undici issues under sustained load:
1. Response body pinning forcing new sockets (#94 workaround removed)
2. 574MB ArrayBuffer accumulation in undici internals
3. Head-of-line blocking causing 1-7s broadcast latency, exceeding 5s write timeout → 100% 202 on TS-originated writes (#116)

Client (`src/client.ts`) intentionally stays on `fetch` — not a hot path.

Closes #116, closes #117.

## Test plan

- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] All 381 TS tests pass (22/22 test files)
- [x] All 155 Go tests pass
- [ ] Deploy to burn-in cluster and verify TS node returns 201 (not 202) under sustained load
- [ ] Monitor TS node external memory — expect significant reduction from 574MB baseline

// ticktockbent