### PR TITLE
chore: gitignore .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ bin/
 !test/burnin/archive-*/*.log
 .vscode/
 .idea/
+.claude/
 *.swp
 *.swo
 *~


### PR DESCRIPTION
## Summary
- Adds `.claude/` to `.gitignore` so Claude Code session state (`scheduled_tasks.lock`, `settings.local.json`, `worktrees/`) stops showing up as untracked.

## Test plan
- [x] `git status` clean after the change.

// ticktockbent