### PR TITLE
chore(burnin): preserve 2.1 segment runner harness

### DIFF
--- a/test/burnin/commands.md
+++ b/test/burnin/commands.md
@@ -566,13 +566,11 @@ DNSMASQ_HOSTS_FILE=/etc/dnsmasq.d/repram-burnin.conf \
 /home/ticktockbent/projects/infrastructure/repram/test/burnin/sign-loop.sh \
   | tee -a $HOME/.repram-burnin/sign-loop.log
 
-# Pane 2: k6 — full 48h with Prometheus remote-write enabled
-docker run --rm -i --network host \
-  -v /home/ticktockbent/projects/infrastructure/repram/test/burnin:/work \
-  -e REPRAM_NODES=http://10.0.20.72:18080,http://10.0.10.81:18080,http://10.0.10.104:18080 \
-  -e BURNIN_DURATION=72h \
-  -e K6_PROMETHEUS_RW_SERVER_URL=http://localhost:9090/api/v1/write \
-  grafana/k6 run --out experimental-prometheus-rw /work/workload.js \
+# Pane 2: k6 — 6 × 12h segments with Prometheus remote-write
+# Each segment writes its summary to ~/.repram-burnin/k6-segment-N.txt
+# and exits, freeing k6's accumulated metric memory. Segment 1 runs
+# full setup; segments 2+ skip it (SKIP_SETUP=true).
+/home/ticktockbent/projects/infrastructure/repram/test/burnin/run-segments.sh \
   | tee -a $HOME/.repram-burnin/k6.log
 
 # Pane 3: dashboard watcher — keep eyes on it during initial 30 min

--- a/test/burnin/ramp-pprof-capture.sh
+++ b/test/burnin/ramp-pprof-capture.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Capture pprof snapshots at regular intervals during a ramp-to-failure run.
+#
+# Run alongside the k6 ramp test. Captures Go heap + goroutine profiles and
+# TS heap stats every INTERVAL seconds. Output goes to a timestamped directory
+# for post-run analysis.
+#
+# Usage:
+#   ./test/burnin/ramp-pprof-capture.sh
+#
+# The goroutine profile is the key diagnostic: pileup on sync.Mutex means
+# contention (pendingWrites, peer map); pileup on net.(*netFD).connect means
+# connection pool exhaustion.
+
+set -uo pipefail
+
+GO_NODES=(10.0.20.72 10.0.10.81)
+TS_NODE=10.0.10.104
+PPROF_PORT=6060
+INTERVAL="${CAPTURE_INTERVAL_SEC:-120}"
+
+OUTDIR="${RAMP_CAPTURE_DIR:-$HOME/.repram-burnin/ramp-captures/$(date +%Y%m%d-%H%M%S)}"
+mkdir -p "$OUTDIR"
+
+echo "$(date -Is) pprof capture started — interval ${INTERVAL}s, output: $OUTDIR"
+
+trap 'echo "$(date -Is) pprof capture stopped"; exit 0' INT TERM
+
+cycle=0
+while :; do
+    cycle=$((cycle + 1))
+    ts=$(date +%s)
+
+    for ip in "${GO_NODES[@]}"; do
+        curl -s -m 10 "http://${ip}:${PPROF_PORT}/debug/pprof/heap" \
+            > "$OUTDIR/heap-${ip}-${ts}.pprof" 2>/dev/null || true
+        curl -s -m 10 "http://${ip}:${PPROF_PORT}/debug/pprof/goroutine" \
+            > "$OUTDIR/goroutine-${ip}-${ts}.pprof" 2>/dev/null || true
+    done
+
+    curl -s -m 10 "http://${TS_NODE}:${PPROF_PORT}/debug/pprof/stats" \
+        > "$OUTDIR/stats-ts-${ts}.json" 2>/dev/null || true
+
+    echo "$(date -Is) cycle=$cycle captured ($(ls "$OUTDIR" | wc -l) files)"
+    sleep "$INTERVAL"
+done

