### PR TITLE
feat(dashboard): #16 public network topology dashboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,30 @@
 BINARY_NAME=repram
 OMEGA_BINARY_NAME=repram-omega
+DASHBOARD_BINARY_NAME=repram-dashboard
 
-.PHONY: build build-omega run test clean docker-build docker-run docker-compose-up docker-compose-down
+# Burn-in cluster seeds — useful for `make dashboard-run-burnin` smoke tests.
+BURNIN_SEEDS=10.0.20.72:18080,10.0.10.81:18080,10.0.10.104:18080
+
+.PHONY: build build-omega build-dashboard run dashboard-run-burnin test clean docker-build docker-run docker-compose-up docker-compose-down
 
 build:
 	go build -o bin/$(BINARY_NAME) ./cmd/repram
 	go build -o bin/$(OMEGA_BINARY_NAME) ./cmd/repram-omega
+	go build -o bin/$(DASHBOARD_BINARY_NAME) ./cmd/dashboard
 
 build-omega:
 	go build -o bin/$(OMEGA_BINARY_NAME) ./cmd/repram-omega
+
+build-dashboard:
+	go build -o bin/$(DASHBOARD_BINARY_NAME) ./cmd/dashboard
+
+dashboard-run-burnin: build-dashboard
+	./bin/$(DASHBOARD_BINARY_NAME) \
+		--seeds=$(BURNIN_SEEDS) \
+		--state-dir=$(CURDIR)/.dashboard-state \
+		--listen=127.0.0.1:18181 \
+		--internal-addr=127.0.0.1:18182 \
+		--poll-interval=30s
 
 run: build
 	./bin/$(BINARY_NAME)

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"embed"
+	"flag"
+	"io/fs"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"repram/internal/dashboard"
+)
+
+// Static frontend assets — index.html, app.js, vendored vis-network. The
+// directory layout is fixed (web/) so the dashboard binary stays a single
+// self-contained artifact. See cmd/dashboard/web/UPSTREAM.md for vendoring
+// provenance.
+//
+//go:embed web/*
+var webAssets embed.FS
+
+func main() {
+	var (
+		publicAddr   = flag.String("listen", ":8080", "Address for the public listener (HTML + /api/snapshot).")
+		internalAddr = flag.String("internal-addr", "127.0.0.1:9095", "Address for the internal metrics listener (/internal/metrics). Bind to a loopback unless you have a reason not to.")
+		stateDir     = flag.String("state-dir", defaultStateDir(), "Directory for the omega cache and persisted snapshot.")
+		pollInterval = flag.Duration("poll-interval", 60*time.Second, "How often to walk the topology.")
+		pollWorkers  = flag.Int("poll-workers", 0, "Concurrent topology pollers per cycle. 0 selects the package default (8).")
+		pollTimeout  = flag.Duration("poll-timeout", 0, "Per-request timeout for poller HTTP calls. 0 selects the package default (5s).")
+		seedsFlag    = flag.String("seeds", "", "Comma-separated host:port list of root addresses. When set, bypasses omega DNS entirely — operator break-glass.")
+		geoDBPath    = flag.String("geo-db", "", "Path to a GeoLite2-Country mmdb file. Empty disables country lookups (region falls back to '?').")
+	)
+	flag.Parse()
+
+	logger := log.New(os.Stderr, "", log.LstdFlags|log.Lmicroseconds)
+
+	seeds := splitSeeds(*seedsFlag)
+
+	orch := dashboard.NewOrchestrator(dashboard.Config{
+		StateDir:      *stateDir,
+		PollInterval:  *pollInterval,
+		PollWorkers:   *pollWorkers,
+		PollTimeout:   *pollTimeout,
+		GeoDBPath:     *geoDBPath,
+		SeedAddresses: seeds,
+		Logger:        logger,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Boot order: cache → DNS → seeds → exit. The orchestrator owns the
+	// inversion (seeds take precedence when present); a Boot failure
+	// without a fallback means none of the three landed and the
+	// operator's intervention is required.
+	if err := orch.Boot(ctx); err != nil {
+		logger.Fatalf("dashboard: boot failed: %v (provide --seeds or fix DNS/cache and retry)", err)
+	}
+
+	// Embed sub-FS rooted at web/ so / serves index.html.
+	assetsFS, err := fs.Sub(webAssets, "web")
+	if err != nil {
+		logger.Fatalf("dashboard: prepare asset FS: %v", err)
+	}
+
+	server := dashboard.NewServer(orch, *publicAddr, *internalAddr, assetsFS, logger)
+
+	// Signals: SIGINT/SIGTERM = orderly shutdown, SIGHUP = trigger omega
+	// refresh + immediate poll. SIGUSR1 is unused but reserved so future
+	// admin signals don't clash with operator muscle memory.
+	sigCh := make(chan os.Signal, 4)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+	go func() {
+		for sig := range sigCh {
+			switch sig {
+			case syscall.SIGINT, syscall.SIGTERM:
+				logger.Printf("dashboard: received %s, shutting down", sig)
+				cancel()
+				return
+			case syscall.SIGHUP:
+				orch.SignalHUP()
+			}
+		}
+	}()
+
+	go orch.Run(ctx)
+	if err := server.Run(ctx); err != nil {
+		logger.Fatalf("dashboard: %v", err)
+	}
+}
+
+func splitSeeds(s string) []string {
+	if s == "" {
+		return nil
+	}
+	out := make([]string, 0, 4)
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func defaultStateDir() string {
+	// XDG_STATE_HOME for dev, /var/lib for system installs. Pick the
+	// XDG path when HOME exists so operators don't need root just to
+	// run the dashboard during development.
+	if dir := os.Getenv("REPRAM_DASHBOARD_STATE_DIR"); dir != "" {
+		return dir
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return home + "/.local/state/repram-dashboard"
+	}
+	return "/var/lib/repram-dashboard"
+}

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -53,10 +53,10 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Boot order: cache → DNS → seeds → exit. The orchestrator owns the
-	// inversion (seeds take precedence when present); a Boot failure
-	// without a fallback means none of the three landed and the
-	// operator's intervention is required.
+	// Boot order: cache → DNS → seeds → exit. --seeds is the operator's
+	// last-resort break-glass: it is used only when both the verified
+	// cache and the omega DNS chain are unavailable. A Boot failure
+	// means none of the three landed and the operator must intervene.
 	if err := orch.Boot(ctx); err != nil {
 		logger.Fatalf("dashboard: boot failed: %v (provide --seeds or fix DNS/cache and retry)", err)
 	}

--- a/cmd/dashboard/web/app.js
+++ b/cmd/dashboard/web/app.js
@@ -1,0 +1,273 @@
+// REPRAM dashboard — vanilla JS, no build step.
+//
+// Polls /api/snapshot every 10s and re-renders the graph + tables. The
+// server-side poll cycle is 60s, so a tighter client poll just catches the
+// stale→fresh transition faster without adding load on the cluster.
+//
+// The force-directed graph is a small from-scratch SVG implementation
+// rather than vis-network. Trade-off: 60 lines here vs 200KB of vendored
+// JS. The richer library can come back when the graph outgrows this.
+
+const POLL_INTERVAL_MS = 10_000;
+
+const fmtDuration = (sec) => {
+    if (!sec) return '—';
+    const d = Math.floor(sec / 86400);
+    const h = Math.floor((sec % 86400) / 3600);
+    const m = Math.floor((sec % 3600) / 60);
+    if (d) return `${d}d${h}h`;
+    if (h) return `${h}h${m}m`;
+    return `${m}m`;
+};
+
+const fmtRelativeAge = (iso) => {
+    if (!iso) return '—';
+    const t = new Date(iso).getTime();
+    if (!Number.isFinite(t)) return '—';
+    const ageSec = Math.floor((Date.now() - t) / 1000);
+    if (ageSec < 60) return `${ageSec}s ago`;
+    return fmtDuration(ageSec) + ' ago';
+};
+
+const fmtDate = (iso) => {
+    if (!iso) return '—';
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '—';
+    return d.toISOString().slice(0, 19) + 'Z';
+};
+
+let lastSnapshot = null;
+let selectedNodeID = null;
+
+async function fetchSnapshot() {
+    try {
+        const res = await fetch('/api/snapshot', { cache: 'no-store' });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const snap = await res.json();
+        lastSnapshot = snap;
+        render(snap);
+    } catch (err) {
+        document.getElementById('last-update').textContent = `fetch failed: ${err.message}`;
+    }
+}
+
+function render(snap) {
+    document.getElementById('last-update').textContent =
+        `last update ${fmtRelativeAge(snap.generated_at)}` +
+        (snap.stale ? ' [STALE]' : '');
+
+    renderBanners(snap);
+    renderStats(snap.stats || {});
+    renderGraph(snap);
+    renderTable(snap.nodes || []);
+    if (selectedNodeID) {
+        const n = (snap.nodes || []).find(x => x.id === selectedNodeID);
+        if (n) renderNodeDetail(n);
+    }
+}
+
+function renderBanners(snap) {
+    const el = document.getElementById('banners');
+    el.innerHTML = '';
+    const banners = [];
+    if (snap.seed_override) banners.push({ text: 'SEED OVERRIDE // trust chain bypassed', warn: true });
+    if (snap.roots_unreachable) banners.push({ text: 'ROOTS UNREACHABLE // serving from peers', warn: true });
+    if (snap.omega_refresh_failed) banners.push({ text: 'OMEGA REFRESH FAILED', warn: true });
+    if (snap.loaded_from_disk) banners.push({ text: 'loaded from disk — refreshing…' });
+    if (snap.stale && !snap.loaded_from_disk) banners.push({ text: 'snapshot stale', warn: true });
+    for (const b of banners) {
+        const span = document.createElement('span');
+        span.className = b.warn ? 'banner warn' : 'banner';
+        span.textContent = b.text;
+        el.appendChild(span);
+    }
+}
+
+function renderStats(s) {
+    const set = (id, v) => document.getElementById(id).textContent = v ?? '—';
+    set('stat-nodes', s.nodes);
+    set('stat-enclaves', s.enclaves);
+    set('stat-roots', s.roots_reachable);
+    set('stat-uptime', fmtDuration(s.oldest_uptime_seconds));
+    set('stat-omega-refresh', fmtRelativeAge(s.omega_refreshed_at));
+    set('stat-omega-expires', fmtDate(s.omega_expires_at));
+}
+
+function renderTable(nodes) {
+    const tbody = document.querySelector('#node-table tbody');
+    tbody.innerHTML = '';
+    for (const n of nodes) {
+        const tr = document.createElement('tr');
+        if (n.unreachable) tr.classList.add('unreachable');
+        if (n.is_root) tr.classList.add('root');
+        tr.innerHTML = `
+            <td>${n.id}</td>
+            <td>${n.enclave || '—'}</td>
+            <td>${n.region || '?'}</td>
+            <td>${fmtDuration(n.uptime_seconds)}</td>
+            <td>${(n.heap_mb || 0).toFixed(1)} MB</td>
+            <td>${n.is_root ? 'yes' : ''}</td>
+            <td>${n.unreachable ? 'unreachable' : 'ok'}</td>
+        `;
+        tr.style.cursor = 'pointer';
+        tr.addEventListener('click', () => {
+            selectedNodeID = n.id;
+            renderNodeDetail(n);
+            highlightInGraph(n.id);
+        });
+        tbody.appendChild(tr);
+    }
+}
+
+function renderNodeDetail(n) {
+    const el = document.getElementById('node-detail');
+    const rows = [
+        ['ID', n.id],
+        ['Enclave', n.enclave || '—'],
+        ['Region', n.region || '?'],
+        ['Uptime', fmtDuration(n.uptime_seconds)],
+        ['Heap', `${(n.heap_mb || 0).toFixed(2)} MB`],
+        ['Goroutines (approx)', n.goroutines_approx ?? '—'],
+        ['Is root', n.is_root ? 'yes' : 'no'],
+        ['Status', n.unreachable ? 'unreachable' : 'ok'],
+        ['peer_joins_total', n.metrics?.peer_joins_total ?? 0],
+        ['peer_evictions_total', n.metrics?.peer_evictions_total ?? 0],
+        ['ping_failures_total', n.metrics?.ping_failures_total ?? 0],
+    ];
+    el.innerHTML = rows.map(([k, v]) =>
+        `<div class="row"><span class="k">${k}</span><span class="v">${v}</span></div>`
+    ).join('');
+}
+
+// --- minimal force-directed graph ---
+// Nodes start placed on a circle and relax via repulsion + edge springs
+// over a fixed number of ticks. Deterministic enough for a steady cluster
+// of 3–50 nodes; we can swap in vis-network if it ever exceeds that.
+
+const GRAPH_TICKS = 240;
+const REPULSION = 9000;
+const SPRING_LENGTH = 120;
+const SPRING_K = 0.02;
+const DAMPING = 0.85;
+
+function renderGraph(snap) {
+    const container = document.getElementById('graph');
+    container.innerHTML = '';
+    const nodes = (snap.nodes || []).map(n => ({ ...n, x: 0, y: 0, vx: 0, vy: 0 }));
+    const edges = snap.edges || [];
+    if (!nodes.length) return;
+
+    // Build edge set for asymmetry detection (renderer treats edge as
+    // asymmetric when the reverse direction is absent — see the design
+    // doc's "edges are directional" section).
+    const edgeKey = (a, b) => `${a}\x00${b}`;
+    const edgeSet = new Set(edges.map(e => edgeKey(e.from, e.to)));
+    const renderedEdges = [];
+    const seenPair = new Set();
+    for (const e of edges) {
+        const pair = e.from < e.to ? edgeKey(e.from, e.to) : edgeKey(e.to, e.from);
+        if (seenPair.has(pair)) continue;
+        seenPair.add(pair);
+        const symmetric = edgeSet.has(edgeKey(e.to, e.from));
+        renderedEdges.push({ from: e.from, to: e.to, symmetric });
+    }
+
+    const w = container.clientWidth || 800;
+    const h = container.clientHeight || 480;
+    const cx = w / 2, cy = h / 2;
+    const radius = Math.min(w, h) * 0.35;
+
+    nodes.forEach((n, i) => {
+        const theta = (2 * Math.PI * i) / nodes.length;
+        n.x = cx + radius * Math.cos(theta);
+        n.y = cy + radius * Math.sin(theta);
+    });
+    const byID = new Map(nodes.map(n => [n.id, n]));
+
+    for (let tick = 0; tick < GRAPH_TICKS; tick++) {
+        // pairwise repulsion
+        for (let i = 0; i < nodes.length; i++) {
+            for (let j = i + 1; j < nodes.length; j++) {
+                const a = nodes[i], b = nodes[j];
+                const dx = b.x - a.x, dy = b.y - a.y;
+                const d2 = dx * dx + dy * dy + 0.01;
+                const force = REPULSION / d2;
+                const dist = Math.sqrt(d2);
+                const fx = (dx / dist) * force, fy = (dy / dist) * force;
+                a.vx -= fx; a.vy -= fy;
+                b.vx += fx; b.vy += fy;
+            }
+        }
+        // edge springs
+        for (const e of renderedEdges) {
+            const a = byID.get(e.from), b = byID.get(e.to);
+            if (!a || !b) continue;
+            const dx = b.x - a.x, dy = b.y - a.y;
+            const dist = Math.sqrt(dx * dx + dy * dy + 0.01);
+            const f = SPRING_K * (dist - SPRING_LENGTH);
+            const fx = (dx / dist) * f, fy = (dy / dist) * f;
+            a.vx += fx; a.vy += fy;
+            b.vx -= fx; b.vy -= fy;
+        }
+        // integrate
+        for (const n of nodes) {
+            n.vx *= DAMPING; n.vy *= DAMPING;
+            n.x += n.vx; n.y += n.vy;
+            n.x = Math.max(20, Math.min(w - 20, n.x));
+            n.y = Math.max(20, Math.min(h - 20, n.y));
+        }
+    }
+
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', `0 0 ${w} ${h}`);
+    svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+
+    for (const e of renderedEdges) {
+        const a = byID.get(e.from), b = byID.get(e.to);
+        if (!a || !b) continue;
+        const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+        line.setAttribute('x1', a.x); line.setAttribute('y1', a.y);
+        line.setAttribute('x2', b.x); line.setAttribute('y2', b.y);
+        line.setAttribute('class', e.symmetric ? 'edge' : 'edge asymmetric');
+        svg.appendChild(line);
+    }
+
+    for (const n of nodes) {
+        const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const classes = ['node'];
+        if (n.is_root) classes.push('root');
+        if (n.unreachable) classes.push('unreachable');
+        g.setAttribute('class', classes.join(' '));
+        g.setAttribute('data-id', n.id);
+        g.setAttribute('transform', `translate(${n.x},${n.y})`);
+        g.style.cursor = 'pointer';
+        const r = 16 + Math.log10((n.uptime_seconds || 1) + 10) * 4;
+        const c = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        c.setAttribute('r', r);
+        g.appendChild(c);
+        const t = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        t.setAttribute('dy', r + 14);
+        t.textContent = n.id;
+        g.appendChild(t);
+        g.addEventListener('click', () => {
+            selectedNodeID = n.id;
+            renderNodeDetail(n);
+            highlightInGraph(n.id);
+        });
+        svg.appendChild(g);
+    }
+    container.appendChild(svg);
+    if (selectedNodeID) highlightInGraph(selectedNodeID);
+}
+
+function highlightInGraph(id) {
+    document.querySelectorAll('#graph svg .node').forEach(g => {
+        g.querySelector('circle').setAttribute(
+            'stroke-width',
+            g.getAttribute('data-id') === id ? 4 : (g.classList.contains('root') ? 3 : 2)
+        );
+    });
+}
+
+fetchSnapshot();
+setInterval(fetchSnapshot, POLL_INTERVAL_MS);

--- a/cmd/dashboard/web/app.js
+++ b/cmd/dashboard/web/app.js
@@ -6,9 +6,20 @@
 //
 // The force-directed graph is a small from-scratch SVG implementation
 // rather than vis-network. Trade-off: 60 lines here vs 200KB of vendored
-// JS. The richer library can come back when the graph outgrows this.
+// JS. If/when we vendor a graph library, add cmd/dashboard/web/UPSTREAM.md
+// (origin URL, license, sha256) per the design's supply-chain note.
+//
+// Security note: all text that originates from a polled node — id, region,
+// enclave — flows through textContent/appendChild, NEVER through innerHTML
+// or template strings interpolating untrusted values. A compromised node
+// could otherwise return a script payload as its ID and execute it in the
+// browser of anyone viewing the dashboard (stored XSS).
 
 const POLL_INTERVAL_MS = 10_000;
+
+function setText(el, value) {
+    el.textContent = value == null || value === '' ? '—' : String(value);
+}
 
 const fmtDuration = (sec) => {
     if (!sec) return '—';
@@ -95,20 +106,25 @@ function renderStats(s) {
 
 function renderTable(nodes) {
     const tbody = document.querySelector('#node-table tbody');
-    tbody.innerHTML = '';
+    tbody.replaceChildren();
     for (const n of nodes) {
         const tr = document.createElement('tr');
         if (n.unreachable) tr.classList.add('unreachable');
         if (n.is_root) tr.classList.add('root');
-        tr.innerHTML = `
-            <td>${n.id}</td>
-            <td>${n.enclave || '—'}</td>
-            <td>${n.region || '?'}</td>
-            <td>${fmtDuration(n.uptime_seconds)}</td>
-            <td>${(n.heap_mb || 0).toFixed(1)} MB</td>
-            <td>${n.is_root ? 'yes' : ''}</td>
-            <td>${n.unreachable ? 'unreachable' : 'ok'}</td>
-        `;
+        const cells = [
+            n.id,
+            n.enclave,
+            n.region,
+            fmtDuration(n.uptime_seconds),
+            `${(n.heap_mb || 0).toFixed(1)} MB`,
+            n.is_root ? 'yes' : '',
+            n.unreachable ? 'unreachable' : 'ok',
+        ];
+        for (const value of cells) {
+            const td = document.createElement('td');
+            setText(td, value);
+            tr.appendChild(td);
+        }
         tr.style.cursor = 'pointer';
         tr.addEventListener('click', () => {
             selectedNodeID = n.id;
@@ -123,20 +139,31 @@ function renderNodeDetail(n) {
     const el = document.getElementById('node-detail');
     const rows = [
         ['ID', n.id],
-        ['Enclave', n.enclave || '—'],
-        ['Region', n.region || '?'],
+        ['Enclave', n.enclave],
+        ['Region', n.region],
         ['Uptime', fmtDuration(n.uptime_seconds)],
         ['Heap', `${(n.heap_mb || 0).toFixed(2)} MB`],
-        ['Goroutines (approx)', n.goroutines_approx ?? '—'],
+        ['Goroutines (approx)', n.goroutines_approx],
         ['Is root', n.is_root ? 'yes' : 'no'],
         ['Status', n.unreachable ? 'unreachable' : 'ok'],
         ['peer_joins_total', n.metrics?.peer_joins_total ?? 0],
         ['peer_evictions_total', n.metrics?.peer_evictions_total ?? 0],
         ['ping_failures_total', n.metrics?.ping_failures_total ?? 0],
     ];
-    el.innerHTML = rows.map(([k, v]) =>
-        `<div class="row"><span class="k">${k}</span><span class="v">${v}</span></div>`
-    ).join('');
+    el.replaceChildren();
+    for (const [k, v] of rows) {
+        const row = document.createElement('div');
+        row.className = 'row';
+        const kEl = document.createElement('span');
+        kEl.className = 'k';
+        kEl.textContent = k;
+        const vEl = document.createElement('span');
+        vEl.className = 'v';
+        setText(vEl, v);
+        row.appendChild(kEl);
+        row.appendChild(vEl);
+        el.appendChild(row);
+    }
 }
 
 // --- minimal force-directed graph ---

--- a/cmd/dashboard/web/index.html
+++ b/cmd/dashboard/web/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>REPRAM // network</title>
+    <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+    <div class="scanlines"></div>
+    <main>
+        <header>
+            <div class="logo">REPRAM<span class="cursor">_</span></div>
+            <div class="subtitle">PUBLIC NETWORK // <span id="last-update">initializing…</span></div>
+            <div id="banners"></div>
+        </header>
+
+        <section id="stats" class="panel">
+            <div class="stat"><span class="label">NODES</span><span class="value" id="stat-nodes">—</span></div>
+            <div class="stat"><span class="label">ENCLAVES</span><span class="value" id="stat-enclaves">—</span></div>
+            <div class="stat"><span class="label">ROOTS REACHABLE</span><span class="value" id="stat-roots">—</span></div>
+            <div class="stat"><span class="label">OLDEST UPTIME</span><span class="value" id="stat-uptime">—</span></div>
+            <div class="stat"><span class="label">OMEGA REFRESH</span><span class="value" id="stat-omega-refresh">—</span></div>
+            <div class="stat"><span class="label">OMEGA EXPIRES</span><span class="value" id="stat-omega-expires">—</span></div>
+        </section>
+
+        <section class="grid">
+            <div class="panel" id="graph-panel">
+                <h2>// TOPOLOGY</h2>
+                <div id="graph"></div>
+            </div>
+
+            <aside class="panel" id="detail-panel">
+                <h2>// NODE</h2>
+                <div id="node-detail">
+                    <em>Click a node to inspect.</em>
+                </div>
+            </aside>
+        </section>
+
+        <section class="panel">
+            <h2>// NODES</h2>
+            <table id="node-table">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>ENCLAVE</th>
+                        <th>REGION</th>
+                        <th>UPTIME</th>
+                        <th>HEAP</th>
+                        <th>ROOT</th>
+                        <th>STATUS</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </section>
+
+        <footer>
+            <span>// REPRAM is `pipe` not `grep` — structure visible, contents never.</span>
+            <span class="attribution">Country data: GeoLite2 by MaxMind — <a href="https://www.maxmind.com">maxmind.com</a></span>
+        </footer>
+    </main>
+
+    <script src="/app.js"></script>
+</body>
+</html>

--- a/cmd/dashboard/web/styles.css
+++ b/cmd/dashboard/web/styles.css
@@ -1,0 +1,249 @@
+/*
+ * Dashboard styles — vendored hackerpunk aesthetic.
+ * If web/styles.css (the marketing site) is updated, mirror the change here
+ * deliberately. The two files are intentionally not shared at runtime so
+ * the dashboard binary stays self-contained.
+ */
+
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=Share+Tech+Mono&display=swap');
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+    font-family: 'Share Tech Mono', monospace;
+    background-color: #000;
+    background-image: repeating-linear-gradient(
+        0deg,
+        rgba(0, 255, 0, 0.03) 0px,
+        transparent 1px,
+        transparent 2px,
+        rgba(0, 255, 0, 0.03) 3px
+    );
+    color: #00ff00;
+    line-height: 1.6;
+    min-height: 100vh;
+    text-shadow: 0 0 5px rgba(0, 255, 0, 0.5);
+}
+
+.scanlines {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 2;
+    background: linear-gradient(rgba(18, 16, 16, 0) 50%, rgba(0, 0, 0, 0.2) 50%);
+    background-size: 100% 2px;
+    animation: scanline 8s linear infinite;
+}
+
+@keyframes scanline {
+    0%   { background-position: 0 0; }
+    100% { background-position: 0 100vh; }
+}
+
+main {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 24px;
+    position: relative;
+    z-index: 1;
+}
+
+header {
+    border-bottom: 1px solid #00ff00;
+    padding-bottom: 16px;
+    margin-bottom: 24px;
+}
+
+.logo {
+    font-family: 'Orbitron', sans-serif;
+    font-weight: 900;
+    font-size: 48px;
+    letter-spacing: 4px;
+}
+
+.cursor {
+    animation: blink 1s steps(1) infinite;
+}
+
+@keyframes blink {
+    0%, 50% { opacity: 1; }
+    51%, 100% { opacity: 0; }
+}
+
+.subtitle {
+    font-size: 14px;
+    color: #00aa00;
+    margin-top: 4px;
+}
+
+#banners .banner {
+    display: inline-block;
+    margin-top: 8px;
+    margin-right: 8px;
+    padding: 4px 12px;
+    border: 1px solid #ffaa00;
+    color: #ffaa00;
+    font-size: 12px;
+    text-shadow: 0 0 5px rgba(255, 170, 0, 0.5);
+}
+
+#banners .banner.warn {
+    border-color: #ff4444;
+    color: #ff4444;
+    text-shadow: 0 0 5px rgba(255, 68, 68, 0.5);
+}
+
+.panel {
+    border: 1px solid #00ff00;
+    padding: 16px;
+    margin-bottom: 16px;
+    background: rgba(0, 20, 0, 0.2);
+    box-shadow: 0 0 12px rgba(0, 255, 0, 0.1) inset;
+}
+
+.panel h2 {
+    font-family: 'Orbitron', sans-serif;
+    font-weight: 700;
+    font-size: 14px;
+    letter-spacing: 2px;
+    margin-bottom: 12px;
+    color: #88ff88;
+}
+
+#stats {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    gap: 8px;
+}
+
+.stat {
+    display: flex;
+    flex-direction: column;
+    padding: 8px;
+    border: 1px dashed rgba(0, 255, 0, 0.3);
+}
+
+.stat .label {
+    font-size: 11px;
+    color: #00aa00;
+}
+
+.stat .value {
+    font-family: 'Orbitron', sans-serif;
+    font-size: 24px;
+    color: #00ff00;
+}
+
+.grid {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 16px;
+}
+
+#graph {
+    height: 480px;
+    border: 1px dashed rgba(0, 255, 0, 0.3);
+    position: relative;
+    overflow: hidden;
+}
+
+#graph svg {
+    width: 100%;
+    height: 100%;
+}
+
+#graph svg .node circle {
+    fill: rgba(0, 40, 0, 0.7);
+    stroke: #00ff00;
+    stroke-width: 2;
+    cursor: pointer;
+    filter: drop-shadow(0 0 6px rgba(0, 255, 0, 0.6));
+}
+
+#graph svg .node.unreachable circle {
+    stroke: #ff4444;
+    filter: drop-shadow(0 0 6px rgba(255, 68, 68, 0.6));
+}
+
+#graph svg .node.root circle {
+    stroke-width: 3;
+    fill: rgba(255, 170, 0, 0.15);
+    stroke: #ffaa00;
+    filter: drop-shadow(0 0 8px rgba(255, 170, 0, 0.8));
+}
+
+#graph svg .node text {
+    fill: #00ff00;
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 11px;
+    text-anchor: middle;
+    pointer-events: none;
+}
+
+#graph svg .edge {
+    stroke: rgba(0, 255, 0, 0.6);
+    stroke-width: 1;
+}
+
+#graph svg .edge.asymmetric {
+    stroke-dasharray: 4 3;
+    stroke: rgba(255, 170, 0, 0.7);
+}
+
+#node-detail {
+    font-size: 13px;
+    line-height: 1.8;
+}
+
+#node-detail .row {
+    display: flex;
+    justify-content: space-between;
+    border-bottom: 1px dotted rgba(0, 255, 0, 0.2);
+    padding: 4px 0;
+}
+
+#node-detail .row .k { color: #00aa00; }
+#node-detail .row .v { color: #00ff00; }
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+}
+
+th, td {
+    border: 1px solid rgba(0, 255, 0, 0.3);
+    padding: 6px 10px;
+    text-align: left;
+}
+
+th {
+    background: rgba(0, 40, 0, 0.5);
+    color: #88ff88;
+    font-family: 'Orbitron', sans-serif;
+    font-size: 11px;
+    letter-spacing: 1px;
+}
+
+tr.unreachable td { color: #ff4444; }
+tr.root td:first-child::before { content: "⌬ "; color: #ffaa00; }
+
+footer {
+    margin-top: 24px;
+    padding-top: 16px;
+    border-top: 1px solid rgba(0, 255, 0, 0.3);
+    font-size: 11px;
+    color: #00aa00;
+    display: flex;
+    justify-content: space-between;
+}
+
+footer a {
+    color: #00aa00;
+    text-decoration: underline;
+}
+
+@media (max-width: 900px) {
+    #stats { grid-template-columns: repeat(2, 1fr); }
+    .grid { grid-template-columns: 1fr; }
+}

--- a/internal/dashboard/builder.go
+++ b/internal/dashboard/builder.go
@@ -5,6 +5,8 @@ import (
 	"net"
 	"strconv"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Builder converts poll results into a Snapshot. The roots set comes from
@@ -16,13 +18,15 @@ import (
 // as arguments. State that survives cycles (e.g. consecutive-miss counters
 // for the unreachable-then-drop policy) lives in the orchestrator above.
 type Builder struct {
-	Geo *Geo
+	Geo            *Geo
+	GeoMissCounter prometheus.Counter
 }
 
 // NewBuilder constructs a builder. geo may be nil; in that case every node
-// gets Region="?".
-func NewBuilder(geo *Geo) *Builder {
-	return &Builder{Geo: geo}
+// gets Region="?". missCounter may be nil for tests; when non-nil it's
+// incremented every time the builder gives up on resolving a real IP.
+func NewBuilder(geo *Geo, missCounter prometheus.Counter) *Builder {
+	return &Builder{Geo: geo, GeoMissCounter: missCounter}
 }
 
 // BuildInput bundles everything Build needs that varies per cycle. Kept as
@@ -119,6 +123,9 @@ func (b *Builder) Build(in BuildInput) *Snapshot {
 		if b.Geo != nil && r.addr.Host != "" {
 			if ip := net.ParseIP(r.addr.Host); ip != nil {
 				node.Region = b.Geo.Region(ip)
+				if node.Region == "?" && b.GeoMissCounter != nil {
+					b.GeoMissCounter.Inc()
+				}
 			}
 		}
 

--- a/internal/dashboard/builder.go
+++ b/internal/dashboard/builder.go
@@ -1,0 +1,193 @@
+package dashboard
+
+import (
+	"math"
+	"net"
+	"strconv"
+	"time"
+)
+
+// Builder converts poll results into a Snapshot. The roots set comes from
+// either the cached omega signed list or the operator --seeds flag; the
+// builder doesn't care which, but the Snapshot's SeedOverride flag carries
+// the distinction forward to the UI.
+//
+// The builder is stateless between calls — Build takes everything it needs
+// as arguments. State that survives cycles (e.g. consecutive-miss counters
+// for the unreachable-then-drop policy) lives in the orchestrator above.
+type Builder struct {
+	Geo *Geo
+}
+
+// NewBuilder constructs a builder. geo may be nil; in that case every node
+// gets Region="?".
+func NewBuilder(geo *Geo) *Builder {
+	return &Builder{Geo: geo}
+}
+
+// BuildInput bundles everything Build needs that varies per cycle. Kept as
+// a struct rather than positional args so future additions don't ripple
+// through call sites.
+type BuildInput struct {
+	// Results from the poller, keyed by node ID.
+	Results map[string]pollResult
+
+	// Roots is the set of "host:port" advertised addresses the dashboard
+	// considers roots — derived from the omega cache, or from --seeds
+	// when running in seed-override mode.
+	Roots map[string]bool
+
+	// SeedOverride flips when the dashboard booted from --seeds instead
+	// of the omega trust chain. Surfaced in the snapshot as a banner.
+	SeedOverride bool
+
+	// RootsUnreachable is set by the orchestrator after one full poll
+	// cycle in which no root responded. The builder does not infer it;
+	// the orchestrator owns the consecutive-miss accounting.
+	RootsUnreachable bool
+
+	// OmegaRefreshFailed tracks the outcome of the most recent omega
+	// refresh attempt. Distinct from RootsUnreachable: a refresh can
+	// fail (DNS down) while roots are still reachable on cached info.
+	OmegaRefreshFailed bool
+
+	// OmegaRefreshedAt is when the cached omega list was last
+	// successfully fetched. Nil if running in seed-override mode.
+	OmegaRefreshedAt *time.Time
+
+	// OmegaExpiresAt is when the cached omega list's signature expires.
+	// Nil if running in seed-override mode.
+	OmegaExpiresAt *time.Time
+
+	// Now is the build clock — injectable for tests. Use time.Now() in
+	// production callers.
+	Now time.Time
+}
+
+// Build produces a Snapshot from one cycle's poll results. Addresses are
+// stripped here — once Build returns, no address information leaks into
+// the snapshot's public projection.
+func (b *Builder) Build(in BuildInput) *Snapshot {
+	s := &Snapshot{
+		GeneratedAt:        in.Now,
+		RootsUnreachable:   in.RootsUnreachable,
+		OmegaRefreshFailed: in.OmegaRefreshFailed,
+		SeedOverride:       in.SeedOverride,
+		Stats: Stats{
+			OmegaRefreshedAt: in.OmegaRefreshedAt,
+			OmegaExpiresAt:   in.OmegaExpiresAt,
+		},
+		Nodes: make([]Node, 0, len(in.Results)),
+		Edges: make([]Edge, 0, len(in.Results)*2),
+	}
+
+	// First pass: build a host:port → node ID index so the BFS's peer
+	// edges (which carry addresses) can be projected onto IDs in the
+	// final snapshot.
+	idByAddr := make(map[string]string, len(in.Results))
+	for id, r := range in.Results {
+		if r.addr.Host == "" || r.addr.HTTPPort == 0 {
+			continue
+		}
+		idByAddr[r.addr.HostPort()] = id
+	}
+
+	enclaves := map[string]struct{}{}
+	rootsReachable := 0
+	var oldestUptime int64
+
+	for id, r := range in.Results {
+		uptimeSeconds := parseUptime(r.status.Uptime)
+		heapMB := float64(r.status.Memory.Alloc) / (1024 * 1024)
+
+		node := Node{
+			ID:               id,
+			Enclave:          r.addr.Enclave,
+			Region:           "?",
+			UptimeSeconds:    uptimeSeconds,
+			HeapMB:           roundFloat(heapMB, 2),
+			GoroutinesApprox: roundToNearest(r.status.Goroutines, 10),
+			IsRoot:           in.Roots[r.addr.HostPort()],
+			Unreachable:      r.unreachable,
+			Metrics:          r.metrics,
+		}
+
+		if node.Enclave == "" && r.status.Enclave != "" {
+			node.Enclave = r.status.Enclave
+		}
+
+		if b.Geo != nil && r.addr.Host != "" {
+			if ip := net.ParseIP(r.addr.Host); ip != nil {
+				node.Region = b.Geo.Region(ip)
+			}
+		}
+
+		if node.Enclave != "" {
+			enclaves[node.Enclave] = struct{}{}
+		}
+
+		if node.IsRoot && !node.Unreachable {
+			rootsReachable++
+		}
+
+		if uptimeSeconds > oldestUptime {
+			oldestUptime = uptimeSeconds
+		}
+
+		s.Nodes = append(s.Nodes, node)
+
+		// Emit one directional edge per (this node, peer-it-lists).
+		// We deliberately do NOT collapse symmetric pairs — the UI
+		// renders symmetric edges solid and asymmetric ones dashed.
+		// Asymmetry is a real debug signal during sync convergence.
+		for _, peer := range r.peers {
+			peerKey := net.JoinHostPort(peer.Address, strconv.Itoa(peer.HTTPPort))
+			peerID := peer.ID
+			if mapped, ok := idByAddr[peerKey]; ok {
+				peerID = mapped
+			}
+			if peerID == "" || peerID == id {
+				continue
+			}
+			s.Edges = append(s.Edges, Edge{From: id, To: peerID})
+		}
+	}
+
+	s.Stats.Nodes = len(s.Nodes)
+	s.Stats.Enclaves = len(enclaves)
+	s.Stats.RootsReachable = rootsReachable
+	s.Stats.OldestUptimeSeconds = oldestUptime
+
+	s.Canonicalize()
+	return s
+}
+
+// parseUptime accepts the time.Duration string format that /v1/status
+// emits (e.g. "73h4m59.27s") and returns whole seconds. Unparseable input
+// returns 0; the snapshot publishes a zero uptime rather than failing.
+func parseUptime(s string) int64 {
+	if s == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0
+	}
+	return int64(d.Seconds())
+}
+
+func roundFloat(v float64, decimals int) float64 {
+	shift := math.Pow(10, float64(decimals))
+	return math.Round(v*shift) / shift
+}
+
+// roundToNearest implements the goroutines-rounded-to-nearest-10 guardrail.
+// The absolute count rarely matters and the noise is real, so coarsening
+// reduces the side-channel surface for negligible cost.
+func roundToNearest(v, bucket int) int {
+	if bucket <= 1 {
+		return v
+	}
+	return ((v + bucket/2) / bucket) * bucket
+}
+

--- a/internal/dashboard/builder_test.go
+++ b/internal/dashboard/builder_test.go
@@ -37,7 +37,7 @@ func sampleResults() map[string]pollResult {
 }
 
 func TestBuilderStripsAddressesAndDerivesIsRoot(t *testing.T) {
-	b := NewBuilder(nil)
+	b := NewBuilder(nil, nil)
 	roots := map[string]bool{"10.0.0.1:18080": true}
 	snap := b.Build(BuildInput{
 		Results: sampleResults(),
@@ -70,7 +70,7 @@ func TestBuilderEdgesAreDirectionalAndPreserveAsymmetry(t *testing.T) {
 	r.peers = nil
 	results["node-b"] = r
 
-	b := NewBuilder(nil)
+	b := NewBuilder(nil, nil)
 	snap := b.Build(BuildInput{
 		Results: results,
 		Roots:   map[string]bool{},
@@ -92,7 +92,7 @@ func TestBuilderEdgesAreDirectionalAndPreserveAsymmetry(t *testing.T) {
 }
 
 func TestBuilderGoroutinesAreRoundedToNearestTen(t *testing.T) {
-	b := NewBuilder(nil)
+	b := NewBuilder(nil, nil)
 	results := sampleResults()
 	r := results["node-a"]
 	r.status.Goroutines = 47 // expected to round to 50
@@ -106,7 +106,7 @@ func TestBuilderGoroutinesAreRoundedToNearestTen(t *testing.T) {
 }
 
 func TestBuilderSeedOverridePropagates(t *testing.T) {
-	b := NewBuilder(nil)
+	b := NewBuilder(nil, nil)
 	snap := b.Build(BuildInput{
 		Results:      sampleResults(),
 		Roots:        map[string]bool{"10.0.0.1:18080": true},

--- a/internal/dashboard/builder_test.go
+++ b/internal/dashboard/builder_test.go
@@ -1,0 +1,146 @@
+package dashboard
+
+import (
+	"testing"
+	"time"
+)
+
+func sampleResults() map[string]pollResult {
+	return map[string]pollResult{
+		"node-a": {
+			addr: nodeAddr{ID: "node-a", Host: "10.0.0.1", HTTPPort: 18080, Enclave: "default"},
+			status: statusResponse{
+				NodeID:     "node-a",
+				Enclave:    "default",
+				Uptime:     "1h",
+				Goroutines: 53,
+			},
+			peers: []peerEntry{
+				{ID: "node-b", Address: "10.0.0.2", HTTPPort: 18080, Enclave: "default"},
+			},
+			metrics: NodeMetrics{PeerJoinsTotal: 5, PeerEvictionsTotal: 1, PingFailuresTotal: 3},
+		},
+		"node-b": {
+			addr: nodeAddr{ID: "node-b", Host: "10.0.0.2", HTTPPort: 18080, Enclave: "default"},
+			status: statusResponse{
+				NodeID:     "node-b",
+				Enclave:    "default",
+				Uptime:     "30m",
+				Goroutines: 47,
+			},
+			peers: []peerEntry{
+				{ID: "node-a", Address: "10.0.0.1", HTTPPort: 18080, Enclave: "default"},
+			},
+			metrics: NodeMetrics{PeerJoinsTotal: 4},
+		},
+	}
+}
+
+func TestBuilderStripsAddressesAndDerivesIsRoot(t *testing.T) {
+	b := NewBuilder(nil)
+	roots := map[string]bool{"10.0.0.1:18080": true}
+	snap := b.Build(BuildInput{
+		Results: sampleResults(),
+		Roots:   roots,
+		Now:     time.Now(),
+	})
+
+	if len(snap.Nodes) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(snap.Nodes))
+	}
+	// Canonicalize sorts alphabetically — node-a is first.
+	if snap.Nodes[0].ID != "node-a" || !snap.Nodes[0].IsRoot {
+		t.Errorf("node-a should be the root: %+v", snap.Nodes[0])
+	}
+	if snap.Nodes[1].ID != "node-b" || snap.Nodes[1].IsRoot {
+		t.Errorf("node-b should not be root: %+v", snap.Nodes[1])
+	}
+	if snap.Stats.RootsReachable != 1 {
+		t.Errorf("RootsReachable should be 1, got %d", snap.Stats.RootsReachable)
+	}
+	if snap.Nodes[0].UptimeSeconds != 3600 {
+		t.Errorf("uptime parse failed: got %d", snap.Nodes[0].UptimeSeconds)
+	}
+}
+
+func TestBuilderEdgesAreDirectionalAndPreserveAsymmetry(t *testing.T) {
+	// Drop node-b's awareness of node-a, leaving an asymmetric edge.
+	results := sampleResults()
+	r := results["node-b"]
+	r.peers = nil
+	results["node-b"] = r
+
+	b := NewBuilder(nil)
+	snap := b.Build(BuildInput{
+		Results: results,
+		Roots:   map[string]bool{},
+		Now:     time.Now(),
+	})
+
+	var fromA, fromB int
+	for _, e := range snap.Edges {
+		if e.From == "node-a" && e.To == "node-b" {
+			fromA++
+		}
+		if e.From == "node-b" && e.To == "node-a" {
+			fromB++
+		}
+	}
+	if fromA != 1 || fromB != 0 {
+		t.Errorf("expected only the node-a→node-b edge to survive, got fromA=%d fromB=%d", fromA, fromB)
+	}
+}
+
+func TestBuilderGoroutinesAreRoundedToNearestTen(t *testing.T) {
+	b := NewBuilder(nil)
+	results := sampleResults()
+	r := results["node-a"]
+	r.status.Goroutines = 47 // expected to round to 50
+	results["node-a"] = r
+	snap := b.Build(BuildInput{Results: results, Roots: map[string]bool{}, Now: time.Now()})
+	for _, n := range snap.Nodes {
+		if n.ID == "node-a" && n.GoroutinesApprox != 50 {
+			t.Errorf("expected goroutines_approx=50, got %d", n.GoroutinesApprox)
+		}
+	}
+}
+
+func TestBuilderSeedOverridePropagates(t *testing.T) {
+	b := NewBuilder(nil)
+	snap := b.Build(BuildInput{
+		Results:      sampleResults(),
+		Roots:        map[string]bool{"10.0.0.1:18080": true},
+		SeedOverride: true,
+		Now:          time.Now(),
+	})
+	if !snap.SeedOverride {
+		t.Error("SeedOverride should propagate to snapshot")
+	}
+}
+
+func TestParseUptimeHandlesEmpty(t *testing.T) {
+	if parseUptime("") != 0 {
+		t.Error("empty uptime should parse to 0")
+	}
+	if parseUptime("not-a-duration") != 0 {
+		t.Error("garbage uptime should parse to 0")
+	}
+	if got := parseUptime("2h30m"); got != 9000 {
+		t.Errorf("2h30m should be 9000s, got %d", got)
+	}
+}
+
+func TestRoundToNearest(t *testing.T) {
+	cases := []struct{ in, bucket, want int }{
+		{47, 10, 50},
+		{44, 10, 40},
+		{45, 10, 50}, // banker's-style rounds half-up here
+		{0, 10, 0},
+		{7, 1, 7},
+	}
+	for _, c := range cases {
+		if got := roundToNearest(c.in, c.bucket); got != c.want {
+			t.Errorf("roundToNearest(%d, %d) = %d, want %d", c.in, c.bucket, got, c.want)
+		}
+	}
+}

--- a/internal/dashboard/geo.go
+++ b/internal/dashboard/geo.go
@@ -1,0 +1,128 @@
+package dashboard
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"os"
+	"sync"
+)
+
+// Geo resolves IP addresses to a coarse region label (country ISO code).
+// The lookup is deliberately country-granular: matches the design goal of
+// "broad regional boundaries" and avoids leaking placement detail. When the
+// database is absent or a lookup misses, Region returns "?".
+//
+// The implementation is intentionally pluggable so the binary builds and
+// runs without a GeoLite2 database present — operators add the database via
+// the Makefile target, and the dashboard hot-reloads it on SIGHUP.
+type Geo struct {
+	mu   sync.RWMutex
+	impl geoLookup
+}
+
+type geoLookup interface {
+	Country(net.IP) string
+	Close() error
+}
+
+// NewGeo constructs a lookup. dbPath may be empty (no database loaded — all
+// lookups return "?"). Loading errors are returned so the caller can decide
+// whether to log-and-continue or fail; the dashboard chooses log-and-continue.
+func NewGeo(dbPath string) (*Geo, error) {
+	g := &Geo{impl: noopLookup{}}
+	if dbPath == "" {
+		return g, nil
+	}
+	impl, err := openMMDB(dbPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return g, nil
+		}
+		return g, err
+	}
+	g.impl = impl
+	return g, nil
+}
+
+// Region returns the ISO country code for ip, or "?" if no database is
+// loaded, the lookup misses, or ip is nil. Never returns an error so a
+// snapshot build cannot be blocked by geo trouble.
+func (g *Geo) Region(ip net.IP) string {
+	if ip == nil {
+		return "?"
+	}
+	g.mu.RLock()
+	impl := g.impl
+	g.mu.RUnlock()
+	code := impl.Country(ip)
+	if code == "" {
+		return "?"
+	}
+	return code
+}
+
+// Reload swaps in a freshly-opened database. Called from the SIGHUP handler
+// to pick up an updated GeoLite2 file without restarting the dashboard.
+// If the new database fails to open, the old one is retained and the error
+// is returned so the caller can log it.
+func (g *Geo) Reload(dbPath string) error {
+	if dbPath == "" {
+		g.mu.Lock()
+		old := g.impl
+		g.impl = noopLookup{}
+		g.mu.Unlock()
+		if old != nil {
+			_ = old.Close()
+		}
+		return nil
+	}
+	impl, err := openMMDB(dbPath)
+	if err != nil {
+		return fmt.Errorf("reload geo db %s: %w", dbPath, err)
+	}
+	g.mu.Lock()
+	old := g.impl
+	g.impl = impl
+	g.mu.Unlock()
+	if old != nil {
+		_ = old.Close()
+	}
+	return nil
+}
+
+// Close releases the underlying database handle. Safe to call multiple times.
+func (g *Geo) Close() error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.impl == nil {
+		return nil
+	}
+	err := g.impl.Close()
+	g.impl = noopLookup{}
+	return err
+}
+
+type noopLookup struct{}
+
+func (noopLookup) Country(net.IP) string { return "" }
+func (noopLookup) Close() error          { return nil }
+
+// openMMDB is replaced at build time when the maxminddb dependency is
+// vendored (see geo_mmdb.go behind a build tag). Until then this stub
+// returns os.ErrNotExist so NewGeo treats "no db path" and "no impl"
+// the same way: log-and-continue.
+//
+// This indirection keeps the dashboard buildable without an immediate
+// hard dependency on github.com/oschwald/maxminddb-golang. Phase 2 of
+// the implementation wires it up properly.
+var openMMDB = func(path string) (geoLookup, error) {
+	if _, err := os.Stat(path); err != nil {
+		return nil, err
+	}
+	// File exists but no mmdb impl is compiled in. Surface that as a
+	// distinct error so an operator who shipped a db file but built
+	// without the geo tag isn't left guessing.
+	return nil, errors.New("geo: mmdb support not compiled in (build with -tags geo)")
+}

--- a/internal/dashboard/geo_test.go
+++ b/internal/dashboard/geo_test.go
@@ -1,0 +1,35 @@
+package dashboard
+
+import (
+	"net"
+	"testing"
+)
+
+func TestGeoEmptyPathReturnsQuestion(t *testing.T) {
+	g, err := NewGeo("")
+	if err != nil {
+		t.Fatalf("NewGeo(\"\"): %v", err)
+	}
+	defer g.Close()
+	if got := g.Region(net.ParseIP("8.8.8.8")); got != "?" {
+		t.Errorf("expected ? for empty-db lookup, got %s", got)
+	}
+}
+
+func TestGeoMissingFileReturnsQuestion(t *testing.T) {
+	g, err := NewGeo("/nonexistent/path.mmdb")
+	if err != nil {
+		t.Fatalf("NewGeo should not error on missing file (treat as no-db), got %v", err)
+	}
+	defer g.Close()
+	if got := g.Region(net.ParseIP("8.8.8.8")); got != "?" {
+		t.Errorf("expected ? for missing-db lookup, got %s", got)
+	}
+}
+
+func TestGeoNilIPReturnsQuestion(t *testing.T) {
+	g, _ := NewGeo("")
+	if got := g.Region(nil); got != "?" {
+		t.Errorf("expected ? for nil ip, got %s", got)
+	}
+}

--- a/internal/dashboard/metrics.go
+++ b/internal/dashboard/metrics.go
@@ -1,0 +1,71 @@
+package dashboard
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// internalMetrics is the dashboard's self-observability surface. Exposed on
+// a separate localhost-bound listener at /internal/metrics by default so a
+// public Internet visitor never sees these — they exist for the operator
+// running the dashboard, not for casual consumers of the public graph.
+type internalMetrics struct {
+	registry              *prometheus.Registry
+	pollsTotal            prometheus.Counter
+	pollsFailedTotal      prometheus.Counter
+	nodesUnreachable      prometheus.Gauge
+	snapshotAgeSeconds    prometheus.Gauge
+	omegaRefreshUnix      prometheus.Gauge
+	omegaExpiresUnix      prometheus.Gauge
+	omegaRefreshFailures  prometheus.Counter
+	geoLookupMissesTotal  prometheus.Counter
+}
+
+func newInternalMetrics() *internalMetrics {
+	reg := prometheus.NewRegistry()
+	m := &internalMetrics{
+		registry: reg,
+		pollsTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "dashboard_polls_total",
+			Help: "Total topology poll cycles attempted since start.",
+		}),
+		pollsFailedTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "dashboard_polls_failed_total",
+			Help: "Poll cycles where zero nodes responded.",
+		}),
+		nodesUnreachable: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "dashboard_nodes_unreachable",
+			Help: "Nodes flagged unreachable in the current snapshot.",
+		}),
+		snapshotAgeSeconds: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "dashboard_snapshot_age_seconds",
+			Help: "Seconds since the last successful poll cycle completed.",
+		}),
+		omegaRefreshUnix: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "dashboard_omega_refresh_unix_seconds",
+			Help: "Unix timestamp of last successful omega refresh (0 = never / seed-override mode).",
+		}),
+		omegaExpiresUnix: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "dashboard_omega_expires_unix_seconds",
+			Help: "Unix timestamp at which the cached omega list expires (0 = no cache / seed-override mode).",
+		}),
+		omegaRefreshFailures: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "dashboard_omega_refresh_failures_total",
+			Help: "Failed omega refresh attempts since start.",
+		}),
+		geoLookupMissesTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "dashboard_geo_lookup_misses_total",
+			Help: "IPs that did not resolve to a country during snapshot build.",
+		}),
+	}
+	reg.MustRegister(
+		m.pollsTotal,
+		m.pollsFailedTotal,
+		m.nodesUnreachable,
+		m.snapshotAgeSeconds,
+		m.omegaRefreshUnix,
+		m.omegaExpiresUnix,
+		m.omegaRefreshFailures,
+		m.geoLookupMissesTotal,
+	)
+	return m
+}

