### PR TITLE
fix(tree): skip self in WebSocket attachment candidates (#120)

### DIFF
--- a/repram-mcp/src/index.ts
+++ b/repram-mcp/src/index.ts
@@ -169,8 +169,19 @@ async function attachToSubstrate(
   seedPeers: string[],
   logger: Logger,
 ): Promise<void> {
+  // Same self-skip as bootstrapFromPeers (#87): the seed list may include
+  // this node's own address (e.g., omega root list). Attaching to self
+  // makes the node both substrate and transient for itself, routing all
+  // PUTs through the self-WS connection instead of broadcasting (#120).
+  const selfAdvertised = `${config.address}:${config.httpPort}`;
+
   // Try each seed peer for WS attachment
   for (const seed of seedPeers) {
+    if (seed === selfAdvertised) {
+      logger.debug(`Skipping self in WS attachment candidates (${seed})`);
+      continue;
+    }
+
     const [address, portStr] = seed.split(":");
     const port = parseInt(portStr, 10);
     if (!address || isNaN(port)) continue;

--- a/repram-mcp/src/node/tree.test.ts
+++ b/repram-mcp/src/node/tree.test.ts
@@ -755,20 +755,22 @@ describe("TreeManager", () => {
         ) => Promise<boolean>;
       }).tryAlternatives.bind(tree);
 
-      // List contains self (by address+port) plus an unreachable peer.
-      // Self should be skipped silently; the unreachable peer will fail
-      // with a connection error. If self were NOT skipped, connectToSubstrate
-      // would try to open a WS connection to the local node (no server
-      // running on 18080 in this test) — both would fail, but the test
-      // verifies that only one connection attempt is made (the non-self entry).
-      const alts: AlternativeParent[] = [
+      // Pass ONLY a self-matching entry. If self-skip works, the loop body
+      // never executes connectToSubstrate, so the call returns false almost
+      // instantly. If self-skip is broken, connectToSubstrate tries to open
+      // a TCP connection to 10.0.10.104:18080 (unreachable in CI), which
+      // blocks for the full 5s perAttemptTimeout before failing.
+      const selfOnlyAlts: AlternativeParent[] = [
         { id: "self-seed", address: "10.0.10.104", http_port: 18080 },
-        { id: "seed-10.0.0.99:8080", address: "10.0.0.99", http_port: 8080 },
       ];
 
-      const result = await tryAlternatives(alts, 1_000, undefined);
-      // Both should fail (self skipped, other unreachable), so result is false.
+      const start = Date.now();
+      const result = await tryAlternatives(selfOnlyAlts, 5_000, undefined);
+      const elapsed = Date.now() - start;
+
       expect(result).toBe(false);
+      // Self-skip should make this return in under 50ms, not 5s+.
+      expect(elapsed).toBeLessThan(500);
 
       tree.stop();
     }, 10_000);

--- a/repram-mcp/src/node/tree.test.ts
+++ b/repram-mcp/src/node/tree.test.ts
@@ -740,6 +740,39 @@ describe("TreeManager", () => {
       await pair.cleanup();
     }, 15_000);
 
+    // #120: tryAlternatives must skip entries matching the local node's
+    // address+port so the node never attaches to itself via WS.
+    it("tryAlternatives skips self-matching entries (#120)", async () => {
+      const localNode = makeNodeInfo("node-c", { address: "10.0.10.104", httpPort: 18080 });
+      const gossip = new GossipProtocol(localNode, 3, silentLogger());
+      const tree = makeTreeManager(localNode, gossip, { inbound: "false" });
+
+      const tryAlternatives = (tree as unknown as {
+        tryAlternatives: (
+          alts: AlternativeParent[],
+          timeout: number,
+          deadline: number | undefined,
+        ) => Promise<boolean>;
+      }).tryAlternatives.bind(tree);
+
+      // List contains self (by address+port) plus an unreachable peer.
+      // Self should be skipped silently; the unreachable peer will fail
+      // with a connection error. If self were NOT skipped, connectToSubstrate
+      // would try to open a WS connection to the local node (no server
+      // running on 18080 in this test) — both would fail, but the test
+      // verifies that only one connection attempt is made (the non-self entry).
+      const alts: AlternativeParent[] = [
+        { id: "self-seed", address: "10.0.10.104", http_port: 18080 },
+        { id: "seed-10.0.0.99:8080", address: "10.0.0.99", http_port: 8080 },
+      ];
+
+      const result = await tryAlternatives(alts, 1_000, undefined);
+      // Both should fail (self skipped, other unreachable), so result is false.
+      expect(result).toBe(false);
+
+      tree.stop();
+    }, 10_000);
+
     it("stop() sets stopping flag and resolves pending sleeps promptly", async () => {
       const tree = makeTreeManager(makeNodeInfo("t-1"), new GossipProtocol(makeNodeInfo("t-1"), 3, silentLogger()));
       const internal = tree as unknown as {

--- a/repram-mcp/src/node/tree.ts
+++ b/repram-mcp/src/node/tree.ts
@@ -554,7 +554,9 @@ export class TreeManager {
 
       // Skip self — seed-list layer uses synthetic IDs so the ID filter
       // in welcome-topology population doesn't catch it. Address+port is
-      // the reliable self-check across all layers (#120).
+      // the reliable self-check across all layers (#120). Literal match
+      // only — loopback aliases (0.0.0.0 vs 127.0.0.1) are not normalized;
+      // config.address is always the routable IP in practice.
       if (alt.address === this.localNode.address && alt.http_port === this.localNode.httpPort) {
         continue;
       }

--- a/repram-mcp/src/node/tree.ts
+++ b/repram-mcp/src/node/tree.ts
@@ -552,6 +552,13 @@ export class TreeManager {
         return false;
       }
 
+      // Skip self — seed-list layer uses synthetic IDs so the ID filter
+      // in welcome-topology population doesn't catch it. Address+port is
+      // the reliable self-check across all layers (#120).
+      if (alt.address === this.localNode.address && alt.http_port === this.localNode.httpPort) {
+        continue;
+      }
+
       this.logger.info(
         `Attempting reattachment to ${alt.id} (${alt.address}:${alt.http_port})`,
       );


### PR DESCRIPTION
## Summary

- **index.ts `attachToSubstrate`**: Skip seed peers matching `config.address:config.httpPort` before attempting WS connection. Same pattern as the HTTP bootstrap self-skip added in PR #103 (#87).
- **tree.ts `tryAlternatives`**: Skip alternatives matching `localNode.address:localNode.httpPort`. Covers all three reattach layers (goodbye payload, cached topology, seed list) — the seed-list layer used synthetic IDs that bypassed the existing node-ID filter.
- **tree.test.ts**: New test verifying `tryAlternatives` skips self-matching entries.

Closes #120.

## Root cause

The omega signed root list includes the node's own address. The WS attachment logic iterated all seeds without a self-skip, so the node connected to its own WS server. This made it both substrate and transient for itself. `cluster.ts put()` checks `treeManager.parent` — with a self-WS parent, PUTs went through WS to self instead of HTTP broadcast to peers. Go nodes never received the PUT, the 5s write timeout fired, and ACKs arrived too late. Result: **100% 202** on all TS-originated writes.

## Test plan

- [x] New unit test: `tryAlternatives skips self-matching entries (#120)`
- [x] All 390 TS tests pass
- [x] All Go tests pass
- [ ] Rebuild TS image, restart node-c, verify 201s on TS-originated writes in burn-in cluster

// ticktockbent