--- a/test/burnin/ramp-to-failure.js
+++ b/test/burnin/ramp-to-failure.js
@@ -1,0 +1,346 @@
+// REPRAM ramp-to-failure test.
+//
+// Two independent scenarios that run sequentially:
+//
+//   1. OPS CEILING — tiny payload, ramping request rate
+//      Finds the maximum ops/sec the cluster can sustain before errors or
+//      latency degrade past the threshold. Bottleneck is gossip amplification,
+//      event loop / goroutine saturation, or rate limiter headroom.
+//
+//   2. DATA THROUGHPUT CEILING — fixed moderate rate, ramping payload size
+//      Finds the maximum bytes/sec the cluster can move. Bottleneck is memory
+//      pressure, gossip serialization cost, or MaxBytesReader.
+//
+// Each scenario ramps in stepped plateaus — hold each level long enough for
+// the system to either stabilize or visibly degrade (~2-3 min per step).
+//
+// Inflection indicators to watch:
+//   - 202 rate: the moment 202s appear, you've crossed the quorum reliability
+//     threshold. That's the first meaningful ceiling.
+//   - Latency shape: if latency climbs but throughput is flat → contention
+//     (pendingWrites mutex, connection pool). If throughput climbs then drops
+//     sharply → resource exhaustion (memory, file descriptors).
+//   - TS external memory: should stabilize at each plateau if the fetch drain
+//     fix holds. Linear climb with rate = leak path still open.
+//
+// Run:
+//   k6 run \
+//     -e REPRAM_NODES=http://10.0.20.72:18080,http://10.0.10.81:18080,http://10.0.10.104:18080 \
+//     test/burnin/ramp-to-failure.js
+//
+// To run only one scenario:
+//   -e SCENARIO=ops      (skip data throughput)
+//   -e SCENARIO=data     (skip ops ceiling)
+//
+// TTL mode (affects GC pressure profile):
+//   -e TTL_MODE=short    (10-30s TTLs — streaming simulation)
+//   -e TTL_MODE=long     (300-600s TTLs — default, matches burn-in)
+
+import http from 'k6/http';
+import { check } from 'k6';
+import { Counter, Rate, Trend } from 'k6/metrics';
+
+const NODES = (__ENV.REPRAM_NODES || 'http://localhost:18080').split(',').map(s => s.trim());
+const SCENARIO_FILTER = (__ENV.SCENARIO || 'both').toLowerCase();
+const TTL_MODE = (__ENV.TTL_MODE || 'long').toLowerCase();
+
+// --- TTL profiles -----------------------------------------------------------
+
+function getTtl() {
+    if (TTL_MODE === 'short') {
+        return 10 + Math.floor(Math.random() * 20); // 10-30s
+    }
+    return 300 + Math.floor(Math.random() * 300); // 300-600s
+}
+
+// --- Payload generators ------------------------------------------------------
+
+function tinyPayload() {
+    return JSON.stringify({ t: Date.now(), v: __VU, i: __ITER });
+}
+
+const DATA_SIZES = [1024, 10240, 102400, 524288, 1048576]; // 1K, 10K, 100K, 512K, 1M
+const DATA_STAGE_DURATION = '3m';
+
+const FILL_STRINGS = {};
+for (const size of DATA_SIZES) {
+    const overhead = 40;
+    FILL_STRINGS[size] = 'X'.repeat(Math.max(0, size - overhead));
+}
+
+function sizedPayload(sizeBytes) {
+    return JSON.stringify({ t: Date.now(), d: FILL_STRINGS[sizeBytes] });
+}
+
+// --- Scenarios ---------------------------------------------------------------
+
+const opsStages = [
+    { target: 100,  duration: '2m' },
+    { target: 250,  duration: '2m' },
+    { target: 500,  duration: '2m' },
+    { target: 1000, duration: '2m' },
+    { target: 2000, duration: '2m' },
+    { target: 3000, duration: '2m' },
+    { target: 4000, duration: '2m' },
+    { target: 5000, duration: '2m' },
+    { target: 6000, duration: '2m' },
+    { target: 8000, duration: '2m' },
+    { target: 10000, duration: '2m' },
+];
+
+const dataStages = DATA_SIZES.map(() => ({
+    target: 50,
+    duration: DATA_STAGE_DURATION,
+}));
+
+function buildScenarios() {
+    const scenarios = {};
+
+    if (SCENARIO_FILTER === 'both' || SCENARIO_FILTER === 'ops') {
+        scenarios.ops_ceiling = {
+            executor: 'ramping-arrival-rate',
+            startRate: 50,
+            timeUnit: '1s',
+            preAllocatedVUs: 50,
+            maxVUs: 200,
+            stages: opsStages,
+            exec: 'opsTest',
+        };
+    }
+
+    if (SCENARIO_FILTER === 'both' || SCENARIO_FILTER === 'data') {
+        scenarios.data_ceiling = {
+            executor: 'ramping-arrival-rate',
+            startRate: 50,
+            timeUnit: '1s',
+            preAllocatedVUs: 30,
+            maxVUs: 100,
+            stages: dataStages,
+            exec: 'dataTest',
+            startTime: SCENARIO_FILTER === 'both'
+                ? `${opsStages.length * 2}m`
+                : '0s',
+        };
+    }
+
+    return scenarios;
+}
+
+export const options = {
+    scenarios: buildScenarios(),
+};
+
+// --- Custom metrics ----------------------------------------------------------
+
+// Ops scenario
+const opsQuorumOk = new Counter('ops_quorum_ok_201');
+const opsQuorumTimeout = new Counter('ops_quorum_timeout_202');
+const opsRateLimited = new Counter('ops_rate_limited_429');
+const opsErrors = new Counter('ops_errors_other');
+const opsQuorumTimeoutRate = new Rate('ops_quorum_timeout_rate');
+const opsLatency = new Trend('ops_put_latency_ms', true);
+
+// Data scenario
+const dataQuorumOk = new Counter('data_quorum_ok_201');
+const dataQuorumTimeout = new Counter('data_quorum_timeout_202');
+const dataRateLimited = new Counter('data_rate_limited_429');
+const dataErrors = new Counter('data_errors_other');
+const dataQuorumTimeoutRate = new Rate('data_quorum_timeout_rate');
+const dataLatency = new Trend('data_put_latency_ms', true);
+
+// Shared
+const putBytes = new Counter('put_payload_bytes');
+
+// --- VU functions ------------------------------------------------------------
+
+export function opsTest() {
+    const node = NODES[__ITER % NODES.length];
+    const key = `ramp-ops-${__VU}-${__ITER}`;
+    const body = tinyPayload();
+    const ttl = getTtl();
+
+    const res = http.put(
+        `${node}/v1/data/${key}`,
+        body,
+        {
+            headers: { 'Content-Type': 'application/json', 'X-TTL': String(ttl) },
+            tags: { scenario: 'ops_ceiling' },
+            name: 'PUT /v1/data/{key}',
+        },
+    );
+
+    opsLatency.add(res.timings.duration);
+    putBytes.add(body.length);
+
+    if (res.status === 200 || res.status === 201) {
+        opsQuorumOk.add(1);
+        opsQuorumTimeoutRate.add(false);
+    } else if (res.status === 202) {
+        opsQuorumTimeout.add(1);
+        opsQuorumTimeoutRate.add(true);
+    } else if (res.status === 429) {
+        opsRateLimited.add(1);
+        opsQuorumTimeoutRate.add(false);
+    } else {
+        opsErrors.add(1);
+        opsQuorumTimeoutRate.add(false);
+    }
+
+    check(res, {
+        'ops: stored (2xx)': (r) => r.status >= 200 && r.status < 300,
+    });
+}
+
+export function dataTest(setupData) {
+    const node = NODES[__ITER % NODES.length];
+    const key = `ramp-data-${__VU}-${__ITER}`;
+    const ttl = getTtl();
+
+    const opsOffsetMs = (SCENARIO_FILTER === 'both')
+        ? opsStages.reduce((s, st) => s + parseInt(st.duration), 0) * 60 * 1000
+        : 0;
+    const elapsedMs = Date.now() - setupData.startedAt - opsOffsetMs;
+    const stageDurationMs = parseInt(DATA_STAGE_DURATION) * 60 * 1000;
+    const stageIdx = Math.min(
+        Math.max(0, Math.floor(elapsedMs / stageDurationMs)),
+        DATA_SIZES.length - 1,
+    );
+    const payloadSize = DATA_SIZES[stageIdx];
+    const body = sizedPayload(payloadSize);
+
+    const res = http.put(
+        `${node}/v1/data/${key}`,
+        body,
+        {
+            headers: { 'Content-Type': 'application/json', 'X-TTL': String(ttl) },
+            tags: { scenario: 'data_ceiling', payload_kb: String(payloadSize / 1024) },
+            name: `PUT /v1/data/{key} [${payloadSize >= 1024 ? payloadSize/1024 + 'KB' : payloadSize + 'B'}]`,
+        },
+    );
+
+    dataLatency.add(res.timings.duration);
+    putBytes.add(body.length);
+
+    if (res.status === 200 || res.status === 201) {
+        dataQuorumOk.add(1);
+        dataQuorumTimeoutRate.add(false);
+    } else if (res.status === 202) {
+        dataQuorumTimeout.add(1);
+        dataQuorumTimeoutRate.add(true);
+    } else if (res.status === 429) {
+        dataRateLimited.add(1);
+        dataQuorumTimeoutRate.add(false);
+    } else {
+        dataErrors.add(1);
+        dataQuorumTimeoutRate.add(false);
+    }
+
+    check(res, {
+        'data: stored (2xx)': (r) => r.status >= 200 && r.status < 300,
+    });
+}
+
+// --- Lifecycle ---------------------------------------------------------------
+
+export function setup() {
+    console.log(`ramp-to-failure: ${NODES.length} nodes — ${NODES.join(', ')}`);
+    console.log(`  scenario: ${SCENARIO_FILTER}`);
+    console.log(`  ttl mode: ${TTL_MODE} (${TTL_MODE === 'short' ? '10-30s' : '300-600s'})`);
+
+    if (SCENARIO_FILTER === 'both' || SCENARIO_FILTER === 'ops') {
+        const maxRate = opsStages[opsStages.length - 1].target;
+        const totalMin = opsStages.reduce((s, st) => s + parseInt(st.duration), 0);
+        console.log(`  ops ceiling: ramp 50 → ${maxRate} ops/sec over ${totalMin}m`);
+    }
+    if (SCENARIO_FILTER === 'both' || SCENARIO_FILTER === 'data') {
+        const sizes = DATA_SIZES.map(s => s >= 1024 ? `${s/1024}KB` : `${s}B`).join(' → ');
+        console.log(`  data ceiling: ${sizes} at 50 ops/sec, ${DATA_STAGE_DURATION}/step`);
+    }
+
+    for (const node of NODES) {
+        const res = http.get(`${node}/v1/health`);
+        if (res.status !== 200) {
+            console.error(`  WARN: ${node} health check failed (HTTP ${res.status})`);
+        }
+    }
+
+    return { startedAt: Date.now() };
+}
+
+export function handleSummary(data) {
+    const lines = ['\n=== RAMP-TO-FAILURE RESULTS ===\n'];
+
+    // --- Ops scenario ---
+    const has_ops = data.metrics.ops_quorum_ok_201;
+    if (has_ops) {
+        const ok = data.metrics.ops_quorum_ok_201?.values?.count || 0;
+        const timeout = data.metrics.ops_quorum_timeout_202?.values?.count || 0;
+        const rl = data.metrics.ops_rate_limited_429?.values?.count || 0;
+        const err = data.metrics.ops_errors_other?.values?.count || 0;
+        const total = ok + timeout + rl + err;
+        const timeoutPct = total > 0 ? ((timeout / total) * 100).toFixed(2) : '0.00';
+
+        lines.push('--- OPS CEILING ---');
+        lines.push(`  Total requests:    ${total}`);
+        lines.push(`  201 (quorum ok):   ${ok}`);
+        lines.push(`  202 (quorum timeout): ${timeout} (${timeoutPct}%)`);
+        lines.push(`  429 (rate limited): ${rl}`);
+        lines.push(`  Other errors:      ${err}`);
+
+        if (data.metrics.ops_put_latency_ms) {
+            const p = data.metrics.ops_put_latency_ms.values;
+            lines.push(`  Latency p50:       ${p['p(50)']?.toFixed(1)}ms`);
+            lines.push(`  Latency p95:       ${p['p(95)']?.toFixed(1)}ms`);
+            lines.push(`  Latency p99:       ${p['p(99)']?.toFixed(1)}ms`);
+            lines.push(`  Latency max:       ${p['max']?.toFixed(1)}ms`);
+        }
+        lines.push('');
+    }
+
+    // --- Data scenario ---
+    const has_data = data.metrics.data_quorum_ok_201;
+    if (has_data) {
+        const ok = data.metrics.data_quorum_ok_201?.values?.count || 0;
+        const timeout = data.metrics.data_quorum_timeout_202?.values?.count || 0;
+        const rl = data.metrics.data_rate_limited_429?.values?.count || 0;
+        const err = data.metrics.data_errors_other?.values?.count || 0;
+        const total = ok + timeout + rl + err;
+        const timeoutPct = total > 0 ? ((timeout / total) * 100).toFixed(2) : '0.00';
+
+        lines.push('--- DATA THROUGHPUT CEILING ---');
+        lines.push(`  Total requests:    ${total}`);
+        lines.push(`  201 (quorum ok):   ${ok}`);
+        lines.push(`  202 (quorum timeout): ${timeout} (${timeoutPct}%)`);
+        lines.push(`  429 (rate limited): ${rl}`);
+        lines.push(`  Other errors:      ${err}`);
+
+        if (data.metrics.data_put_latency_ms) {
+            const p = data.metrics.data_put_latency_ms.values;
+            lines.push(`  Latency p50:       ${p['p(50)']?.toFixed(1)}ms`);
+            lines.push(`  Latency p95:       ${p['p(95)']?.toFixed(1)}ms`);
+            lines.push(`  Latency p99:       ${p['p(99)']?.toFixed(1)}ms`);
+            lines.push(`  Latency max:       ${p['max']?.toFixed(1)}ms`);
+        }
+        lines.push('');
+    }
+
+    // --- Totals ---
+    if (data.metrics.put_payload_bytes) {
+        const totalMB = data.metrics.put_payload_bytes.values.count / 1024 / 1024;
+        lines.push(`Total data pushed:   ${totalMB.toFixed(1)} MB`);
+    }
+
+    lines.push('');
+    lines.push('Look for the inflection point: the stage where 202s first');
+    lines.push('appear is your quorum reliability ceiling. If 429s dominate,');
+    lines.push('raise REPRAM_RATE_LIMIT and rerun to find the real wall.');
+    lines.push('');
+
+    console.log(lines.join('\n'));
+
+    return {
+        stdout: textSummary(data, { indent: '  ', enableColors: true }) + lines.join('\n'),
+    };
+}
+
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.3/index.js';