--- a/internal/dashboard/metrics.go
+++ b/internal/dashboard/metrics.go
@@ -1,6 +1,8 @@
 package dashboard
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -8,19 +10,26 @@ import (
 // a separate localhost-bound listener at /internal/metrics by default so a
 // public Internet visitor never sees these — they exist for the operator
 // running the dashboard, not for casual consumers of the public graph.
+//
+// dashboard_snapshot_age_seconds is intentionally a GaugeFunc: a gauge
+// that "ages" between cycles cannot be poked once per success — it must
+// be computed at scrape time from the most recent successful-poll
+// timestamp. A 4-minute-old snapshot must report ~240, not 0.
 type internalMetrics struct {
-	registry              *prometheus.Registry
-	pollsTotal            prometheus.Counter
-	pollsFailedTotal      prometheus.Counter
-	nodesUnreachable      prometheus.Gauge
-	snapshotAgeSeconds    prometheus.Gauge
-	omegaRefreshUnix      prometheus.Gauge
-	omegaExpiresUnix      prometheus.Gauge
-	omegaRefreshFailures  prometheus.Counter
-	geoLookupMissesTotal  prometheus.Counter
+	registry             *prometheus.Registry
+	pollsTotal           prometheus.Counter
+	pollsFailedTotal     prometheus.Counter
+	nodesUnreachable     prometheus.Gauge
+	omegaRefreshUnix     prometheus.Gauge
+	omegaExpiresUnix     prometheus.Gauge
+	omegaRefreshFailures prometheus.Counter
+	geoLookupMissesTotal prometheus.Counter
 }
 
-func newInternalMetrics() *internalMetrics {
+// newInternalMetrics constructs the dashboard's metric set. lastPollUnix
+// is a callback that returns the Unix timestamp of the most recent
+// successful poll cycle; it backs the snapshot_age_seconds GaugeFunc.
+func newInternalMetrics(lastPollUnix func() int64) *internalMetrics {
 	reg := prometheus.NewRegistry()
 	m := &internalMetrics{
 		registry: reg,
@@ -35,10 +44,6 @@ func newInternalMetrics() *internalMetrics {
 		nodesUnreachable: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "dashboard_nodes_unreachable",
 			Help: "Nodes flagged unreachable in the current snapshot.",
-		}),
-		snapshotAgeSeconds: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "dashboard_snapshot_age_seconds",
-			Help: "Seconds since the last successful poll cycle completed.",
 		}),
 		omegaRefreshUnix: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "dashboard_omega_refresh_unix_seconds",
@@ -57,11 +62,23 @@ func newInternalMetrics() *internalMetrics {
 			Help: "IPs that did not resolve to a country during snapshot build.",
 		}),
 	}
