### PR TITLE
fix(ts): dedicated persistent connection per peer, not shared pool

### DIFF
--- a/repram-mcp/src/node/gossip.ts
+++ b/repram-mcp/src/node/gossip.ts
@@ -169,6 +169,10 @@ export class GossipProtocol {
       );
       return false;
     }
+    const existing = this.peers.get(node.id);
+    if (existing && (existing.address !== node.address || existing.httpPort !== node.httpPort)) {
+      this.transport?.onPeerRemoved?.(existing);
+    }
     this.peers.set(node.id, node);
     this.peerFailures.delete(node.id); // reset failure counter on (re-)add
     this.metricsCallbacks?.onPeersActive(this.peers.size);

--- a/repram-mcp/src/node/gossip.ts
+++ b/repram-mcp/src/node/gossip.ts
@@ -28,6 +28,8 @@ export const MAX_SEEN_MESSAGES = 100_000;
 export interface Transport {
   send(target: NodeInfo, msg: Message): Promise<void>;
   setMessageHandler(handler: (msg: Message) => void): void;
+  onPeerRemoved?(peer: NodeInfo): void;
+  destroy?(): void;
 }
 
 // --- Message ID generation ---
@@ -146,6 +148,7 @@ export class GossipProtocol {
       clearInterval(this.topologySyncTimer);
       this.topologySyncTimer = null;
     }
+    this.transport?.destroy?.();
   }
 
   // --- Peer management ---
@@ -174,8 +177,10 @@ export class GossipProtocol {
   }
 
   removePeer(nodeId: string): void {
+    const peer = this.peers.get(nodeId);
     this.peers.delete(nodeId);
     this.peerFailures.delete(nodeId);
+    if (peer) this.transport?.onPeerRemoved?.(peer);
     this.metricsCallbacks?.onPeersActive(this.peers.size);
   }
 

--- a/repram-mcp/src/node/transport.test.ts
+++ b/repram-mcp/src/node/transport.test.ts
@@ -5,9 +5,13 @@ import type { Message, NodeInfo, WireMessage } from "./types.js";
 
 const mockRequest = vi.fn();
 
+class MockAgent {
+  destroy = vi.fn();
+}
+
 vi.mock("node:http", () => ({
   request: mockRequest,
-  Agent: vi.fn(),
+  Agent: MockAgent,
 }));
 
 // Import after mock so the module picks up the mocked http
@@ -472,5 +476,63 @@ describe("httpPost", () => {
 
     const result = await httpPost("http://10.0.0.1:8080/v1/test", "{}", {});
     expect(result.statusCode).toBe(200);
+  });
+});
+
+// --- Peer connection lifecycle ---
+
+describe("HTTPTransport peer connection lifecycle", () => {
+  it("creates a dedicated agent per peer on first send", async () => {
+    setupMockRequest(200);
+
+    const logger = new Logger("error");
+    const transport = new HTTPTransport(makeNodeInfo(), "", logger);
+
+    const peer1 = makeNodeInfo({ id: "peer-1", address: "10.0.0.1", httpPort: 8080 });
+    const peer2 = makeNodeInfo({ id: "peer-2", address: "10.0.0.2", httpPort: 8080 });
+
+    await transport.send(peer1, makeMessage());
+    await transport.send(peer2, makeMessage());
+    await transport.send(peer1, makeMessage()); // reuses existing agent
+
+    // Each call uses its own agent instance — 2 unique agents created
+    const agents = mockRequest.mock.calls.map((c: unknown[]) => (c[0] as { agent: unknown }).agent);
+    expect(agents[0]).toBe(agents[2]); // same peer-1 agent reused
+    expect(agents[0]).not.toBe(agents[1]); // different agents for different peers
+  });
+
+  it("onPeerRemoved destroys the agent for that peer", async () => {
+    setupMockRequest(200);
+
+    const logger = new Logger("error");
+    const transport = new HTTPTransport(makeNodeInfo(), "", logger);
+
+    const peer = makeNodeInfo({ id: "peer-1", address: "10.0.0.1", httpPort: 8080 });
+    await transport.send(peer, makeMessage());
+
+    // The agent was created — now remove the peer
+    transport.onPeerRemoved(peer);
+
+    // Sending again should create a fresh agent
+    await transport.send(peer, makeMessage());
+    const agents = mockRequest.mock.calls.map((c: unknown[]) => (c[0] as { agent: unknown }).agent);
+    expect(agents[0]).not.toBe(agents[1]);
+  });
+
+  it("destroy cleans up all peer agents", async () => {
+    setupMockRequest(200);
+
+    const logger = new Logger("error");
+    const transport = new HTTPTransport(makeNodeInfo(), "", logger);
+
+    await transport.send(makeNodeInfo({ id: "p1", address: "10.0.0.1" }), makeMessage());
+    await transport.send(makeNodeInfo({ id: "p2", address: "10.0.0.2" }), makeMessage());
+
+    transport.destroy();
+
+    // After destroy, sending creates new agents
+    await transport.send(makeNodeInfo({ id: "p1", address: "10.0.0.1" }), makeMessage());
+    const agents = mockRequest.mock.calls.map((c: unknown[]) => (c[0] as { agent: unknown }).agent);
+    expect(agents[0]).not.toBe(agents[2]); // new agent after destroy
   });
 });