--- a/test/burnin/run-segments.sh
+++ b/test/burnin/run-segments.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Run the burn-in workload in 12-hour segments. Each segment writes its
+# summary to a separate file, then k6 exits and restarts fresh — no
+# unbounded memory accumulation.
+#
+# Segment 1 runs full setup (ref set + graveyard + warmup).
+# Segments 2+ skip setup (SKIP_SETUP=true) so there's no 6-minute gap.
+#
+# Usage:
+#   ./test/burnin/run-segments.sh
+#
+# Env vars (all optional):
+#   REPRAM_NODES         — comma-sep node URLs (default: burn-in cluster)
+#   SEGMENT_DURATION     — per-segment duration (default: 12h)
+#   TOTAL_SEGMENTS       — how many segments (default: 6 = 72h)
+#   K6_PROMETHEUS_RW_SERVER_URL — Prometheus remote-write URL
+
+set -uo pipefail
+
+NODES="${REPRAM_NODES:-http://10.0.20.72:18080,http://10.0.10.81:18080,http://10.0.10.104:18080}"
+DURATION="${SEGMENT_DURATION:-12h}"
+SEGMENTS="${TOTAL_SEGMENTS:-6}"
+PROM_URL="${K6_PROMETHEUS_RW_SERVER_URL:-http://localhost:9090/api/v1/write}"
+WORKDIR=/home/ticktockbent/projects/infrastructure/repram/test/burnin
+LOGDIR="$HOME/.repram-burnin"
+
+mkdir -p "$LOGDIR"
+
+echo "$(date -Is) burn-in: ${SEGMENTS} × ${DURATION} segments"
+echo "  nodes: $NODES"
+echo "  summaries: $LOGDIR/k6-segment-*.txt"
+
+for seg in $(seq 1 "$SEGMENTS"); do
+    skip_setup="false"
+    if [[ "$seg" -gt 1 ]]; then
+        skip_setup="true"
+    fi
+
+    echo ""
+    echo "$(date -Is) === SEGMENT ${seg}/${SEGMENTS} (${DURATION}, skip_setup=${skip_setup}) ==="
+
+    docker run --rm -i --network host \
+        -v "$WORKDIR":/work \
+        -e REPRAM_NODES="$NODES" \
+        -e BURNIN_DURATION="$DURATION" \
+        -e SKIP_SETUP="$skip_setup" \
+        -e SEGMENT="$seg" \
+        -e K6_PROMETHEUS_RW_SERVER_URL="$PROM_URL" \
+        grafana/k6 run --out experimental-prometheus-rw /work/workload.js \
+        2>&1 | tee "$LOGDIR/k6-segment-${seg}.txt"
+
+    exit_code=${PIPESTATUS[0]}
+    echo "$(date -Is) segment ${seg} exited with code ${exit_code}"
+
+    # Exit 99 = k6 threshold crossed — not a fatal error, continue to next segment.
+    # Only stop on real failures (connection errors, script errors, etc.).
+    if [[ "$exit_code" -ne 0 && "$exit_code" -ne 99 ]]; then
+        echo "$(date -Is) segment ${seg} FAILED (exit ${exit_code}) — stopping"
+        exit "$exit_code"
+    fi
+    if [[ "$exit_code" -eq 99 ]]; then
+        echo "$(date -Is) segment ${seg} threshold crossed (exit 99) — continuing"
+    fi
+done
+
+echo ""
+echo "$(date -Is) burn-in complete: all ${SEGMENTS} segments finished"