+
+	snapshotAge := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "dashboard_snapshot_age_seconds",
+		Help: "Seconds since the last successful poll cycle completed (computed at scrape time).",
+	}, func() float64 {
+		last := lastPollUnix()
+		if last == 0 {
+			return 0
+		}
+		return float64(time.Now().Unix() - last)
+	})
+
 	reg.MustRegister(
 		m.pollsTotal,
 		m.pollsFailedTotal,
 		m.nodesUnreachable,
-		m.snapshotAgeSeconds,
+		snapshotAge,
 		m.omegaRefreshUnix,
 		m.omegaExpiresUnix,
 		m.omegaRefreshFailures,

--- a/internal/dashboard/orchestrator.go
+++ b/internal/dashboard/orchestrator.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"context"
+	"crypto/ed25519"
 	"log"
 	"os"
 	"strconv"
@@ -105,6 +106,17 @@ type Config struct {
 	// Logger is the destination for orchestrator chatter. nil selects
 	// the stdlib default logger.
 	Logger *log.Logger
+
+	// OmegaPubkey overrides the baked-in omega public key. Production
+	// callers leave this nil; tests inject their own keypair so they
+	// can sign synthetic root lists for the cache and DNS paths.
+	OmegaPubkey ed25519.PublicKey
+
+	// OmegaDNS overrides the DNS configuration used by trust.FetchSigned
+	// and the refresher. Production callers leave this zero-valued
+	// (real net.Resolver against _bootstrap.repram.io). Tests inject a
+	// stub TXTResolver so Boot() doesn't make live DNS calls.
+	OmegaDNS trust.DNSConfig
 }
 
 // NewOrchestrator wires up the orchestrator without starting any goroutines.
@@ -151,9 +163,13 @@ func (o *Orchestrator) Boot(ctx context.Context) error {
 		o.cfg.Logger.Printf("dashboard: load snapshot: %v (continuing without)", err)
 	}
 
-	pubkey, err := trust.DecodedOmegaPubkey()
-	if err != nil {
-		return err
+	pubkey := o.cfg.OmegaPubkey
+	if pubkey == nil {
+		baked, err := trust.DecodedOmegaPubkey()
+		if err != nil {
+			return err
+		}
+		pubkey = baked
 	}
 
 	// 1. Verified cache — preferred. A still-valid cache lets the
@@ -175,7 +191,7 @@ func (o *Orchestrator) Boot(ctx context.Context) error {
 	// 2. DNS resolution against the omega trust chain.
 	fetchCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	list, dnsErr := trust.FetchSigned(fetchCtx, trust.DNSConfig{}, pubkey, time.Now())
+	list, dnsErr := trust.FetchSigned(fetchCtx, o.cfg.OmegaDNS, pubkey, time.Now())
 	if dnsErr == nil {
 		if err := trust.SaveCache(o.cfg.StateDir, list); err != nil {
 			o.cfg.Logger.Printf("dashboard: save omega cache: %v (continuing)", err)
@@ -192,6 +208,11 @@ func (o *Orchestrator) Boot(ctx context.Context) error {
 	//    UI banner makes that visible.
 	if len(o.cfg.SeedAddresses) > 0 {
 		o.applyRoots(normalizeAddrs(o.cfg.SeedAddresses), RootSourceSeeds, nil, time.Time{})
+		// Clear omega_refresh_failed: in seeds mode the refresher
+		// never runs, so this flag would otherwise stay true forever
+		// and double up with the SeedOverride banner. The
+		// seed_override flag is the single meaningful signal here.
+		o.markRefreshFailed(false)
 		o.cfg.Logger.Printf("dashboard: cache and DNS unavailable; booting from %d operator-supplied seeds, trust chain bypassed",
 			len(o.cfg.SeedAddresses))
 		return nil
@@ -218,13 +239,26 @@ func cacheFileMtime(dir string) time.Time {
 // SIGHUP handler. Returns when ctx is cancelled.
 func (o *Orchestrator) Run(ctx context.Context) {
 	// Stand up the trust.Refresher only when we're operating under the
-	// real trust chain. Seed-override skips it by design.
+	// real trust chain. Seed-override skips it by design. Pubkey-decode
+	// failure is non-fatal: we skip the refresher and let the
+	// poll loop continue serving whatever the cache provided. A real
+	// failure here means the binary's baked-in pubkey is malformed,
+	// which is a build-time problem, not a runtime one.
 	if o.source == RootSourceOmega && o.currentList != nil {
-		pubkey, err := trust.DecodedOmegaPubkey()
-		if err == nil {
+		pubkey := o.cfg.OmegaPubkey
+		if pubkey == nil {
+			baked, err := trust.DecodedOmegaPubkey()
+			if err != nil {
+				o.cfg.Logger.Printf("dashboard: decode omega pubkey: %v (running without refresher)", err)
+			} else {
+				pubkey = baked
+			}
+		}
+		if pubkey != nil {
 			o.refresher = trust.NewRefresher(trust.RefresherConfig{
 				Pubkey:   pubkey,
 				CacheDir: o.cfg.StateDir,
+				DNS:      o.cfg.OmegaDNS,
 				OnUpdate: o.onOmegaUpdate,
 				OnError: func(err error) {
 					o.cfg.Logger.Printf("dashboard: omega refresh: %v", err)

--- a/internal/dashboard/orchestrator.go
+++ b/internal/dashboard/orchestrator.go
@@ -1,0 +1,410 @@
+package dashboard
+
+import (
+	"context"
+	"log"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"repram/internal/trust"
+)
+
+// MaxRootsUnreachableCycles is how many consecutive poll cycles without any
+// reachable root the dashboard tolerates before triggering an omega refresh.
+// Five at 60s default = ~5 minutes of degradation before reaching for DNS.
+const MaxRootsUnreachableCycles = 5
+
+// RootSource captures where the dashboard's current root set came from.
+// The distinction matters: omega-derived roots carry the trust chain;
+// seed-derived roots bypass it and the snapshot must say so.
+type RootSource int
+
+const (
+	RootSourceOmega RootSource = iota
+	RootSourceSeeds
+)
+
+// Orchestrator drives the dashboard's main loop. It owns:
+//   - The current snapshot (served to /api/snapshot)
+//   - Cycle state (roots-unreachable streak, omega-refresh-failed flag)
+//   - The trust.Refresher (only when RootSource == omega)
+//   - The poller and builder
+//
+// Concurrency: snapshot reads happen on every HTTP request; cycle writes
+// happen once per poll interval. The snapshot is held behind an atomic
+// pointer so readers never block writers and vice versa.
+type Orchestrator struct {
+	cfg Config
+
+	poller  *Poller
+	builder *Builder
+	metrics *internalMetrics
+
+	// snapshot holds the current snapshot as a *Snapshot. Atomic so HTTP
+	// readers never contend with the poll-cycle writer.
+	snapshot atomic.Pointer[Snapshot]
+
+	// rootsMu guards roots and rootsConsecutiveMisses. The set rotates
+	// when the omega cache is refreshed or a seed override is applied.
+	rootsMu                 sync.RWMutex
+	roots                   map[string]bool
+	rootsConsecutiveMisses  int
+	source                  RootSource
+	currentList             *trust.SignedList
+	omegaRefreshFailedFlag  bool
+	omegaRefreshFailedMu    sync.Mutex
+
+	refresher *trust.Refresher
+	hupCh     chan struct{}
+}
+
+// Config bundles the orchestrator's startup parameters. Most fields have
+// sensible zero-value defaults; see field comments.
+type Config struct {
+	// StateDir is where omega.json (root-list.json, per trust.CacheFileName)
+	// and snapshot.json live. Must be writable.
+	StateDir string
+
+	// PollInterval is how often the orchestrator walks the topology.
+	// Zero selects 60s.
+	PollInterval time.Duration
+
+	// PollWorkers and PollTimeout are forwarded to the poller. Zero selects
+	// DefaultPollWorkers / DefaultPollTimeout.
+	PollWorkers int
+	PollTimeout time.Duration
+
+	// GeoDBPath is the GeoLite2-Country mmdb path, or empty for no-op geo.
+	GeoDBPath string
+
+	// SeedAddresses is the operator's break-glass — when non-empty the
+	// dashboard skips omega resolution entirely and treats these as
+	// roots. Snapshots gain SeedOverride=true.
+	SeedAddresses []string
+
+	// Logger is the destination for orchestrator chatter. nil selects
+	// the stdlib default logger.
+	Logger *log.Logger
+}
+
+// NewOrchestrator wires up the orchestrator without starting any goroutines.
+// Call Boot once before Run.
+func NewOrchestrator(cfg Config) *Orchestrator {
+	if cfg.PollInterval == 0 {
+		cfg.PollInterval = 60 * time.Second
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = log.Default()
+	}
+	geo, err := NewGeo(cfg.GeoDBPath)
+	if err != nil {
+		cfg.Logger.Printf("dashboard: geo init: %v (continuing without)", err)
+	}
+	return &Orchestrator{
+		cfg:     cfg,
+		poller:  NewPoller(cfg.PollWorkers, cfg.PollTimeout),
+		builder: NewBuilder(geo),
+		metrics: newInternalMetrics(),
+		hupCh:   make(chan struct{}, 1),
+	}
+}
+
+// Boot resolves the initial root set following the design's documented
+// order: cached omega list, then DNS, then --seeds, else exit-worthy error.
+// Also loads any persisted snapshot so readers see something immediately.
+func (o *Orchestrator) Boot(ctx context.Context) error {
+	// Load a prior snapshot if one exists. Failures here are non-fatal —
+	// a fresh deploy has no snapshot and that's fine.
+	if prior, err := LoadSnapshot(o.cfg.StateDir); err == nil && prior != nil {
+		prior.Stale = true
+		prior.LoadedFromDisk = true
+		o.snapshot.Store(prior)
+		o.cfg.Logger.Printf("dashboard: loaded prior snapshot (%d nodes, generated %s)",
+			len(prior.Nodes), prior.GeneratedAt.Format(time.RFC3339))
+	} else if err != nil {
+		o.cfg.Logger.Printf("dashboard: load snapshot: %v (continuing without)", err)
+	}
+
+	// Operator break-glass takes precedence. The flag is "I know what
+	// I'm doing, bypass the trust chain" — no DNS attempt is made.
+	if len(o.cfg.SeedAddresses) > 0 {
+		o.applyRoots(normalizeAddrs(o.cfg.SeedAddresses), RootSourceSeeds, nil)
+		o.cfg.Logger.Printf("dashboard: booted with %d operator-supplied seeds, trust chain bypassed",
+			len(o.cfg.SeedAddresses))
+		return nil
+	}
+
+	pubkey, err := trust.DecodedOmegaPubkey()
+	if err != nil {
+		return err
+	}
+
+	// Try the cache first. A still-valid cache lets the dashboard come
+	// up without any DNS at all — the design intent.
+	if cached, err := trust.LoadCache(o.cfg.StateDir); err != nil {
+		o.cfg.Logger.Printf("dashboard: load omega cache: %v (will try DNS)", err)
+	} else if cached != nil {
+		if verr := cached.Verify(pubkey, time.Now()); verr == nil {
+			o.applyRoots(normalizeAddrs(cached.Nodes), RootSourceOmega, cached)
+			o.cfg.Logger.Printf("dashboard: booted from cached omega list (%d roots, expires %s)",
+				len(cached.Nodes), time.Unix(cached.Expires, 0).Format(time.RFC3339))
+			return nil
+		} else {
+			o.cfg.Logger.Printf("dashboard: cached omega list failed verification: %v (will try DNS)", verr)
+		}
+	}
+
+	// Cache miss or invalid; fall to DNS.
+	fetchCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	list, err := trust.FetchSigned(fetchCtx, trust.DNSConfig{}, pubkey, time.Now())
+	if err != nil {
+		o.cfg.Logger.Printf("dashboard: omega DNS resolution failed: %v", err)
+		o.markRefreshFailed(true)
+		return err
+	}
+	if err := trust.SaveCache(o.cfg.StateDir, list); err != nil {
+		o.cfg.Logger.Printf("dashboard: save omega cache: %v (continuing)", err)
+	}
+	o.applyRoots(normalizeAddrs(list.Nodes), RootSourceOmega, list)
+	o.cfg.Logger.Printf("dashboard: booted from DNS-fetched omega list (%d roots)", len(list.Nodes))
+	return nil
+}
+
+// Run blocks driving the poll loop, the optional omega refresher, and the
+// SIGHUP handler. Returns when ctx is cancelled.
+func (o *Orchestrator) Run(ctx context.Context) {
+	// Stand up the trust.Refresher only when we're operating under the
+	// real trust chain. Seed-override skips it by design.
+	if o.source == RootSourceOmega && o.currentList != nil {
+		pubkey, err := trust.DecodedOmegaPubkey()
+		if err == nil {
+			o.refresher = trust.NewRefresher(trust.RefresherConfig{
+				Pubkey:   pubkey,
+				CacheDir: o.cfg.StateDir,
+				OnUpdate: o.onOmegaUpdate,
+				OnError: func(err error) {
+					o.cfg.Logger.Printf("dashboard: omega refresh: %v", err)
+					o.markRefreshFailed(true)
+					o.metrics.omegaRefreshFailures.Inc()
+				},
+			}, o.currentList)
+			go o.refresher.Run(ctx)
+		}
+	}
+
+	ticker := time.NewTicker(o.cfg.PollInterval)
+	defer ticker.Stop()
+
+	// Kick off the first poll immediately so /api/snapshot isn't 60s
+	// behind on cold-start when there's no prior snapshot to display.
+	o.cycle(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			o.cycle(ctx)
+		case <-o.hupCh:
+			o.cfg.Logger.Println("dashboard: SIGHUP — triggering omega refresh")
+			if o.refresher != nil {
+				o.refresher.Trigger()
+			}
+			// Also kick a poll so the operator's manual intervention
+			// produces an immediate snapshot update.
+			o.cycle(ctx)
+		}
+	}
+}
+
+// SignalHUP is called from the signal handler in main. Coalesces extra HUPs.
+func (o *Orchestrator) SignalHUP() {
+	select {
+	case o.hupCh <- struct{}{}:
+	default:
+	}
+}
+
+// Snapshot returns the most recently published snapshot. Nil only between
+// orchestrator construction and the first successful cycle (or prior-disk
+// snapshot load), so HTTP handlers should null-check before serving.
+func (o *Orchestrator) Snapshot() *Snapshot {
+	return o.snapshot.Load()
+}
+
+// MetricsRegistry exposes the internal Prometheus registry so the HTTP
+// server can mount it at /internal/metrics.
+func (o *Orchestrator) MetricsRegistry() *prometheus.Registry {
+	return o.metrics.registry
+}
+
+func (o *Orchestrator) cycle(ctx context.Context) {
+	o.metrics.pollsTotal.Inc()
+
+	o.rootsMu.RLock()
+	seeds := make([]string, 0, len(o.roots))
+	for addr := range o.roots {
+		seeds = append(seeds, addr)
+	}
+	rootsSnapshotted := make(map[string]bool, len(o.roots))
+	for k, v := range o.roots {
+		rootsSnapshotted[k] = v
+	}
+	source := o.source
+	currentList := o.currentList
+	o.rootsMu.RUnlock()
+
+	pollCtx, cancel := context.WithTimeout(ctx, o.cfg.PollInterval)
+	defer cancel()
+
+	results := o.poller.Walk(pollCtx, seeds)
+
+	// Compute roots-reachable bookkeeping before publishing.
+	rootsReachable := 0
+	unreachableNodes := 0
+	for _, r := range results {
+		if r.unreachable {
+			unreachableNodes++
+			continue
+		}
+		if rootsSnapshotted[r.addr.HostPort()] {
+			rootsReachable++
+		}
+	}
+
+	o.rootsMu.Lock()
+	if rootsReachable == 0 && len(seeds) > 0 {
+		o.rootsConsecutiveMisses++
+	} else {
+		o.rootsConsecutiveMisses = 0
+	}
+	missesNow := o.rootsConsecutiveMisses
+	o.rootsMu.Unlock()
+
+	if missesNow >= MaxRootsUnreachableCycles && source == RootSourceOmega && o.refresher != nil {
+		o.cfg.Logger.Printf("dashboard: %d consecutive cycles with no reachable root — triggering omega refresh", missesNow)
+		o.refresher.Trigger()
+	}
+
+	in := BuildInput{
+		Results:            results,
+		Roots:              rootsSnapshotted,
+		SeedOverride:       source == RootSourceSeeds,
+		RootsUnreachable:   rootsReachable == 0 && len(seeds) > 0,
+		OmegaRefreshFailed: o.refreshFailed(),
+		Now:                time.Now(),
+	}
+	if currentList != nil {
+		refreshed := time.Now()
+		expires := time.Unix(currentList.Expires, 0)
+		in.OmegaRefreshedAt = &refreshed
+		in.OmegaExpiresAt = &expires
+		o.metrics.omegaRefreshUnix.Set(float64(refreshed.Unix()))
+		o.metrics.omegaExpiresUnix.Set(float64(expires.Unix()))
+	}
+
+	snap := o.builder.Build(in)
+	snap.Stale = len(results) == 0
+
+	if len(results) == 0 {
+		o.metrics.pollsFailedTotal.Inc()
+		// Don't overwrite a populated snapshot with an empty one — keep
+		// serving the last-known graph with stale=true.
+		if prior := o.snapshot.Load(); prior != nil && len(prior.Nodes) > 0 {
+			prior.Stale = true
+			o.snapshot.Store(prior)
+			return
+		}
+	}
+
+	o.metrics.nodesUnreachable.Set(float64(unreachableNodes))
+	o.metrics.snapshotAgeSeconds.Set(0)
+	o.snapshot.Store(snap)
+
+	if err := SaveSnapshot(o.cfg.StateDir, snap); err != nil {
+		o.cfg.Logger.Printf("dashboard: save snapshot: %v", err)
+	}
+}
+
+func (o *Orchestrator) onOmegaUpdate(list *trust.SignedList) {
+	o.applyRoots(normalizeAddrs(list.Nodes), RootSourceOmega, list)
+	o.markRefreshFailed(false)
+	o.cfg.Logger.Printf("dashboard: omega list refreshed (%d roots, expires %s)",
+		len(list.Nodes), time.Unix(list.Expires, 0).Format(time.RFC3339))
+}
+
+func (o *Orchestrator) applyRoots(addrs map[string]bool, source RootSource, list *trust.SignedList) {
+	o.rootsMu.Lock()
+	defer o.rootsMu.Unlock()
+	o.roots = addrs
+	o.source = source
+	o.currentList = list
+	o.rootsConsecutiveMisses = 0
+}
+
+func (o *Orchestrator) markRefreshFailed(v bool) {
+	o.omegaRefreshFailedMu.Lock()
+	o.omegaRefreshFailedFlag = v
+	o.omegaRefreshFailedMu.Unlock()
+}
+
+func (o *Orchestrator) refreshFailed() bool {
+	o.omegaRefreshFailedMu.Lock()
+	defer o.omegaRefreshFailedMu.Unlock()
+	return o.omegaRefreshFailedFlag
+}
+
+func normalizeAddrs(in []string) map[string]bool {
+	out := make(map[string]bool, len(in))
+	for _, a := range in {
+		a = strings.TrimSpace(a)
+		if a == "" {
+			continue
+		}
+		// Validate parseability; silently drop garbage. We never want
+		// to brick the dashboard on one malformed seed.
+		host, portStr, err := splitHostPortRaw(a)
+		if err != nil {
+			continue
+		}
+		if _, err := strconv.Atoi(portStr); err != nil {
+			continue
+		}
+		out[hostPortJoin(host, portStr)] = true
+	}
+	return out
+}
+
+// splitHostPortRaw is a stdlib-equivalent split that tolerates IPv6 literals
+// and rejects bare hostnames without ports. Lives here so the trust-package
+// dependency stays a one-way edge.
+func splitHostPortRaw(s string) (host, port string, err error) {
+	// net.SplitHostPort handles IPv6 literals in [brackets]:port too.
+	h, p, e := splitHostPort(s)
+	if e != nil {
+		return "", "", e
+	}
+	return h, strconv.Itoa(p), nil
+}
+
+func hostPortJoin(host, port string) string {
+	// Re-join via strings.Builder to canonicalize; net.JoinHostPort
+	// adds [] around IPv6.
+	var b strings.Builder
+	if strings.ContainsRune(host, ':') {
+		b.WriteByte('[')
+		b.WriteString(host)
+		b.WriteByte(']')
+	} else {
+		b.WriteString(host)
+	}
+	b.WriteByte(':')
+	b.WriteString(port)
+	return b.String()
+}

--- a/internal/dashboard/orchestrator.go
+++ b/internal/dashboard/orchestrator.go
@@ -3,6 +3,7 @@ package dashboard
 import (
 	"context"
 	"log"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -43,6 +44,7 @@ type Orchestrator struct {
 
 	poller  *Poller
 	builder *Builder
+	geo     *Geo
 	metrics *internalMetrics
 
 	// snapshot holds the current snapshot as a *Snapshot. Atomic so HTTP
@@ -51,13 +53,26 @@ type Orchestrator struct {
 
 	// rootsMu guards roots and rootsConsecutiveMisses. The set rotates
 	// when the omega cache is refreshed or a seed override is applied.
-	rootsMu                 sync.RWMutex
-	roots                   map[string]bool
-	rootsConsecutiveMisses  int
-	source                  RootSource
-	currentList             *trust.SignedList
-	omegaRefreshFailedFlag  bool
-	omegaRefreshFailedMu    sync.Mutex
+	rootsMu                sync.RWMutex
+	roots                  map[string]bool
+	rootsConsecutiveMisses int
+	source                 RootSource
+	currentList            *trust.SignedList
+	currentListFetchedAt   time.Time
+	omegaRefreshFailedFlag bool
+	omegaRefreshFailedMu   sync.Mutex
+
+	// cycleMu serializes poll cycles so a slow walk can't overlap with
+	// the next ticker fire and race on rootsConsecutiveMisses. TryLock
+	// would let us count skipped cycles, but Go's sync.Mutex doesn't
+	// expose that — we just record an atomic skip count instead.
+	cycleMu      sync.Mutex
+	cyclesSkipped atomic.Uint64
+
+	// lastSuccessfulPoll backs the dashboard_snapshot_age_seconds
+	// GaugeFunc — gauges that age between cycles must be computed at
+	// scrape time, not poked once per cycle.
+	lastSuccessfulPoll atomic.Int64
 
 	refresher *trust.Refresher
 	hupCh     chan struct{}
@@ -105,18 +120,24 @@ func NewOrchestrator(cfg Config) *Orchestrator {
 	if err != nil {
 		cfg.Logger.Printf("dashboard: geo init: %v (continuing without)", err)
 	}
-	return &Orchestrator{
-		cfg:     cfg,
-		poller:  NewPoller(cfg.PollWorkers, cfg.PollTimeout),
-		builder: NewBuilder(geo),
-		metrics: newInternalMetrics(),
-		hupCh:   make(chan struct{}, 1),
+	o := &Orchestrator{
+		cfg:    cfg,
+		poller: NewPoller(cfg.PollWorkers, cfg.PollTimeout),
+		geo:    geo,
+		hupCh:  make(chan struct{}, 1),
 	}
+	o.metrics = newInternalMetrics(o.lastSuccessfulPoll.Load)
+	o.builder = NewBuilder(geo, o.metrics.geoLookupMissesTotal)
+	return o
 }
 
-// Boot resolves the initial root set following the design's documented
+// Boot resolves the initial root set following the design v3 documented
 // order: cached omega list, then DNS, then --seeds, else exit-worthy error.
-// Also loads any persisted snapshot so readers see something immediately.
+// `--seeds` is the last-resort break-glass — when a still-valid cache
+// exists, it takes precedence even if the operator also supplied seeds, so
+// the dashboard's steady-state behavior matches a node that booted from
+// the same cache. Boot also loads any persisted snapshot so readers see
+// something immediately.
 func (o *Orchestrator) Boot(ctx context.Context) error {
 	// Load a prior snapshot if one exists. Failures here are non-fatal —
 	// a fresh deploy has no snapshot and that's fine.
@@ -130,27 +151,19 @@ func (o *Orchestrator) Boot(ctx context.Context) error {
 		o.cfg.Logger.Printf("dashboard: load snapshot: %v (continuing without)", err)
 	}
 
-	// Operator break-glass takes precedence. The flag is "I know what
-	// I'm doing, bypass the trust chain" — no DNS attempt is made.
-	if len(o.cfg.SeedAddresses) > 0 {
-		o.applyRoots(normalizeAddrs(o.cfg.SeedAddresses), RootSourceSeeds, nil)
-		o.cfg.Logger.Printf("dashboard: booted with %d operator-supplied seeds, trust chain bypassed",
-			len(o.cfg.SeedAddresses))
-		return nil
-	}
-
 	pubkey, err := trust.DecodedOmegaPubkey()
 	if err != nil {
 		return err
 	}
 
-	// Try the cache first. A still-valid cache lets the dashboard come
-	// up without any DNS at all — the design intent.
+	// 1. Verified cache — preferred. A still-valid cache lets the
+	//    dashboard come up without any DNS at all.
 	if cached, err := trust.LoadCache(o.cfg.StateDir); err != nil {
 		o.cfg.Logger.Printf("dashboard: load omega cache: %v (will try DNS)", err)
 	} else if cached != nil {
 		if verr := cached.Verify(pubkey, time.Now()); verr == nil {
-			o.applyRoots(normalizeAddrs(cached.Nodes), RootSourceOmega, cached)
+			fetchedAt := cacheFileMtime(o.cfg.StateDir)
+			o.applyRoots(normalizeAddrs(cached.Nodes), RootSourceOmega, cached, fetchedAt)
 			o.cfg.Logger.Printf("dashboard: booted from cached omega list (%d roots, expires %s)",
 				len(cached.Nodes), time.Unix(cached.Expires, 0).Format(time.RFC3339))
 			return nil
@@ -159,21 +172,46 @@ func (o *Orchestrator) Boot(ctx context.Context) error {
 		}
 	}
 
-	// Cache miss or invalid; fall to DNS.
+	// 2. DNS resolution against the omega trust chain.
 	fetchCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	list, err := trust.FetchSigned(fetchCtx, trust.DNSConfig{}, pubkey, time.Now())
+	list, dnsErr := trust.FetchSigned(fetchCtx, trust.DNSConfig{}, pubkey, time.Now())
+	if dnsErr == nil {
+		if err := trust.SaveCache(o.cfg.StateDir, list); err != nil {
+			o.cfg.Logger.Printf("dashboard: save omega cache: %v (continuing)", err)
+		}
+		o.applyRoots(normalizeAddrs(list.Nodes), RootSourceOmega, list, time.Now())
+		o.cfg.Logger.Printf("dashboard: booted from DNS-fetched omega list (%d roots)", len(list.Nodes))
+		return nil
+	}
+	o.cfg.Logger.Printf("dashboard: omega DNS resolution failed: %v", dnsErr)
+	o.markRefreshFailed(true)
+
+	// 3. --seeds operator break-glass — last resort. Trust chain is
+	//    bypassed and the snapshot will carry seed_override:true so the
+	//    UI banner makes that visible.
+	if len(o.cfg.SeedAddresses) > 0 {
+		o.applyRoots(normalizeAddrs(o.cfg.SeedAddresses), RootSourceSeeds, nil, time.Time{})
+		o.cfg.Logger.Printf("dashboard: cache and DNS unavailable; booting from %d operator-supplied seeds, trust chain bypassed",
+			len(o.cfg.SeedAddresses))
+		return nil
+	}
+
+	// 4. Exit-worthy: no cache, no DNS, no seeds. Operator must provide
+	//    one of the three.
+	return dnsErr
+}
+
+// cacheFileMtime reads the modification time of the omega cache file so
+// the dashboard reports an honest "last refreshed" timestamp across
+// restarts. Falls back to zero time on stat failure — the snapshot then
+// omits OmegaRefreshedAt, which is more truthful than reporting "now".
+func cacheFileMtime(dir string) time.Time {
+	info, err := os.Stat(dir + "/" + trust.CacheFileName)
 	if err != nil {
-		o.cfg.Logger.Printf("dashboard: omega DNS resolution failed: %v", err)
-		o.markRefreshFailed(true)
-		return err
+		return time.Time{}
 	}
-	if err := trust.SaveCache(o.cfg.StateDir, list); err != nil {
-		o.cfg.Logger.Printf("dashboard: save omega cache: %v (continuing)", err)
-	}
-	o.applyRoots(normalizeAddrs(list.Nodes), RootSourceOmega, list)
-	o.cfg.Logger.Printf("dashboard: booted from DNS-fetched omega list (%d roots)", len(list.Nodes))
-	return nil
+	return info.ModTime()
 }
 
 // Run blocks driving the poll loop, the optional omega refresher, and the
@@ -212,9 +250,16 @@ func (o *Orchestrator) Run(ctx context.Context) {
 		case <-ticker.C:
 			o.cycle(ctx)
 		case <-o.hupCh:
-			o.cfg.Logger.Println("dashboard: SIGHUP — triggering omega refresh")
+			o.cfg.Logger.Println("dashboard: SIGHUP — refreshing omega + reloading geo DB")
 			if o.refresher != nil {
 				o.refresher.Trigger()
+			}
+			if o.geo != nil && o.cfg.GeoDBPath != "" {
+				if err := o.geo.Reload(o.cfg.GeoDBPath); err != nil {
+					o.cfg.Logger.Printf("dashboard: geo reload: %v (keeping previous DB)", err)
+				} else {
+					o.cfg.Logger.Println("dashboard: geo DB reloaded")
+				}
 			}
 			// Also kick a poll so the operator's manual intervention
 			// produces an immediate snapshot update.
@@ -245,6 +290,18 @@ func (o *Orchestrator) MetricsRegistry() *prometheus.Registry {
 }
 
 func (o *Orchestrator) cycle(ctx context.Context) {
+	// Serialize cycles. A walk that runs longer than PollInterval would
+	// otherwise overlap with the next ticker fire and race on
+	// rootsConsecutiveMisses. Skipping (not queueing) keeps the
+	// dashboard from falling further behind under load.
+	if !o.cycleMu.TryLock() {
+		o.cyclesSkipped.Add(1)
+		o.cfg.Logger.Printf("dashboard: skipping cycle — previous cycle still in flight (%d total skips)",
+			o.cyclesSkipped.Load())
+		return
+	}
+	defer o.cycleMu.Unlock()
+
 	o.metrics.pollsTotal.Inc()
 
 	o.rootsMu.RLock()
@@ -258,9 +315,18 @@ func (o *Orchestrator) cycle(ctx context.Context) {
 	}
 	source := o.source
 	currentList := o.currentList
+	currentListFetchedAt := o.currentListFetchedAt
 	o.rootsMu.RUnlock()
 
-	pollCtx, cancel := context.WithTimeout(ctx, o.cfg.PollInterval)
+	// Leave 5s headroom against the ticker so the next cycle never has
+	// to fight this one for cycleMu — a 60s interval becomes a 55s walk
+	// budget. The bounded worker pool plus per-request timeout normally
+	// keeps cycles well under this.
+	walkBudget := o.cfg.PollInterval - 5*time.Second
+	if walkBudget <= 0 {
+		walkBudget = o.cfg.PollInterval
+	}
+	pollCtx, cancel := context.WithTimeout(ctx, walkBudget)
 	defer cancel()
 
 	results := o.poller.Walk(pollCtx, seeds)
@@ -301,12 +367,14 @@ func (o *Orchestrator) cycle(ctx context.Context) {
 		Now:                time.Now(),
 	}
 	if currentList != nil {
-		refreshed := time.Now()
 		expires := time.Unix(currentList.Expires, 0)
-		in.OmegaRefreshedAt = &refreshed
 		in.OmegaExpiresAt = &expires
-		o.metrics.omegaRefreshUnix.Set(float64(refreshed.Unix()))
 		o.metrics.omegaExpiresUnix.Set(float64(expires.Unix()))
+		if !currentListFetchedAt.IsZero() {
+			refreshed := currentListFetchedAt
+			in.OmegaRefreshedAt = &refreshed
+			o.metrics.omegaRefreshUnix.Set(float64(refreshed.Unix()))
+		}
 	}
 
 	snap := o.builder.Build(in)
@@ -324,7 +392,7 @@ func (o *Orchestrator) cycle(ctx context.Context) {
 	}
 
 	o.metrics.nodesUnreachable.Set(float64(unreachableNodes))
-	o.metrics.snapshotAgeSeconds.Set(0)
+	o.lastSuccessfulPoll.Store(time.Now().Unix())
 	o.snapshot.Store(snap)
 
 	if err := SaveSnapshot(o.cfg.StateDir, snap); err != nil {
@@ -333,18 +401,19 @@ func (o *Orchestrator) cycle(ctx context.Context) {
 }
 
 func (o *Orchestrator) onOmegaUpdate(list *trust.SignedList) {
-	o.applyRoots(normalizeAddrs(list.Nodes), RootSourceOmega, list)
+	o.applyRoots(normalizeAddrs(list.Nodes), RootSourceOmega, list, time.Now())
 	o.markRefreshFailed(false)
 	o.cfg.Logger.Printf("dashboard: omega list refreshed (%d roots, expires %s)",
 		len(list.Nodes), time.Unix(list.Expires, 0).Format(time.RFC3339))
 }
 
-func (o *Orchestrator) applyRoots(addrs map[string]bool, source RootSource, list *trust.SignedList) {
+func (o *Orchestrator) applyRoots(addrs map[string]bool, source RootSource, list *trust.SignedList, fetchedAt time.Time) {
 	o.rootsMu.Lock()
 	defer o.rootsMu.Unlock()
 	o.roots = addrs
 	o.source = source
 	o.currentList = list
+	o.currentListFetchedAt = fetchedAt
 	o.rootsConsecutiveMisses = 0
 }
 

--- a/internal/dashboard/orchestrator_test.go
+++ b/internal/dashboard/orchestrator_test.go
@@ -2,6 +2,9 @@ package dashboard
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -10,35 +13,162 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"repram/internal/trust"
 )
 
-// TestBootSeedsAreLastResort verifies the v3 boot order: cache → DNS →
-// seeds → exit. A still-valid cache must take precedence over --seeds, so
-// the dashboard's steady-state behavior tracks the network's signed root
-// list rather than a stale operator break-glass.
-//
-// This test asserts the *order* indirectly: with both an unreachable DNS
-// path and a fresh --seeds set, an empty state dir must NOT short-circuit
-// to seeds before attempting DNS. We confirm via the seed_override flag
-// on the snapshot — it should only be true when DNS also failed.
-func TestBootDoesNotShortCircuitToSeeds(t *testing.T) {
-	// With seeds provided but DNS resolvable (cached), the source must
-	// resolve to RootSourceOmega — never seeds — when a cache is present.
-	// We can't run the full Boot path here without DNS infrastructure;
-	// the smoke test in the repository verifies the live cluster path.
-	// What we DO assert: applyRoots preserves the source it was given,
-	// so the boot-order code in Boot() is the single point of decision.
+// stubTXTResolver is an in-memory dns.TXTResolver. Each entry is either a
+// canned response or an error; absence is treated as NXDOMAIN.
+type stubTXTResolver struct {
+	records map[string][]string
+	err     map[string]error
+}
+
+func (s *stubTXTResolver) LookupTXT(_ context.Context, name string) ([]string, error) {
+	if err, ok := s.err[name]; ok {
+		return nil, err
+	}
+	if recs, ok := s.records[name]; ok {
+		return recs, nil
+	}
+	return nil, errors.New("nxdomain")
+}
+
+func newSignedList(t *testing.T, priv ed25519.PrivateKey, nodes []string, expires time.Time) *trust.SignedList {
+	t.Helper()
+	list := &trust.SignedList{
+		Version: trust.OmegaVersion,
+		Expires: expires.Unix(),
+		Nodes:   nodes,
+	}
+	list.Sign(priv)
+	return list
+}
+
+// TestApplyRootsPreservesSource verifies the small invariant that
+// applyRoots stores the source it was given. The boot-order logic in
+// Boot() relies on this — Boot is the single point of decision for which
+// source the orchestrator runs under.
+func TestApplyRootsPreservesSource(t *testing.T) {
 	o := NewOrchestrator(Config{StateDir: t.TempDir()})
 	o.applyRoots(map[string]bool{"10.0.0.1:18080": true}, RootSourceOmega, nil, time.Now())
 	if o.source != RootSourceOmega {
 		t.Fatalf("applyRoots should set source=omega, got %v", o.source)
 	}
-
-	// applyRoots with seeds must mark the source accordingly. This is
-	// the only path that produces seed_override:true in the snapshot.
 	o.applyRoots(map[string]bool{"10.0.0.2:18080": true}, RootSourceSeeds, nil, time.Time{})
 	if o.source != RootSourceSeeds {
 		t.Fatalf("applyRoots should set source=seeds, got %v", o.source)
+	}
+}
+
+// TestBootValidCacheBeatsSeeds verifies the v3 boot-order invariant: a
+// still-valid cache is preferred over --seeds even when both are present.
+// Without this guarantee, an operator who left --seeds in their service
+// file would silently bypass the trust chain even after cache resolution
+// succeeded — exactly the regression v1's first review caught.
+func TestBootValidCacheBeatsSeeds(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	dir := t.TempDir()
+
+	// Plant a fresh, signed cache that the orchestrator can verify.
+	cached := newSignedList(t, priv, []string{"cache-root.example:9090"}, time.Now().Add(1*time.Hour))
+	if err := trust.SaveCache(dir, cached); err != nil {
+		t.Fatalf("save cache: %v", err)
+	}
+
+	o := NewOrchestrator(Config{
+		StateDir:      dir,
+		OmegaPubkey:   pub,
+		SeedAddresses: []string{"10.0.0.99:18080"}, // would-be seeds
+		// OmegaDNS left zero — Boot must not reach DNS at all because
+		// the cache short-circuits. If the boot order were ever
+		// re-inverted, the test would either flake on DNS or fall
+		// through to seeds and fail the source check below.
+	})
+	if err := o.Boot(context.Background()); err != nil {
+		t.Fatalf("boot: %v", err)
+	}
+	if o.source != RootSourceOmega {
+		t.Errorf("expected source=omega from valid cache, got %v", o.source)
+	}
+	if _, ok := o.roots["cache-root.example:9090"]; !ok {
+		t.Errorf("cache root not adopted: %+v", o.roots)
+	}
+}
+
+// TestBootDNSBeatsSeedsWhenCacheAbsent verifies the second step of the
+// boot order: with no cache, DNS resolution is attempted before falling
+// through to --seeds.
+func TestBootDNSBeatsSeedsWhenCacheAbsent(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	list := newSignedList(t, priv, []string{"dns-root.example:9090"}, time.Now().Add(1*time.Hour))
+
+	resolver := &stubTXTResolver{
+		records: map[string][]string{
+			"_bootstrap.repram.io": {"omega=_omega.repram.io"},
+			"_omega.repram.io":     {list.Encode()},
+		},
+	}
+
+	o := NewOrchestrator(Config{
+		StateDir:      t.TempDir(),
+		OmegaPubkey:   pub,
+		OmegaDNS:      trust.DNSConfig{Resolver: resolver},
+		SeedAddresses: []string{"10.0.0.99:18080"},
+	})
+	if err := o.Boot(context.Background()); err != nil {
+		t.Fatalf("boot: %v", err)
+	}
+	if o.source != RootSourceOmega {
+		t.Errorf("expected source=omega from DNS resolution, got %v", o.source)
+	}
+	if _, ok := o.roots["dns-root.example:9090"]; !ok {
+		t.Errorf("DNS-resolved root not adopted: %+v", o.roots)
+	}
+}
+
+// TestBootSeedsAreLastResort verifies the third step: with no cache and
+// DNS failing, --seeds is consulted as the operator's break-glass and the
+// snapshot carries SeedOverride. Also verifies omega_refresh_failed is
+// cleared on the seeds path so the UI doesn't double-banner.
+func TestBootSeedsAreLastResort(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	resolver := &stubTXTResolver{
+		err: map[string]error{"_bootstrap.repram.io": errors.New("dns down")},
+	}
+
+	o := NewOrchestrator(Config{
+		StateDir:      t.TempDir(),
+		OmegaPubkey:   pub,
+		OmegaDNS:      trust.DNSConfig{Resolver: resolver},
+		SeedAddresses: []string{"10.0.0.99:18080"},
+	})
+	if err := o.Boot(context.Background()); err != nil {
+		t.Fatalf("boot: %v", err)
+	}
+	if o.source != RootSourceSeeds {
+		t.Errorf("expected source=seeds after cache+DNS fail, got %v", o.source)
+	}
+	if o.refreshFailed() {
+		t.Errorf("omega_refresh_failed should be cleared on the seeds success path; UI would otherwise double-banner alongside seed_override")
+	}
+}
+
+// TestBootExitsWhenNothingAvailable verifies the fourth step: no cache,
+// no DNS, no seeds → return non-zero so the operator's start-script
+// surfaces the failure rather than the dashboard quietly serving nothing.
+func TestBootExitsWhenNothingAvailable(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	resolver := &stubTXTResolver{
+		err: map[string]error{"_bootstrap.repram.io": errors.New("dns down")},
+	}
+	o := NewOrchestrator(Config{
+		StateDir:    t.TempDir(),
+		OmegaPubkey: pub,
+		OmegaDNS:    trust.DNSConfig{Resolver: resolver},
+	})
+	if err := o.Boot(context.Background()); err == nil {
+		t.Error("expected Boot to return error when cache, DNS, and seeds are all unavailable")
 	}
 }
 
@@ -71,7 +201,9 @@ func TestConcurrentCyclesAreSerialized(t *testing.T) {
 }
 
 // TestBootLoadsPriorSnapshotAsStale verifies snapshot persistence is
-// loaded with stale=true and loaded_from_disk=true on cold start.
+// loaded with stale=true and loaded_from_disk=true on cold start. The DNS
+// path is stubbed so the test is hermetic — a live DNS lookup would add
+// 10s wall-clock in environments without external resolution.
 func TestBootLoadsPriorSnapshotAsStale(t *testing.T) {
 	dir := t.TempDir()
 	prior := &Snapshot{
@@ -82,15 +214,22 @@ func TestBootLoadsPriorSnapshotAsStale(t *testing.T) {
 	if err := SaveSnapshot(dir, prior); err != nil {
 		t.Fatal(err)
 	}
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	resolver := &stubTXTResolver{
+		err: map[string]error{"_bootstrap.repram.io": errors.New("stubbed: no dns")},
+	}
 	o := NewOrchestrator(Config{
 		StateDir:      dir,
-		SeedAddresses: []string{"127.0.0.1:1"}, // seeds-only path, no DNS needed
+		OmegaPubkey:   pub,
+		OmegaDNS:      trust.DNSConfig{Resolver: resolver},
+		SeedAddresses: []string{"127.0.0.1:1"},
 	})
-	// Boot will try cache (none) → DNS (will fail with a real lookup
-	// here, but that's fine — it'll fall through to seeds). For this
-	// test we only care about the snapshot-load behavior, which
-	// happens before any of that.
-	_ = o.Boot(context.Background())
+	// Boot will try cache (none) → DNS (stub fails fast) → seeds (succeed).
+	// We only care about the prior-snapshot-load behavior, which runs
+	// before any of that.
+	if err := o.Boot(context.Background()); err != nil {
+		t.Fatalf("boot: %v", err)
+	}
 
 	loaded := o.Snapshot()
 	if loaded == nil || loaded.Nodes[0].ID != "node-old" {

--- a/internal/dashboard/orchestrator_test.go
+++ b/internal/dashboard/orchestrator_test.go
@@ -1,0 +1,124 @@
+package dashboard
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestBootSeedsAreLastResort verifies the v3 boot order: cache → DNS →
+// seeds → exit. A still-valid cache must take precedence over --seeds, so
+// the dashboard's steady-state behavior tracks the network's signed root
+// list rather than a stale operator break-glass.
+//
+// This test asserts the *order* indirectly: with both an unreachable DNS
+// path and a fresh --seeds set, an empty state dir must NOT short-circuit
+// to seeds before attempting DNS. We confirm via the seed_override flag
+// on the snapshot — it should only be true when DNS also failed.
+func TestBootDoesNotShortCircuitToSeeds(t *testing.T) {
+	// With seeds provided but DNS resolvable (cached), the source must
+	// resolve to RootSourceOmega — never seeds — when a cache is present.
+	// We can't run the full Boot path here without DNS infrastructure;
+	// the smoke test in the repository verifies the live cluster path.
+	// What we DO assert: applyRoots preserves the source it was given,
+	// so the boot-order code in Boot() is the single point of decision.
+	o := NewOrchestrator(Config{StateDir: t.TempDir()})
+	o.applyRoots(map[string]bool{"10.0.0.1:18080": true}, RootSourceOmega, nil, time.Now())
+	if o.source != RootSourceOmega {
+		t.Fatalf("applyRoots should set source=omega, got %v", o.source)
+	}
+
+	// applyRoots with seeds must mark the source accordingly. This is
+	// the only path that produces seed_override:true in the snapshot.
+	o.applyRoots(map[string]bool{"10.0.0.2:18080": true}, RootSourceSeeds, nil, time.Time{})
+	if o.source != RootSourceSeeds {
+		t.Fatalf("applyRoots should set source=seeds, got %v", o.source)
+	}
+}
+
+// TestConcurrentCyclesAreSerialized verifies that a slow cycle does not
+// race with the next tick. We start two cycles in quick succession; the
+// second must skip because the first holds cycleMu.
+func TestConcurrentCyclesAreSerialized(t *testing.T) {
+	srv := slowFakeNode(t, 200*time.Millisecond)
+	defer srv.Close()
+
+	dir := t.TempDir()
+	o := NewOrchestrator(Config{
+		StateDir:     dir,
+		PollInterval: 1 * time.Second,
+		PollWorkers:  1,
+		PollTimeout:  2 * time.Second,
+	})
+	host, port := srvHostPort(t, srv)
+	o.applyRoots(map[string]bool{fmt.Sprintf("%s:%d", host, port): true}, RootSourceSeeds, nil, time.Time{})
+
+	ctx := context.Background()
+	go o.cycle(ctx)
+	// Brief sleep so the first cycle is in flight before the second.
+	time.Sleep(20 * time.Millisecond)
+	o.cycle(ctx) // expected to skip
+
+	if o.cyclesSkipped.Load() != 1 {
+		t.Errorf("expected 1 cycle skip, got %d", o.cyclesSkipped.Load())
+	}
+}
+
+// TestBootLoadsPriorSnapshotAsStale verifies snapshot persistence is
+// loaded with stale=true and loaded_from_disk=true on cold start.
+func TestBootLoadsPriorSnapshotAsStale(t *testing.T) {
+	dir := t.TempDir()
+	prior := &Snapshot{
+		GeneratedAt: time.Now().Add(-1 * time.Hour),
+		Stats:       Stats{Nodes: 1},
+		Nodes:       []Node{{ID: "node-old"}},
+	}
+	if err := SaveSnapshot(dir, prior); err != nil {
+		t.Fatal(err)
+	}
+	o := NewOrchestrator(Config{
+		StateDir:      dir,
+		SeedAddresses: []string{"127.0.0.1:1"}, // seeds-only path, no DNS needed
+	})
+	// Boot will try cache (none) → DNS (will fail with a real lookup
+	// here, but that's fine — it'll fall through to seeds). For this
+	// test we only care about the snapshot-load behavior, which
+	// happens before any of that.
+	_ = o.Boot(context.Background())
+
+	loaded := o.Snapshot()
+	if loaded == nil || loaded.Nodes[0].ID != "node-old" {
+		t.Fatalf("prior snapshot not loaded: %+v", loaded)
+	}
+	if !loaded.Stale || !loaded.LoadedFromDisk {
+		t.Errorf("expected stale=true loaded_from_disk=true, got stale=%v lfd=%v", loaded.Stale, loaded.LoadedFromDisk)
+	}
+}
+
+func slowFakeNode(t *testing.T, delay time.Duration) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/topology", func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(delay)
+		fmt.Fprintf(w, `{"node_id":"slow","enclave":"default","peers":[]}`)
+	})
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"node_id":"slow","enclave":"default","uptime":"1h","memory":{"alloc":0},"goroutines":1}`)
+	})
+	mux.HandleFunc("/v1/metrics", func(w http.ResponseWriter, _ *http.Request) {})
+	return httptest.NewServer(mux)
+}
+
+func srvHostPort(t *testing.T, srv *httptest.Server) (string, int) {
+	t.Helper()
+	u, _ := url.Parse(srv.URL)
+	host, portStr, _ := strings.Cut(u.Host, ":")
+	port, _ := strconv.Atoi(portStr)
+	return host, port
+}

--- a/internal/dashboard/poller.go
+++ b/internal/dashboard/poller.go
@@ -25,6 +25,19 @@ const DefaultPollWorkers = 8
 // timeout, so anything slower than that is in degraded territory anyway.
 const DefaultPollTimeout = 5 * time.Second
 
+// MaxResponseBytes caps any single HTTP response body the poller will
+// read. A malicious node could otherwise serve gigabytes at /v1/metrics
+// or /v1/topology and exhaust the dashboard heap. 1 MiB matches REPRAM's
+// own server-side request-body limit (MaxRequestSize) — anything beyond
+// is degenerate.
+const MaxResponseBytes int64 = 1 << 20
+
+// MaxVisitedNodes caps how many distinct addresses one BFS cycle will
+// pursue. A malicious node returning thousands of fabricated peers would
+// otherwise drive an unbounded number of outbound dials. The cap is
+// generous (the public mesh is small), but bounded.
+const MaxVisitedNodes = 1024
+
 // nodeAddr is the dashboard's internal pairing of identity + endpoint. The
 // public snapshot strips the address (see Builder.Build); this lives only in
 // the poller's working set.
@@ -142,6 +155,14 @@ func (p *Poller) Walk(ctx context.Context, seeds []string) map[string]pollResult
 			mu.Unlock()
 			return
 		}
+		if len(visited) >= MaxVisitedNodes {
+			// Cap is generous (the public mesh is small). Hitting it
+			// usually means a node served fabricated peer entries.
+			// Silently dropping is the right move — the orchestrator
+			// publishes the partial graph and the cycle continues.
+			mu.Unlock()
+			return
+		}
 		visited[key] = true
 		pending++
 		mu.Unlock()
@@ -175,7 +196,11 @@ func (p *Poller) Walk(ctx context.Context, seeds []string) map[string]pollResult
 						return
 					}
 					res := p.pollOne(ctx, addr)
-					results <- res
+					select {
+					case results <- res:
+					case <-ctx.Done():
+						return
+					}
 					for _, peer := range res.peers {
 						if peer.Address == "" || peer.HTTPPort == 0 {
 							continue
@@ -272,8 +297,11 @@ func fetchJSON[T any](ctx context.Context, client *http.Client, url string) (T, 
 	if resp.StatusCode != 200 {
 		return zero, fmt.Errorf("http %d", resp.StatusCode)
 	}
+	// Same cap as fetchText — bound the JSON parser against a malicious
+	// or runaway node. Honest topology/status responses are kilobytes;
+	// 1 MiB is two orders of magnitude past that.
 	var out T
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, MaxResponseBytes)).Decode(&out); err != nil {
 		return zero, err
 	}
 	return out, nil
@@ -292,7 +320,10 @@ func fetchText(ctx context.Context, client *http.Client, url string) (string, er
 	if resp.StatusCode != 200 {
 		return "", fmt.Errorf("http %d", resp.StatusCode)
 	}
-	body, err := io.ReadAll(resp.Body)
+	// Cap the read to MaxResponseBytes — a malicious node could otherwise
+	// serve gigabytes here and exhaust the dashboard heap. The cap is
+	// well above any honest /v1/metrics or /v1/topology response.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, MaxResponseBytes))
 	if err != nil {
 		return "", err
 	}

--- a/internal/dashboard/poller.go
+++ b/internal/dashboard/poller.go
@@ -1,0 +1,350 @@
+package dashboard
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DefaultPollWorkers is the bounded worker pool size. One slow node must
+// not gate the cycle; eight in parallel is plenty for a network of dozens
+// and bounds the dashboard's outbound socket count.
+const DefaultPollWorkers = 8
+
+// DefaultPollTimeout is the per-request HTTP deadline. Three round trips
+// (topology, status, metrics) can take up to 3x this, but worker concurrency
+// keeps the cycle bounded. Five seconds matches the cluster's gossip-write
+// timeout, so anything slower than that is in degraded territory anyway.
+const DefaultPollTimeout = 5 * time.Second
+
+// nodeAddr is the dashboard's internal pairing of identity + endpoint. The
+// public snapshot strips the address (see Builder.Build); this lives only in
+// the poller's working set.
+type nodeAddr struct {
+	ID       string
+	Host     string
+	HTTPPort int
+	Enclave  string
+}
+
+func (n nodeAddr) HostPort() string {
+	return net.JoinHostPort(n.Host, strconv.Itoa(n.HTTPPort))
+}
+
+// pollResult is what one worker produces per node. unreachable means at
+// least one of {topology, status} failed and the snapshot should mark this
+// node accordingly. peers is the raw topology list (which the BFS uses to
+// discover new nodes). metrics may be partially populated when /v1/metrics
+// is missing or unparseable — that's logged, not fatal.
+type pollResult struct {
+	addr        nodeAddr
+	unreachable bool
+	status      statusResponse
+	metrics     NodeMetrics
+	peers       []peerEntry
+}
+
+// statusResponse is the subset of /v1/status the dashboard consumes. Kept
+// minimal so unknown fields are silently dropped — REPRAM may add to
+// status over time and the dashboard should not error on that.
+type statusResponse struct {
+	NodeID  string `json:"node_id"`
+	Enclave string `json:"enclave"`
+	Network string `json:"network"`
+	Uptime  string `json:"uptime"`
+	Memory  struct {
+		Alloc int64 `json:"alloc"`
+	} `json:"memory"`
+	Goroutines int `json:"goroutines"`
+}
+
+type topologyResponse struct {
+	NodeID  string      `json:"node_id"`
+	Enclave string      `json:"enclave"`
+	Peers   []peerEntry `json:"peers"`
+}
+
+type peerEntry struct {
+	ID       string `json:"id"`
+	Address  string `json:"address"`
+	HTTPPort int    `json:"http_port"`
+	Enclave  string `json:"enclave"`
+}
+
+// Poller walks the network topology BFS-style from a seed set and produces
+// per-cycle results that the Builder consumes. Stateless across cycles
+// except for HTTP client reuse — every cycle re-walks from the seed set so
+// a node that has dropped out of the graph drops out of the snapshot.
+type Poller struct {
+	client  *http.Client
+	workers int
+}
+
+// NewPoller constructs a poller with sensible defaults. workers <= 0
+// selects DefaultPollWorkers; requestTimeout <= 0 selects DefaultPollTimeout.
+// The underlying http.Client reuses connections per Go's standard transport
+// pooling — a long-lived dashboard against a small cluster keeps a handful
+// of warm connections.
+func NewPoller(workers int, requestTimeout time.Duration) *Poller {
+	if workers <= 0 {
+		workers = DefaultPollWorkers
+	}
+	if requestTimeout <= 0 {
+		requestTimeout = DefaultPollTimeout
+	}
+	return &Poller{
+		client: &http.Client{
+			Timeout: requestTimeout,
+			Transport: &http.Transport{
+				MaxIdleConnsPerHost: 4,
+				IdleConnTimeout:     90 * time.Second,
+			},
+		},
+		workers: workers,
+	}
+}
+
+// Walk performs one full BFS cycle starting from seeds. Returns one entry
+// per discovered node — including unreachable ones — keyed by node ID. The
+// caller (Builder.Build) is responsible for converting these results into
+// the snapshot's public projection.
+//
+// Seeds are addresses ("host:port"). The first successful /v1/topology
+// reply assigns the node its canonical ID; later peer entries that match
+// either ID or address are coalesced. This matches how the cluster itself
+// reasons about identity (id is authoritative once known).
+func (p *Poller) Walk(ctx context.Context, seeds []string) map[string]pollResult {
+	if len(seeds) == 0 {
+		return map[string]pollResult{}
+	}
+
+	queue := make(chan nodeAddr, 256)
+	results := make(chan pollResult, 64)
+
+	var (
+		mu      sync.Mutex
+		visited = map[string]bool{} // keyed by host:port
+		pending int
+	)
+
+	enqueue := func(a nodeAddr) {
+		key := a.HostPort()
+		mu.Lock()
+		if visited[key] {
+			mu.Unlock()
+			return
+		}
+		visited[key] = true
+		pending++
+		mu.Unlock()
+		select {
+		case queue <- a:
+		case <-ctx.Done():
+		}
+	}
+
+	// Seed the queue with placeholder addresses; the ID is filled in by
+	// the first successful topology call.
+	for _, seed := range seeds {
+		host, port, err := splitHostPort(seed)
+		if err != nil {
+			continue
+		}
+		enqueue(nodeAddr{Host: host, HTTPPort: port})
+	}
+
+	var workersWg sync.WaitGroup
+	for i := 0; i < p.workers; i++ {
+		workersWg.Add(1)
+		go func() {
+			defer workersWg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case addr, ok := <-queue:
+					if !ok {
+						return
+					}
+					res := p.pollOne(ctx, addr)
+					results <- res
+					for _, peer := range res.peers {
+						if peer.Address == "" || peer.HTTPPort == 0 {
+							continue
+						}
+						enqueue(nodeAddr{
+							ID:       peer.ID,
+							Host:     peer.Address,
+							HTTPPort: peer.HTTPPort,
+							Enclave:  peer.Enclave,
+						})
+					}
+					mu.Lock()
+					pending--
+					done := pending == 0
+					mu.Unlock()
+					if done {
+						close(queue)
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	collected := map[string]pollResult{}
+	collectorDone := make(chan struct{})
+	go func() {
+		defer close(collectorDone)
+		for r := range results {
+			id := r.addr.ID
+			if id == "" {
+				id = r.addr.HostPort()
+			}
+			collected[id] = r
+		}
+	}()
+
+	workersWg.Wait()
+	close(results)
+	<-collectorDone
+	return collected
+}
+
+// pollOne hits /v1/topology then /v1/status then /v1/metrics for a single
+// node. A topology failure marks the node unreachable; status/metrics
+// failures populate what they can and continue. The 5s per-request
+// timeout (set on the shared client) bounds the worst-case wait.
+func (p *Poller) pollOne(ctx context.Context, addr nodeAddr) pollResult {
+	base := fmt.Sprintf("http://%s", addr.HostPort())
+	res := pollResult{addr: addr}
+
+	topo, err := fetchJSON[topologyResponse](ctx, p.client, base+"/v1/topology")
+	if err != nil {
+		res.unreachable = true
+		return res
+	}
+	if topo.NodeID != "" {
+		res.addr.ID = topo.NodeID
+	}
+	if topo.Enclave != "" {
+		res.addr.Enclave = topo.Enclave
+	}
+	res.peers = topo.Peers
+
+	status, err := fetchJSON[statusResponse](ctx, p.client, base+"/v1/status")
+	if err == nil {
+		res.status = status
+		if status.NodeID != "" {
+			res.addr.ID = status.NodeID
+		}
+		if status.Enclave != "" {
+			res.addr.Enclave = status.Enclave
+		}
+	}
+
+	if metricsText, err := fetchText(ctx, p.client, base+"/v1/metrics"); err == nil {
+		res.metrics = parseMetrics(metricsText)
+	}
+
+	return res
+}
+
+func fetchJSON[T any](ctx context.Context, client *http.Client, url string) (T, error) {
+	var zero T
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return zero, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return zero, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return zero, fmt.Errorf("http %d", resp.StatusCode)
+	}
+	var out T
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return zero, err
+	}
+	return out, nil
+}
+
+func fetchText(ctx context.Context, client *http.Client, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("http %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+// parseMetrics extracts the four counters the dashboard cares about from a
+// Prometheus exposition. We do not pull in the full Prometheus parser
+// because the surface is tiny and stable: four `repram_*` counters in a
+// well-formed text exposition. Anything malformed falls through to zero.
+func parseMetrics(text string) NodeMetrics {
+	var m NodeMetrics
+	scan := bufio.NewScanner(strings.NewReader(text))
+	for scan.Scan() {
+		line := scan.Text()
+		if line == "" || line[0] == '#' {
+			continue
+		}
+		name, value, ok := strings.Cut(line, " ")
+		if !ok {
+			continue
+		}
+		// Strip optional labels — the metrics we read have none, but
+		// be defensive in case that changes.
+		if idx := strings.Index(name, "{"); idx >= 0 {
+			name = name[:idx]
+		}
+		num, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+		if err != nil {
+			continue
+		}
+		u := uint64(num)
+		switch name {
+		case "repram_peer_joins_total":
+			m.PeerJoinsTotal = u
+		case "repram_peer_evictions_total":
+			m.PeerEvictionsTotal = u
+		case "repram_ping_failures_total":
+			m.PingFailuresTotal = u
+		}
+	}
+	return m
+}
+
+func splitHostPort(s string) (string, int, error) {
+	host, portStr, err := net.SplitHostPort(s)
+	if err != nil {
+		return "", 0, err
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return "", 0, err
+	}
+	return host, port, nil
+}

--- a/internal/dashboard/poller_test.go
+++ b/internal/dashboard/poller_test.go
@@ -1,0 +1,160 @@
+package dashboard
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeNode is a tiny in-memory REPRAM node: serves /v1/topology, /v1/status,
+// and /v1/metrics with operator-supplied payloads. Used by poller tests to
+// stand up small clusters without touching the network.
+type fakeNode struct {
+	srv      *httptest.Server
+	id       string
+	enclave  string
+	peers    []peerEntry
+	uptime   string
+	memAlloc int64
+	gor      int
+	metrics  map[string]uint64
+	httpPort int
+	host     string
+}
+
+func startFakeNode(t *testing.T, id, enclave string) *fakeNode {
+	t.Helper()
+	fn := &fakeNode{id: id, enclave: enclave, uptime: "1h"}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/topology", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"node_id":%q,"enclave":%q,"peers":[`, fn.id, fn.enclave)
+		for i, p := range fn.peers {
+			if i > 0 {
+				w.Write([]byte(","))
+			}
+			fmt.Fprintf(w, `{"id":%q,"address":%q,"http_port":%d,"enclave":%q}`, p.ID, p.Address, p.HTTPPort, p.Enclave)
+		}
+		w.Write([]byte(`]}`))
+	})
+	mux.HandleFunc("/v1/status", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"node_id":%q,"enclave":%q,"uptime":%q,"memory":{"alloc":%d},"goroutines":%d}`,
+			fn.id, fn.enclave, fn.uptime, fn.memAlloc, fn.gor)
+	})
+	mux.HandleFunc("/v1/metrics", func(w http.ResponseWriter, _ *http.Request) {
+		for k, v := range fn.metrics {
+			fmt.Fprintf(w, "%s %d\n", k, v)
+		}
+	})
+	fn.srv = httptest.NewServer(mux)
+	t.Cleanup(fn.srv.Close)
+
+	u, _ := url.Parse(fn.srv.URL)
+	host, portStr, _ := strings.Cut(u.Host, ":")
+	port, _ := strconv.Atoi(portStr)
+	fn.host = host
+	fn.httpPort = port
+	return fn
+}
+
+func TestPollerWalksFullCluster(t *testing.T) {
+	a := startFakeNode(t, "node-a", "default")
+	b := startFakeNode(t, "node-b", "default")
+	c := startFakeNode(t, "node-c", "default")
+	// Wire peer awareness — a knows b and c; b knows a and c; c knows a and b.
+	a.peers = []peerEntry{
+		{ID: "node-b", Address: b.host, HTTPPort: b.httpPort, Enclave: "default"},
+		{ID: "node-c", Address: c.host, HTTPPort: c.httpPort, Enclave: "default"},
+	}
+	b.peers = []peerEntry{
+		{ID: "node-a", Address: a.host, HTTPPort: a.httpPort, Enclave: "default"},
+		{ID: "node-c", Address: c.host, HTTPPort: c.httpPort, Enclave: "default"},
+	}
+	c.peers = []peerEntry{
+		{ID: "node-a", Address: a.host, HTTPPort: a.httpPort, Enclave: "default"},
+		{ID: "node-b", Address: b.host, HTTPPort: b.httpPort, Enclave: "default"},
+	}
+	a.metrics = map[string]uint64{
+		"repram_peer_joins_total":     5,
+		"repram_peer_evictions_total": 1,
+		"repram_ping_failures_total":  2,
+	}
+
+	p := NewPoller(4, 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	results := p.Walk(ctx, []string{fmt.Sprintf("%s:%d", a.host, a.httpPort)})
+
+	if len(results) != 3 {
+		t.Fatalf("expected 3 nodes discovered, got %d (%+v)", len(results), results)
+	}
+	for _, id := range []string{"node-a", "node-b", "node-c"} {
+		r, ok := results[id]
+		if !ok {
+			t.Errorf("missing %s in walk results", id)
+			continue
+		}
+		if r.unreachable {
+			t.Errorf("%s should not be unreachable", id)
+		}
+	}
+	if results["node-a"].metrics.PeerJoinsTotal != 5 {
+		t.Errorf("metrics not propagated: %+v", results["node-a"].metrics)
+	}
+}
+
+func TestPollerMarksUnreachableOnTopologyFailure(t *testing.T) {
+	// Use a server that refuses connections — close immediately.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	u, _ := url.Parse(srv.URL)
+
+	p := NewPoller(2, 1*time.Second)
+	results := p.Walk(context.Background(), []string{u.Host})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for unreachable seed, got %d", len(results))
+	}
+	for _, r := range results {
+		if !r.unreachable {
+			t.Errorf("expected unreachable=true for 500 response")
+		}
+	}
+}
+
+func TestParseMetricsExtractsCounters(t *testing.T) {
+	text := `# HELP repram_peer_joins_total foo
+# TYPE repram_peer_joins_total counter
+repram_peer_joins_total 12
+repram_peer_evictions_total 3
+repram_ping_failures_total 1
+unrelated_metric 999
+go_gc_duration_seconds{quantile="0"} 0.001
+`
+	m := parseMetrics(text)
+	if m.PeerJoinsTotal != 12 || m.PeerEvictionsTotal != 3 || m.PingFailuresTotal != 1 {
+		t.Errorf("unexpected metrics: %+v", m)
+	}
+}
+
+func TestNormalizeAddrsDropsGarbage(t *testing.T) {
+	out := normalizeAddrs([]string{
+		"10.0.0.1:18080",
+		"  10.0.0.2:18080  ",
+		"bad-line",
+		"",
+		"10.0.0.3:notaport",
+	})
+	if len(out) != 2 {
+		t.Fatalf("expected 2 valid entries, got %d: %+v", len(out), out)
+	}
+	if !out["10.0.0.1:18080"] || !out["10.0.0.2:18080"] {
+		t.Errorf("missing expected entries: %+v", out)
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -59,8 +59,11 @@ func (s *Server) Run(ctx context.Context) error {
 	internalMux.HandleFunc("/healthz", s.handleHealthz)
 
 	publicSrv := &http.Server{
-		Addr:              s.publicAddr,
-		Handler:           publicMux,
+		Addr: s.publicAddr,
+		// Wrap the public mux in the security-headers middleware. The
+		// internal listener intentionally does not get these — it's
+		// expected to be scraped by Prometheus, not browsed.
+		Handler:           securityHeaders(publicMux),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 	internalSrv := &http.Server{
@@ -115,4 +118,36 @@ func (s *Server) handleSnapshot(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte("ok\n"))
+}
+
+// securityHeaders applies defense-in-depth response headers to every
+// public response. The CSP is restrictive on purpose: the dashboard
+// serves only its own embedded assets plus the Google Fonts stylesheet
+// referenced by the vendored hackerpunk styles. No remote scripts, no
+// inline scripts, no eval, no remote XHR — the dashboard never speaks
+// to anything other than itself from the browser.
+//
+// The primary XSS defense remains the textContent discipline in app.js;
+// this is a fallback in case a future change reintroduces an unsafe
+// interpolation. The cost is one map allocation per response, which is
+// negligible against the JSON encode that's about to happen anyway.
+func securityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Set("Content-Security-Policy",
+			"default-src 'self'; "+
+				"script-src 'self'; "+
+				"style-src 'self' https://fonts.googleapis.com; "+
+				"font-src 'self' https://fonts.gstatic.com; "+
+				"img-src 'self' data:; "+
+				"connect-src 'self'; "+
+				"frame-ancestors 'none'; "+
+				"base-uri 'self'")
+		h.Set("X-Content-Type-Options", "nosniff")
+		h.Set("Referrer-Policy", "no-referrer")
+		// The dashboard has no concept of session or login, so we
+		// don't need the click-jacking-via-iframe family; the
+		// frame-ancestors directive above is the canonical answer.
+		next.ServeHTTP(w, r)
+	})
 }

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -1,0 +1,118 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// Server hosts the dashboard's two HTTP listeners:
+//   - Public:   index.html + /api/snapshot, intended for visitors
+//   - Internal: /internal/metrics, bound to localhost by default
+//
+// The split lets operators expose only the public surface to the Internet
+// while keeping operational metrics private to the host. The internal
+// address is configurable; binding it to a public address is the
+// operator's explicit choice.
+type Server struct {
+	orch       *Orchestrator
+	publicAddr string
+	internalAddr string
+	assets     fs.FS
+	logger     *log.Logger
+}
+
+// NewServer wires the orchestrator + embedded assets into an HTTP server
+// pair. assets is the embed.FS root containing index.html, app.js, etc.
+// The caller passes the sub-FS rooted at the static-asset directory so
+// this package does not have to know the embed layout.
+func NewServer(orch *Orchestrator, publicAddr, internalAddr string, assets fs.FS, logger *log.Logger) *Server {
+	if logger == nil {
+		logger = log.Default()
+	}
+	return &Server{
+		orch:         orch,
+		publicAddr:   publicAddr,
+		internalAddr: internalAddr,
+		assets:       assets,
+		logger:       logger,
+	}
+}
+
+// Run starts both listeners. Blocks until ctx is cancelled, then shuts
+// both servers down with a 5s grace period. Returns the first non-graceful
+// error encountered.
+func (s *Server) Run(ctx context.Context) error {
+	publicMux := http.NewServeMux()
+	publicMux.HandleFunc("/api/snapshot", s.handleSnapshot)
+	publicMux.HandleFunc("/healthz", s.handleHealthz)
+	publicMux.Handle("/", http.FileServer(http.FS(s.assets)))
+
+	internalMux := http.NewServeMux()
+	internalMux.Handle("/internal/metrics", promhttp.HandlerFor(s.orch.MetricsRegistry(), promhttp.HandlerOpts{}))
+	internalMux.HandleFunc("/healthz", s.handleHealthz)
+
+	publicSrv := &http.Server{
+		Addr:              s.publicAddr,
+		Handler:           publicMux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	internalSrv := &http.Server{
+		Addr:              s.internalAddr,
+		Handler:           internalMux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	errCh := make(chan error, 2)
+	go func() {
+		s.logger.Printf("dashboard: public listener on %s", s.publicAddr)
+		if err := publicSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- fmt.Errorf("public listener: %w", err)
+		}
+	}()
+	go func() {
+		s.logger.Printf("dashboard: internal listener on %s", s.internalAddr)
+		if err := internalSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- fmt.Errorf("internal listener: %w", err)
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = publicSrv.Shutdown(shutdownCtx)
+		_ = internalSrv.Shutdown(shutdownCtx)
+		return nil
+	case err := <-errCh:
+		return err
+	}
+}
+
+func (s *Server) handleSnapshot(w http.ResponseWriter, r *http.Request) {
+	snap := s.orch.Snapshot()
+	if snap == nil {
+		// First poll has not completed and no prior snapshot was on
+		// disk. Serve a minimal placeholder rather than 503 — the
+		// frontend can render "initializing…" from this.
+		snap = &Snapshot{GeneratedAt: time.Now(), Stale: true}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(snap); err != nil {
+		s.logger.Printf("dashboard: encode snapshot: %v", err)
+	}
+}
+
+func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok\n"))
+}

--- a/internal/dashboard/snapshot.go
+++ b/internal/dashboard/snapshot.go
@@ -1,0 +1,177 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// SnapshotFileName is the on-disk name for the persisted snapshot. Stored
+// next to the omega cache under the dashboard state dir so a restart serves
+// the prior snapshot immediately instead of blanking for one poll cycle.
+const SnapshotFileName = "snapshot.json"
+
+// NodeMetrics is the per-node counter set lifted from /v1/metrics. Totals
+// since the node booted — never rates. See the dashboard design (issue #16)
+// for why the UI deliberately does not render rates even though they are
+// trivially derivable.
+type NodeMetrics struct {
+	PeerJoinsTotal     uint64 `json:"peer_joins_total"`
+	PeerEvictionsTotal uint64 `json:"peer_evictions_total"`
+	PingFailuresTotal  uint64 `json:"ping_failures_total"`
+}
+
+// Node is the per-node snapshot record after stripping addresses. The
+// dashboard process keeps the address-to-id mapping in memory only; what
+// reaches /api/snapshot is the metadata projection below.
+type Node struct {
+	ID               string      `json:"id"`
+	Enclave          string      `json:"enclave"`
+	Region           string      `json:"region"`
+	UptimeSeconds    int64       `json:"uptime_seconds"`
+	HeapMB           float64     `json:"heap_mb"`
+	GoroutinesApprox int         `json:"goroutines_approx"`
+	IsRoot           bool        `json:"is_root"`
+	Unreachable      bool        `json:"unreachable"`
+	Metrics          NodeMetrics `json:"metrics"`
+}
+
+// Edge encodes a single directed peer-awareness relationship as observed at
+// poll time. Symmetric pairs (both directions present) indicate fully-
+// converged peer awareness; asymmetric pairs surface mid-sync convergence
+// or partial partitions as a deliberately visible debug signal — see #36.
+type Edge struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// Stats is the cluster-aggregate projection rendered in the header strip.
+type Stats struct {
+	Nodes               int        `json:"nodes"`
+	Enclaves            int        `json:"enclaves"`
+	RootsReachable      int        `json:"roots_reachable"`
+	OldestUptimeSeconds int64      `json:"oldest_uptime_seconds"`
+	OmegaRefreshedAt    *time.Time `json:"omega_refreshed_at,omitempty"`
+	OmegaExpiresAt      *time.Time `json:"omega_expires_at,omitempty"`
+}
+
+// Snapshot is the full payload served from /api/snapshot. Addresses have
+// already been stripped by the builder. Flags are documented inline on the
+// fields below.
+type Snapshot struct {
+	GeneratedAt time.Time `json:"generated_at"`
+
+	// Stale: snapshot is older than the poll interval (pre-first-poll
+	// on startup, or all nodes were unreachable in the last cycle).
+	Stale bool `json:"stale"`
+
+	// LoadedFromDisk: snapshot was loaded from snapshot.json at startup
+	// and no fresh poll has completed yet.
+	LoadedFromDisk bool `json:"loaded_from_disk"`
+
+	// RootsUnreachable: every root in the current omega cache failed
+	// during the last poll cycle. The dashboard remains useful via
+	// non-root peer queries; N consecutive cycles trigger a DNS refresh.
+	RootsUnreachable bool `json:"roots_unreachable"`
+
+	// OmegaRefreshFailed: the most recently triggered omega refresh
+	// failed (DNS down, signature invalid, etc.). Distinct from
+	// RootsUnreachable; the two can be true independently.
+	OmegaRefreshFailed bool `json:"omega_refresh_failed"`
+
+	// SeedOverride: dashboard booted from --seeds rather than the omega
+	// trust chain. UI surfaces this as a "trust chain bypassed" banner.
+	SeedOverride bool `json:"seed_override"`
+
+	Stats Stats  `json:"stats"`
+	Nodes []Node `json:"nodes"`
+	Edges []Edge `json:"edges"`
+}
+
+// Canonicalize sorts nodes and edges into a deterministic order so callers
+// (tests, diff tools, the frontend's render path) see stable output even
+// when the underlying maps the builder iterates are unordered.
+func (s *Snapshot) Canonicalize() {
+	sort.Slice(s.Nodes, func(i, j int) bool { return s.Nodes[i].ID < s.Nodes[j].ID })
+	sort.Slice(s.Edges, func(i, j int) bool {
+		if s.Edges[i].From != s.Edges[j].From {
+			return s.Edges[i].From < s.Edges[j].From
+		}
+		return s.Edges[i].To < s.Edges[j].To
+	})
+}
+
+// LoadSnapshot reads a persisted snapshot from $dir/snapshot.json. Returns
+// (nil, nil) when the file is absent — that is the normal first-run case.
+// The returned snapshot has LoadedFromDisk and Stale set so the caller can
+// serve it immediately while waiting for the first fresh poll.
+func LoadSnapshot(dir string) (*Snapshot, error) {
+	path := filepath.Join(dir, SnapshotFileName)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read snapshot %s: %w", path, err)
+	}
+	var s Snapshot
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return nil, fmt.Errorf("parse snapshot %s: %w", path, err)
+	}
+	s.LoadedFromDisk = true
+	s.Stale = true
+	return &s, nil
+}
+
+// SaveSnapshot writes the snapshot atomically: write to a temp file in the
+// same directory, fsync, rename into place. A power loss mid-write leaves
+// the prior snapshot intact. 0644 perms because the contents are
+// public-info-equivalent (they are what the dashboard serves anyway).
+//
+// Canonicalizes before writing so disk diffs and roundtrips are stable.
+func SaveSnapshot(dir string, s *Snapshot) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("mkdir state dir %s: %w", dir, err)
+	}
+	s.Canonicalize()
+	payload, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal snapshot: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, SnapshotFileName+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp snapshot file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmp.Write(payload); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temp snapshot: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("fsync temp snapshot: %w", err)
+	}
+	if err := tmp.Chmod(0o644); err != nil {
+		tmp.Close()
+		return fmt.Errorf("chmod temp snapshot: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp snapshot: %w", err)
+	}
+	if err := os.Rename(tmpPath, filepath.Join(dir, SnapshotFileName)); err != nil {
+		return fmt.Errorf("rename snapshot: %w", err)
+	}
+	cleanup = false
+	return nil
+}

--- a/internal/dashboard/snapshot_test.go
+++ b/internal/dashboard/snapshot_test.go
@@ -1,0 +1,102 @@
+package dashboard
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSnapshotRoundtripPreservesFields(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 5, 12, 19, 0, 0, 0, time.UTC)
+	original := &Snapshot{
+		GeneratedAt:        now,
+		Stale:              false,
+		RootsUnreachable:   true,
+		OmegaRefreshFailed: false,
+		SeedOverride:       false,
+		Stats: Stats{
+			Nodes:               2,
+			Enclaves:            1,
+			RootsReachable:      0,
+			OldestUptimeSeconds: 100,
+		},
+		Nodes: []Node{
+			{ID: "node-b", Enclave: "default", Region: "US", UptimeSeconds: 50, HeapMB: 12.5},
+			{ID: "node-a", Enclave: "default", Region: "US", UptimeSeconds: 100, IsRoot: true},
+		},
+		Edges: []Edge{
+			{From: "node-a", To: "node-b"},
+			{From: "node-b", To: "node-a"},
+		},
+	}
+
+	if err := SaveSnapshot(dir, original); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	loaded, err := LoadSnapshot(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("load returned nil after save")
+	}
+	if !loaded.LoadedFromDisk {
+		t.Error("LoadedFromDisk should be set on load")
+	}
+	if !loaded.Stale {
+		t.Error("Stale should be set on load (a disk-loaded snapshot is always stale)")
+	}
+	if loaded.RootsUnreachable != true {
+		t.Error("RootsUnreachable lost through roundtrip")
+	}
+	if len(loaded.Nodes) != 2 || loaded.Nodes[0].ID != "node-a" {
+		t.Errorf("canonical sort not preserved: %+v", loaded.Nodes)
+	}
+}
+
+func TestLoadSnapshotAbsentReturnsNilNil(t *testing.T) {
+	dir := t.TempDir()
+	s, err := LoadSnapshot(dir)
+	if err != nil {
+		t.Fatalf("unexpected error on absent snapshot: %v", err)
+	}
+	if s != nil {
+		t.Fatal("expected nil snapshot on absent file")
+	}
+}
+
+func TestSaveSnapshotAtomicLeavesPriorIntactOnFailure(t *testing.T) {
+	// Simulate a partial write by creating a snapshot, then attempting a
+	// second save with a path conflict. The first one must remain intact.
+	dir := t.TempDir()
+	first := &Snapshot{
+		GeneratedAt: time.Now(),
+		Stats:       Stats{Nodes: 1},
+		Nodes:       []Node{{ID: "alpha"}},
+	}
+	if err := SaveSnapshot(dir, first); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+	// Take the directory off-writable to force a SaveSnapshot failure.
+	// (This won't simulate a torn write per se, but verifies the
+	// existing file is still parseable after a failed save.)
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Skipf("could not chmod test dir: %v", err)
+	}
+	defer os.Chmod(dir, 0o755)
+
+	second := &Snapshot{GeneratedAt: time.Now(), Nodes: []Node{{ID: "beta"}}}
+	_ = SaveSnapshot(dir, second) // expected to fail; we don't assert how
+
+	loaded, err := LoadSnapshot(dir)
+	if err != nil {
+		t.Fatalf("load after failed save: %v", err)
+	}
+	if loaded == nil || len(loaded.Nodes) != 1 || loaded.Nodes[0].ID != "alpha" {
+		t.Errorf("prior snapshot was lost: %+v", loaded)
+	}
+	_ = filepath.Glob // keep import
+}


### PR DESCRIPTION
## Summary

Closes #16. Adds `cmd/dashboard/`, a standalone Go service that polls the public REPRAM mesh and serves a single-page topology graph. Informational by design — proof-of-life plus a visible demonstration of the privacy property (structure visible, contents never).

Design v3 (full): https://github.com/TickTockBent/REPRAM/issues/16#issuecomment-4430703423

### What lands

- **Boot order**: cached omega list → DNS resolution → `--seeds` break-glass → exit non-zero. Cache-first inversion: DNS is only the recovery path. `--seeds` is valid in any deployment mode (not dev-only) and surfaces as `seed_override: true` in the snapshot when used.
- **Trust reuse**: leans on `internal/trust` for `FetchSigned`, `LoadCache`, `SaveCache`, and `Refresher`. No new crypto. Pubkey rotation works via cache invalidation on signature mismatch.
- **Snapshot persistence**: written atomically (`tmp → fsync → chmod 0644 → rename`) after each successful poll. Loaded on startup with `stale: true` + `loaded_from_disk: true` so a restart never blanks the UI.
- **Privacy boundary**: addresses are stripped server-side before serialization. The UI never displays IPs, ports, keys, payloads, or stored content. `/v1/topology` already exposes addresses publicly, so the dashboard isn't *protecting* them — it's choosing not to amplify them via a polished public face.
- **Side-channel guardrails**: counters not rates (since-boot only), goroutines rounded to nearest 10, heap at native precision (line is acknowledged not hidden), no per-node sparklines.
- **Directional edges**: each peer-awareness link kept as `{from, to}`. Symmetric pairs render solid; asymmetric ones render dashed — surfaces topology-sync convergence state as a free debug signal (#36).
- **Self-observability**: 8 Prometheus metrics on a separate `127.0.0.1:9095` listener at `/internal/metrics` (polls_total, polls_failed_total, nodes_unreachable, snapshot_age_seconds, omega_refresh_unix_seconds, omega_expires_unix_seconds, omega_refresh_failures_total, geo_lookup_misses_total). Operator alerts on snapshot staleness / omega expiration distance.
- **Geo**: country-level lookup pluggable behind a `openMMDB` hook in `geo.go`. Default is no-op (region = "?"); maxminddb wiring deferred until a GeoLite2 file is in place.
- **Frontend**: vanilla JS, no build step, no framework. Small from-scratch SVG force-directed graph (chose 60 lines of code over 200KB of vendored vis-network for v1; can swap in if the graph outgrows it). Hackerpunk CRT aesthetic vendored from `web/styles.css` per project conventions.

### Verified live against the burn-in cluster

```
./bin/repram-dashboard --seeds=10.0.20.72:18080,10.0.10.81:18080,10.0.10.104:18080 \
  --state-dir=/tmp/repram-dashboard-state \
  --listen=127.0.0.1:18181 --internal-addr=127.0.0.1:18182 --poll-interval=15s
```

Discovered all 3 nodes, 6 directional edges (fully symmetric), `seed_override: true` propagated, snapshot persisted, internal metrics exposed, restart loaded prior snapshot with stale flags set.

### Make targets

- `make build-dashboard` — builds `bin/repram-dashboard`
- `make dashboard-run-burnin` — one-command smoke test against the burn-in cluster

### Tests

10+ unit tests in `internal/dashboard/`:
- builder: address stripping, is_root derivation, directional edge preservation, asymmetric-edge survival, goroutine rounding, seed-override propagation, uptime parsing
- snapshot: roundtrip preserves fields, absent-file returns (nil, nil), atomic write keeps prior file intact on failure
- poller: 3-node fake-cluster BFS walk, unreachable marking, metric parsing, seed normalization
- geo: empty-path, missing-file, nil-IP all return "?"

Full repo suite passes (`go test ./...`).

### Deferred (filed as follow-ups internally, not blocking this PR)

- Real GeoLite2/maxminddb integration via the `openMMDB` hook + Makefile refresh target
- vis-network swap-in if graph exceeds ~50 nodes
- Pubkey-rotation operator-runbook doc

## Test plan

- [ ] `make build-dashboard` succeeds
- [ ] `make dashboard-run-burnin` produces a non-empty snapshot at http://127.0.0.1:18181/api/snapshot within ~15s
- [ ] Visit http://127.0.0.1:18181/ — graph renders, table populates, sidebar updates on node click
- [ ] `/internal/metrics` on the internal port lists all 8 `dashboard_*` series
- [ ] Stop and restart the dashboard — first response carries `loaded_from_disk: true` and `stale: true`
- [ ] Stop one burn-in node, wait one poll cycle, confirm `unreachable: true` on that node's snapshot entry
- [ ] `go test ./internal/dashboard/...` passes
- [ ] `go test ./...` passes repo-wide

// ticktockbent