--- a/repram-mcp/src/node/transport.test.ts
+++ b/repram-mcp/src/node/transport.test.ts
@@ -510,8 +510,11 @@ describe("HTTPTransport peer connection lifecycle", () => {
     const peer = makeNodeInfo({ id: "peer-1", address: "10.0.0.1", httpPort: 8080 });
     await transport.send(peer, makeMessage());
 
+    const firstAgent = mockRequest.mock.calls[0][0].agent as MockAgent;
+
     // The agent was created — now remove the peer
     transport.onPeerRemoved(peer);
+    expect(firstAgent.destroy).toHaveBeenCalledTimes(1);
 
     // Sending again should create a fresh agent
     await transport.send(peer, makeMessage());

--- a/repram-mcp/src/node/transport.ts
+++ b/repram-mcp/src/node/transport.ts
@@ -5,9 +5,10 @@
  * between internal Message objects and the JSON wire format (WireMessage),
  * including base64 encoding of binary data for Go compatibility.
  *
- * Uses node:http instead of fetch/undici to avoid connection pool
- * contention, ArrayBuffer accumulation, and head-of-line blocking
- * under sustained gossip load (#94, #116, #117).
+ * Uses node:http with one dedicated Agent per peer — a persistent
+ * connection that's always warm, no pool contention, no burst queuing.
+ * Gossip talks to a fixed, known set of peers for the lifetime of the
+ * process; a connection pool is the wrong abstraction (#116, #117).
  */
 
 import { request as httpRequest, Agent } from "node:http";
@@ -15,7 +16,6 @@ import { signBody } from "./auth.js";
 import type { Logger } from "./logger.js";
 import type { Message, NodeInfo, WireMessage, WireNodeInfo } from "./types.js";
 
-const gossipAgent = new Agent({ keepAlive: true, maxSockets: 4 });
 const bootstrapAgent = new Agent({ keepAlive: true, maxSockets: 2 });
 
 export class HTTPTransport {
@@ -23,11 +23,40 @@ export class HTTPTransport {
   private clusterSecret: string;
   private logger: Logger;
   private messageHandler: ((msg: Message) => void) | null = null;
+  private peerAgents = new Map<string, Agent>();
 
   constructor(localNode: NodeInfo, clusterSecret: string, logger: Logger) {
     this.localNode = localNode;
     this.clusterSecret = clusterSecret;
     this.logger = logger;
+  }
+
+  private agentFor(target: NodeInfo): Agent {
+    const key = `${target.address}:${target.httpPort}`;
+    let agent = this.peerAgents.get(key);
+    if (!agent) {
+      agent = new Agent({ keepAlive: true, maxSockets: 1 });
+      this.peerAgents.set(key, agent);
+      this.logger.debug(`Created dedicated connection for peer ${target.id} (${key})`);
+    }
+    return agent;
+  }
+
+  onPeerRemoved(peer: NodeInfo): void {
+    const key = `${peer.address}:${peer.httpPort}`;
+    const agent = this.peerAgents.get(key);
+    if (agent) {
+      agent.destroy();
+      this.peerAgents.delete(key);
+      this.logger.debug(`Closed dedicated connection for evicted peer ${peer.id} (${key})`);
+    }
+  }
+
+  destroy(): void {
+    for (const agent of this.peerAgents.values()) {
+      agent.destroy();
+    }
+    this.peerAgents.clear();
   }
 
   async send(target: NodeInfo, msg: Message): Promise<void> {
@@ -52,7 +81,7 @@ export class HTTPTransport {
           path: "/v1/gossip/message",
           method: "POST",
           headers,
-          agent: gossipAgent,
+          agent: this.agentFor(target),
         },
         (res) => {
           let body = "";


### PR DESCRIPTION
## Summary

- Replaces the shared `gossipAgent` (maxSockets: 4, all peers contend for the same 4 sockets) with a `Map<string, Agent>` of per-peer Agents (maxSockets: 1, keepAlive: true). One dedicated, always-warm connection per peer.
- Adds `onPeerRemoved()` to the Transport interface — called by `GossipProtocol.removePeer()` on eviction, destroys the stale Agent so evicted peers don't leave dangling sockets.
- Adds `destroy()` to clean up all peer agents on shutdown, called from `GossipProtocol.stop()`.
- New peers from bootstrap/topology-sync get connections lazily on first `send()`.

Under sustained load, the shared pool caused 4-7s socket queuing that exceeded the 5s write timeout — even after PR #118 parallelized broadcasts. The root cause was that all gossip traffic (PUTs, ACKs, PINGs, SYNCs) to all peers shared 4 sockets. Under burst concurrency from parallel broadcasts, later requests waited seconds for a free socket.

With dedicated connections, each peer always has a warm socket ready. No contention, no queuing, no burst sensitivity. At ≤9 peers (below fanout threshold), that's ≤9 persistent sockets — trivial.

Closes #116, closes #117.

## Test plan

- [x] TypeScript type check passes
- [x] All 389 TS tests pass (22/22 files)
- [ ] Deploy to burn-in cluster and verify TS node returns 201 under sustained load
- [ ] Confirm `ss` shows 1 connection per peer (not shared pool growth)
- [ ] Verify peer eviction closes the stale connection
- [ ] Monitor ArrayBuffer memory stays low (no regression from PR #118)

// ticktockbent