--- a/test/burnin/workload.js
+++ b/test/burnin/workload.js
@@ -38,6 +38,9 @@ const GRAVEYARD_WARMUP_SEC = 360;
 // that's expected behavior.
 const REF_TTL_SEC = 72 * 3600;
 
+const SEGMENT_DURATION = __ENV.BURNIN_DURATION || '12h';
+const SKIP_SETUP = (__ENV.SKIP_SETUP || '').toLowerCase() === 'true';
+
 export const options = {
     setupTimeout: '15m',
     scenarios: {
@@ -45,7 +48,7 @@ export const options = {
             executor: 'constant-arrival-rate',
             rate: 50,
             timeUnit: '1s',
-            duration: __ENV.BURNIN_DURATION || '72h',
+            duration: SEGMENT_DURATION,
             preAllocatedVUs: 30,
             maxVUs: 60,
         },
@@ -62,33 +65,45 @@ const refMissUnexpected = new Counter('ref_get_unexpected_404');
 const expiredHitUnexpected = new Counter('graveyard_get_unexpected_200');
 
 export function setup() {
+    const segment = __ENV.SEGMENT || '1';
     console.log(`burn-in workload: ${NODES.length} nodes — ${NODES.join(', ')}`);
+    console.log(`  segment: ${segment}  duration: ${SEGMENT_DURATION}  skip_setup: ${SKIP_SETUP}`);
+
+    if (SKIP_SETUP) {
+        console.log('skipping ref/graveyard setup (SKIP_SETUP=true)');
+        return { startedAt: Date.now(), segment };
+    }
+
     console.log(`  ref set: ${REF_SET_SIZE} keys @ ${REF_TTL_SEC}s TTL`);
     console.log(`  graveyard: ${GRAVEYARD_SIZE} keys @ ${GRAVEYARD_TTL_SEC}s TTL (warmup ${GRAVEYARD_WARMUP_SEC}s)`);
 
-    // Write to one node — gossip replicates to the others. Use the first node
-    // so the seed traffic origin is deterministic.
     const seed = NODES[0];
 
     for (let i = 0; i < REF_SET_SIZE; i++) {
         http.put(
             `${seed}/v1/data/bench-ref-${i}`,
             JSON.stringify({ i, kind: 'ref' }),
-            { headers: { 'Content-Type': 'application/json', 'X-TTL': String(REF_TTL_SEC) } },
+            {
+                headers: { 'Content-Type': 'application/json', 'X-TTL': String(REF_TTL_SEC) },
+                name: 'PUT /v1/data/{ref}',
+            },
         );
     }
     for (let i = 0; i < GRAVEYARD_SIZE; i++) {
         http.put(
             `${seed}/v1/data/bench-graveyard-${i}`,
             JSON.stringify({ i, kind: 'graveyard' }),
-            { headers: { 'Content-Type': 'application/json', 'X-TTL': String(GRAVEYARD_TTL_SEC) } },
+            {
+                headers: { 'Content-Type': 'application/json', 'X-TTL': String(GRAVEYARD_TTL_SEC) },
+                name: 'PUT /v1/data/{graveyard}',
+            },
         );
     }
 
     console.log(`waiting ${GRAVEYARD_WARMUP_SEC}s for graveyard to expire before main run`);
     sleep(GRAVEYARD_WARMUP_SEC);
     console.log('warmup complete; starting workload');
-    return { startedAt: Date.now() };
+    return { startedAt: Date.now(), segment };
 }
 
 export default function () {
@@ -124,7 +139,10 @@ function doPut(node) {
 function doGetExisting(node) {
     const i = Math.floor(Math.random() * REF_SET_SIZE);
     const key = `bench-ref-${i}`;
-    const res = http.get(`${node}/v1/data/${key}`, { tags: { op: 'get_existing' } });
+    const res = http.get(`${node}/v1/data/${key}`, {
+        tags: { op: 'get_existing' },
+        name: 'GET /v1/data/{ref}',
+    });
     if (res.status === 404) refMissUnexpected.add(1);
     check(res, { 'GET ref 200': (r) => r.status === 200 });
 }
@@ -132,7 +150,10 @@ function doGetExisting(node) {
 function doGetExpired(node) {
     const i = Math.floor(Math.random() * GRAVEYARD_SIZE);
     const key = `bench-graveyard-${i}`;
-    const res = http.get(`${node}/v1/data/${key}`, { tags: { op: 'get_expired' } });
+    const res = http.get(`${node}/v1/data/${key}`, {
+        tags: { op: 'get_expired' },
+        name: 'GET /v1/data/{graveyard}',
+    });
     if (res.status === 200) expiredHitUnexpected.add(1);
     check(res, { 'GET expired 404': (r) => r.status === 404 });
 }
@@ -140,7 +161,10 @@ function doGetExpired(node) {
 function doHead(node) {
     const i = Math.floor(Math.random() * REF_SET_SIZE);
     const key = `bench-ref-${i}`;
-    const res = http.request('HEAD', `${node}/v1/data/${key}`, null, { tags: { op: 'head' } });
+    const res = http.request('HEAD', `${node}/v1/data/${key}`, null, {
+        tags: { op: 'head' },
+        name: 'HEAD /v1/data/{ref}',
+    });
     check(res, { 'HEAD 200': (r) => r.status === 200 });
 }
 
@@ -149,7 +173,10 @@ function doList(node) {
     const prefix = `bench-agent-${agentId}-`;
     const res = http.get(
         `${node}/v1/keys?prefix=${encodeURIComponent(prefix)}&limit=100`,
-        { tags: { op: 'list' } },
+        {
+            tags: { op: 'list' },
+            name: 'GET /v1/keys?prefix={agent}',
+        },
     );
     check(res, { 'list 200': (r) => r.status === 200 });
 }


### PR DESCRIPTION
## Summary
- Preserves the burn-in 2.1 harness pieces that lived locally during the run.
- workload.js gets `SEGMENT_DURATION` + `SKIP_SETUP` env handling so segments 2-6 reuse setup state.
- New `run-segments.sh` chains 6 × 12h k6 runs and tolerates exit 99 between segments — this is how k6 frees its accumulated metric memory between windows.
- New `ramp-to-failure.js` + `ramp-pprof-capture.sh` are queued for the next test (ops ceiling + pprof capture during ramp).

Companion to AAR-2.1.md already on main. Re-usable for burn-in 2.2.

## Test plan
- [x] Files are inert until invoked by an operator.
- [x] No effect on production builds.

// ticktockbent